### PR TITLE
Conditionally display original shipping cost in cart components

### DIFF
--- a/src/app/carrito/Step1.tsx
+++ b/src/app/carrito/Step1.tsx
@@ -183,9 +183,11 @@ export default function Step1({ onContinue }: { onContinue: () => void }) {
               <div className="flex justify-between text-sm">
                 <span>Envío</span>
                 <span>
-                  <span className="line-through mr-2 text-gray-400">
-                    {String(Number(ORIGINAL_SHIPPING_COST).toLocaleString())}
-                  </span>
+                  {cartProducts.length > 0 && (
+                    <span className="line-through mr-2 text-gray-400">
+                      {String(Number(ORIGINAL_SHIPPING_COST).toLocaleString())}
+                    </span>
+                  )}
                   <span className="font-bold">0</span>
                 </span>
               </div>

--- a/src/app/carrito/Step2.tsx
+++ b/src/app/carrito/Step2.tsx
@@ -844,9 +844,11 @@ export default function Step2({
               <div className="flex justify-between text-base">
                 <span>Envío</span>
                 <span>
-                  <span className="line-through mr-2 text-gray-400">
-                    {String(formatPrice(ORIGINAL_SHIPPING_COST))}
-                  </span>
+                  {cartProducts.length > 0 && (
+                    <span className="line-through mr-2 text-gray-400">
+                      {String(Number(ORIGINAL_SHIPPING_COST).toLocaleString())}
+                    </span>
+                  )}
                   <span className="font-bold">0</span>
                 </span>
               </div>

--- a/src/app/carrito/components/OrderSummary.tsx
+++ b/src/app/carrito/components/OrderSummary.tsx
@@ -70,9 +70,11 @@ export const OrderSummary: React.FC<OrderSummaryProps> = ({
           <div className="flex justify-between text-base">
             <span>Envío</span>
             <span>
-              <span className="line-through mr-2 text-gray-400">
-                {String(formatPrice(ORIGINAL_SHIPPING_COST))}
-              </span>
+              {cartProducts.length > 0 && (
+                <span className="line-through mr-2 text-gray-400">
+                  {String(Number(ORIGINAL_SHIPPING_COST).toLocaleString())}
+                </span>
+              )}
               <span className="font-bold">0</span>
             </span>
           </div>

--- a/src/app/carrito/components/Step4OrderSummary.tsx
+++ b/src/app/carrito/components/Step4OrderSummary.tsx
@@ -15,7 +15,12 @@ export default function Step4OrderSummary({
   onFinishPayment,
 }: Step4OrderSummaryProps) {
   const router = useRouter();
-  const { calculations, formatPrice: cartFormatPrice, isEmpty, products } = useCart();
+  const {
+    calculations,
+    formatPrice: cartFormatPrice,
+    isEmpty,
+    products,
+  } = useCart();
 
   if (isEmpty) {
     return (
@@ -58,17 +63,19 @@ export default function Step4OrderSummary({
           <div className="flex justify-between text-base">
             <span>Envío</span>
             <span>
-              <span className="line-through mr-2 text-gray-400">
-                {String(cartFormatPrice(ORIGINAL_SHIPPING_COST))}
-              </span>
+              {products.length > 0 && (
+                <span className="line-through mr-2 text-gray-400">
+                  {String(Number(ORIGINAL_SHIPPING_COST).toLocaleString())}
+                </span>
+              )}
               <span className="font-bold">{cartFormatPrice(0)}</span>
             </span>
           </div>
           {products.length > 0 && (
-                <div className="text-xs text-green-600">
-                  tienes envío gratis en esta compra
-                </div>
-              )}
+            <div className="text-xs text-green-600">
+              tienes envío gratis en esta compra
+            </div>
+          )}
         </div>
         {/* Total: siempre string */}
         <div className="flex justify-between text-lg font-bold mt-2">


### PR DESCRIPTION
Display the original shipping cost only when there are products in the cart. This change enhances the user experience by preventing unnecessary information from being shown when the cart is empty.