### PR TITLE
Fix/products responsive panel filtros

### DIFF
--- a/src/app/productos/components/FilterSidebar.tsx
+++ b/src/app/productos/components/FilterSidebar.tsx
@@ -168,7 +168,7 @@ export default function FilterSidebar({
   return (
     <div
       className={cn(
-        "bg-[#F5F5F5] rounded-none border-0 shadow-none",
+        "bg-[#F5F5F5] rounded-lg border-0 shadow-none",
         stickyContainerClasses,
         className
       )}

--- a/src/app/productos/components/FilterSidebar.tsx
+++ b/src/app/productos/components/FilterSidebar.tsx
@@ -367,7 +367,7 @@ export function MobileFilterModal({
       {/* Backdrop animado */}
       <div
         className={cn(
-          "lg:hidden fixed inset-0 z-50 transition-all duration-300 ease-in-out",
+          "lg:hidden fixed inset-0 z-[70] transition-all duration-300 ease-in-out",
           isOpen ? "bg-black/50 backdrop-blur-sm" : "bg-transparent"
         )}
         onClick={onClose}
@@ -377,7 +377,7 @@ export function MobileFilterModal({
       <div
         className={cn(
           // en mobile dejamos un pequeño gap a la izquierda con left-4
-          "lg:hidden fixed inset-y-0 right-0 left-4 z-50 w-full max-w-sm bg-white shadow-2xl",
+          "lg:hidden fixed inset-y-0 right-0 left-4 z-[70] w-full max-w-sm bg-white shadow-2xl",
           "transition-transform duration-300 ease-in-out",
           isOpen ? "translate-x-0" : "translate-x-full"
         )}

--- a/src/app/productos/dispositivos-moviles/Accesorios.tsx
+++ b/src/app/productos/dispositivos-moviles/Accesorios.tsx
@@ -68,7 +68,7 @@ export default function AccesoriosSection() {
   const stickyState = useSticky({
     sidebarRef,
     productsRef,
-    topOffset: 120,
+    topOffset: 200,
     enabled: stickyEnabled,
   });
   const { containerClasses, wrapperClasses, style } =

--- a/src/app/productos/dispositivos-moviles/GalaxyBuds.tsx
+++ b/src/app/productos/dispositivos-moviles/GalaxyBuds.tsx
@@ -66,7 +66,7 @@ export default function GalaxyBudsSection() {
   const stickyState = useSticky({
     sidebarRef,
     productsRef,
-    topOffset: 120,
+    topOffset: 200,
     enabled: stickyEnabled,
   });
   const { containerClasses, wrapperClasses, style } =

--- a/src/app/productos/dispositivos-moviles/Relojes.tsx
+++ b/src/app/productos/dispositivos-moviles/Relojes.tsx
@@ -66,7 +66,7 @@ export default function RelojesSection() {
   const stickyState = useSticky({
     sidebarRef,
     productsRef,
-    topOffset: 120,
+    topOffset: 200,
     enabled: stickyEnabled,
   });
   const { containerClasses, wrapperClasses, style } =

--- a/src/app/productos/dispositivos-moviles/Smartphones.tsx
+++ b/src/app/productos/dispositivos-moviles/Smartphones.tsx
@@ -80,7 +80,7 @@ export default function SmartphonesSection() {
   const stickyState = useSticky({
     sidebarRef,
     productsRef,
-    topOffset: 120,
+    topOffset: 200,
     enabled: stickyEnabled,
   });
   const { containerClasses, wrapperClasses, style } =

--- a/src/app/productos/dispositivos-moviles/Tabletas.tsx
+++ b/src/app/productos/dispositivos-moviles/Tabletas.tsx
@@ -58,7 +58,7 @@ export default function TabletasSection() {
   const stickyState = useSticky({
     sidebarRef,
     productsRef,
-    topOffset: 120,
+    topOffset: 200,
     enabled: stickyEnabled,
   });
   const { containerClasses, wrapperClasses, style } =


### PR DESCRIPTION
- Bordes de panel de filtros redondeados.
- Panel de filtros no es cubierto por el header en mobile.
- Al hacer scroll en web, el panel de filtros se queda sticky más abajo para no ser cubeirto por header.