### PR TITLE
fix: Resolve infinite loop in AddressAutocomplete useEffect

### DIFF
--- a/src/components/forms/AddressAutocomplete.tsx
+++ b/src/components/forms/AddressAutocomplete.tsx
@@ -162,11 +162,10 @@ export function AddressAutocomplete({
    * Inicializa el input con el valor externo solo la primera vez
    */
   useEffect(() => {
-    if (value !== undefined && inputValue === '') {
+    if (value !== undefined && value !== inputValue) {
       setInputValue(value);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]); // Solo cuando value cambia, no inputValue para evitar loops infinitos
+  }, [value, inputValue]);
 
   /**
    * Efecto para cerrar dropdown al hacer click fuera


### PR DESCRIPTION
## Summary
- Fixed infinite loop caused by incorrect useEffect dependency array in AddressAutocomplete component
- Changed condition from checking empty inputValue to comparing value !== inputValue  
- Properly included inputValue in dependencies array to prevent endless re-renders during address input

## Test plan
- [ ] Navigate to account creation form
- [ ] Start typing in address field
- [ ] Verify no infinite console logs appear
- [ ] Verify autocomplete still works correctly
- [ ] Verify no browser freezing occurs

🤖 Generated with [Claude Code](https://claude.ai/code)