### PR TITLE
hotfix(posthog): re-enable network body/header capture in session recordings

### DIFF
--- a/src/lib/posthogClient.ts
+++ b/src/lib/posthogClient.ts
@@ -47,6 +47,8 @@ export const posthogConfig = {
     maskAllInputs: true, // Oculta inputs sensibles
     maskAllText: false,
     recordCrossOriginIframes: false,
+    recordHeaders: true,
+    recordBody: true,
     // Replace PostHog's aggressive default scrubbing (which redacts ANY body
     // containing "token", "auth", etc.) with targeted field-level redaction.
     maskCapturedNetworkRequestFn: (request: CapturedNetworkRequest) => {


### PR DESCRIPTION
## Summary
- Re-enables `recordBody: true` and `recordHeaders: true` in PostHog session recording config so network payloads are captured in replays
- Adds `posthog.identify()` call on session restore from localStorage so returning users show their email in replays
- Adds `associateEmailWithSession()` helper that links email to the PostHog session across all user touchpoints (guest checkout, billing, support SOAP, support email form)

## Context
- `recordBody`/`recordHeaders` were removed in e9b2e700 because they broke session replays. The root cause was PostHog's aggressive default scrubbing — not the flags themselves. Now that `maskCapturedNetworkRequestFn` provides targeted field-level redaction, these options work correctly
- `posthog.identify()` was only called during login, not on session restore — most returning users appeared anonymous in replays
- Guest users and support flow users never got their email associated with the session

## Touchpoints covered
| Touchpoint | File | Trigger |
|---|---|---|
| Login | `auth/context.tsx` | Already existed |
| Session restore | `auth/context.tsx` | Page load with saved session |
| Guest checkout | `carrito/Step2.tsx` | Guest registration form |
| Billing data | `carrito/Step6.tsx` | Billing form submission |
| Support SOAP | `soporte/inicio_de_soporte/page.tsx` | Document lookup response |
| Support email form | `soporte/correo_electronico/page.tsx` | Form submission |

## Test plan
- [ ] Deploy and verify session replays still work (no blank recordings)
- [ ] Check PostHog Inspector → Payload tab shows request/response bodies
- [ ] Verify sensitive data (passwords, card numbers, tokens) is properly redacted
- [ ] Confirm payment processor requests (epayco, stripe, mercadopago) are excluded
- [ ] Verify returning logged-in users show email in session replays
- [ ] Verify guest checkout users show email after Step2
- [ ] Verify support flow users show email after SOAP lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)