### PR TITLE
feat(posthog): identify users by email across all session touchpoints

### DIFF
--- a/src/app/carrito/Step2.tsx
+++ b/src/app/carrito/Step2.tsx
@@ -21,6 +21,7 @@ import {
   getTradeInValidationMessage,
 } from "./utils/validateTradeIn";
 import { toast } from "sonner";
+import { associateEmailWithSession } from "@/lib/posthogClient";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -341,6 +342,11 @@ export default function Step2({
 
       // Guardar userId temporalmente (solo en estado, no en localStorage todavía)
       setGuestUserId(registerResult.userId);
+
+      // Associate guest email with PostHog session
+      associateEmailWithSession(guestForm.email.toLowerCase(), {
+        $name: `${guestForm.nombre} ${guestForm.apellido}`.trim(),
+      });
 
       // 2. Establecer estado inicial para OTP pero SIN enviarlo aún
       // Esto permite que el usuario seleccione el método de envío (WhatsApp o Email)

--- a/src/app/carrito/Step6.tsx
+++ b/src/app/carrito/Step6.tsx
@@ -13,6 +13,7 @@ import AddNewAddressForm from "./components/AddNewAddressForm";
 import { MapPin, Plus, Check, Trash2 } from "lucide-react";
 import { safeGetLocalStorage } from "@/lib/localStorage";
 import { useCart } from "@/hooks/useCart";
+import { associateEmailWithSession } from "@/lib/posthogClient";
 import { validateTradeInProducts, getTradeInValidationMessage } from "./utils/validateTradeIn";
 import { toast } from "sonner";
 
@@ -588,6 +589,13 @@ export default function Step6({ onBack, onContinue }: Step6Props) {
         "checkout-billing-data",
         JSON.stringify(billingToSave)
       );
+
+      // Associate billing email with PostHog session
+      if (billingToSave.email) {
+        associateEmailWithSession(billingToSave.email, {
+          $name: billingToSave.nombre,
+        });
+      }
 
       if (onContinue) {
         onContinue();

--- a/src/app/soporte/correo_electronico/page.tsx
+++ b/src/app/soporte/correo_electronico/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { associateEmailWithSession } from "@/lib/posthogClient";
 
 export default function CorreoElectronicoPage() {
   const [formData, setFormData] = useState({
@@ -37,6 +38,11 @@ export default function CorreoElectronicoPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (formData.email) {
+      associateEmailWithSession(formData.email, {
+        $name: `${formData.firstName} ${formData.lastName}`.trim() || undefined,
+      });
+    }
     // Handle form submission
     console.log("Form submitted:", formData);
   };

--- a/src/app/soporte/inicio_de_soporte/page.tsx
+++ b/src/app/soporte/inicio_de_soporte/page.tsx
@@ -17,6 +17,7 @@ import { ArrowLeft, CreditCard, Building2, ChevronDown } from "lucide-react";
 import pseLogo from "@/img/iconos/logo-pse.png";
 import cardValidator from "card-validator";
 import AnimatedCard from "@/components/ui/AnimatedCard";
+import { associateEmailWithSession } from "@/lib/posthogClient";
 
 type DocumentoWithRegistro = Documento & { registro?: string };
 
@@ -526,6 +527,11 @@ export default function InicioDeSoportePage() {
       // Silently ensure user exists (create guest if needed) + internal logout if email differs
       const doc0 = response.data?.obtenerDocumentosResult?.documentos?.[0];
       if (doc0?.email) {
+        // Associate SOAP email with PostHog session for replay identification
+        associateEmailWithSession(doc0.email.toLowerCase().trim(), {
+          $name: doc0.cliente || undefined,
+        });
+
         // Full logout if logged-in user email differs from support order email
         if (user?.email) {
           const loggedEmail = user.email.toLowerCase().trim();

--- a/src/features/auth/context.tsx
+++ b/src/features/auth/context.tsx
@@ -65,6 +65,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setUser(userData);
           apiClient.setAuthToken(savedToken!);
 
+          // Identify user in PostHog on session restore
+          const userRole = userData.role ?? (userData as User & { rol?: number }).rol;
+          setPosthogUserId(userData.id, {
+            $email: userData.email,
+            $name: `${userData.nombre ?? ""} ${userData.apellido ?? ""}`.trim(),
+            telefono: userData.telefono,
+            role: userRole,
+          });
+
           // ✅ NUEVO: Cargar dirección predeterminada si no está en localStorage
           const existingAddress = localStorage.getItem('checkout-address');
           if (!existingAddress || existingAddress === 'null' || existingAddress === 'undefined') {

--- a/src/lib/posthogClient.ts
+++ b/src/lib/posthogClient.ts
@@ -183,6 +183,26 @@ export function setPosthogUserId(
   posthogUtils.identify(userId, userProperties);
 }
 
+/**
+ * Associate an email with the current PostHog session.
+ * Works even for anonymous/guest users — sets $set_once so the first email
+ * seen sticks as the canonical one, while $set keeps the latest.
+ */
+export function associateEmailWithSession(
+  email: string,
+  extraProperties?: Record<string, unknown>
+) {
+  if (typeof window === "undefined" || !email) return;
+  try {
+    posthog.setPersonProperties(
+      { $email: email, ...extraProperties },
+      { $initial_email: email }
+    );
+  } catch (error) {
+    console.error("Error associating email with PostHog session:", error);
+  }
+}
+
 // Utilidades para interactuar con PostHog
 export const posthogUtils = {
   /**


### PR DESCRIPTION
## Summary
- Adds `posthog.identify()` on session restore so returning logged-in users show their email in replays (was only called during login)
- Adds `associateEmailWithSession()` helper that links email to the PostHog session at every touchpoint where we have access to it

## Touchpoints covered
| Touchpoint | File | Trigger |
|---|---|---|
| Session restore | `auth/context.tsx` | Page load with saved session |
| Guest checkout | `carrito/Step2.tsx` | Guest registration form |
| Billing data | `carrito/Step6.tsx` | Billing form submission |
| Support SOAP | `soporte/inicio_de_soporte/page.tsx` | Document lookup response |
| Support email form | `soporte/correo_electronico/page.tsx` | Form submission |

## Test plan
- [ ] Verify returning logged-in users show email in session replays
- [ ] Verify guest checkout users show email after Step2 registration
- [ ] Verify billing form submission associates email
- [ ] Verify support SOAP lookup associates email from backend response
- [ ] Verify support email form submission associates email

🤖 Generated with [Claude Code](https://claude.com/claude-code)