### PR TITLE
fix(checkout): remove remaining selectedAddress checks blocking save

### DIFF
--- a/src/app/carrito/components/AddNewAddressForm.tsx
+++ b/src/app/carrito/components/AddNewAddressForm.tsx
@@ -1066,7 +1066,7 @@ export default function AddNewAddressForm({
     if (onSubmitRef) {
       onSubmitRef.current = async () => {
         // Validar antes de proceder
-        if (!validateForm() || !selectedAddress) {
+        if (!validateForm()) {
           return;
         }
         // Llamar a handleSubmitInternal
@@ -1687,13 +1687,12 @@ export default function AddNewAddressForm({
                 type="submit"
                 disabled={
                   isLoading ||
-                  !selectedAddress ||
                   !formData.nombreDireccion ||
                   !formData.instruccionesEntrega ||
                   (!formData.usarMismaParaFacturacion && !selectedBillingAddress)
                 }
                 className={`flex-1 text-white px-6 py-3 rounded-xl font-bold transition border-2 ${
-                  !(isLoading || !selectedAddress || !formData.nombreDireccion || !formData.instruccionesEntrega || (!formData.usarMismaParaFacturacion && !selectedBillingAddress))
+                  !(isLoading || !formData.nombreDireccion || !formData.instruccionesEntrega || (!formData.usarMismaParaFacturacion && !selectedBillingAddress))
                     ? "bg-green-600 border-green-500 hover:bg-green-700 hover:border-green-600 shadow-lg shadow-green-500/40 hover:shadow-xl hover:shadow-green-500/50"
                     : "bg-gray-400 border-gray-300 cursor-not-allowed"
                 }`}


### PR DESCRIPTION
## Summary

Seguimiento de PR #904 — quedaban 2 checks de `selectedAddress` que bloqueaban el botón "Guardar dirección" en paso 2:

- `disabled={!selectedAddress || ...}` en el botón "Guardar dirección" (línea 1690)
- `!selectedAddress` guard en `onSubmitRef` (línea 1069)

Ambos removidos. Ahora el formulario completo funciona sin Google Places.

## Test plan

- [ ] Llenar dirección manual → paso 2 → "Guardar dirección" debe estar habilitado (verde)
- [ ] Click "Guardar dirección" → debe crear la dirección en el backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)