### PR TITLE
fix(checkout): rejected payments showing success page

### DIFF
--- a/src/app/carrito/components/ThreeDSecureModal.tsx
+++ b/src/app/carrito/components/ThreeDSecureModal.tsx
@@ -78,13 +78,11 @@ export const ThreeDSecureModal: React.FC<ThreeDSecureModalProps> = ({
                 console.log('⏳ [3DS] Still pending, retrying in 2 seconds...');
                 // Todavía pendiente, esperar un poco y reintentar
                 setTimeout(verifyTransaction, 2000);
-            } else if (response.ok && (data.type || data.orderStatus === 'APPROVED' || data.status === 200)) {
+            } else if (response.ok && data.orderStatus === 'APPROVED') {
                 console.log('✅ [3DS] Transaction approved!');
-                // Aprobado
                 onSuccess();
             } else {
                 console.error('❌ [3DS] Transaction rejected:', data);
-                // Rechazado
                 onError(data.message || 'Transacción rechazada');
             }
         } catch (error) {

--- a/src/app/success-checkout/[orderId]/page.tsx
+++ b/src/app/success-checkout/[orderId]/page.tsx
@@ -106,7 +106,29 @@ export default function SuccessCheckoutPage({
   const pathParams = use(params);
   const router = useRouter();
   const [open, setOpen] = useState(true);
+  const [verified, setVerified] = useState(false);
   const { clearCart } = useCart();
+
+  // Safety net: verificar que la orden realmente fue aprobada
+  useEffect(() => {
+    const verifyOrderStatus = async () => {
+      try {
+        const res = await apiClient.get<{ orderStatus?: string; message?: string }>(
+          `/api/orders/verify/${pathParams.orderId}`
+        );
+        if (res.data?.orderStatus === "REJECTED") {
+          router.replace(
+            `/error-checkout?message=${encodeURIComponent(res.data?.message || "Tu pago fue rechazado por el banco")}`
+          );
+          return;
+        }
+      } catch {
+        // Si falla la verificación, mostrar success como fallback
+      }
+      setVerified(true);
+    };
+    verifyOrderStatus();
+  }, [pathParams.orderId, router]);
   const { trackPurchase } = useAnalyticsWithUser();
   const whatsappSentRef = useRef(false);
   const analyticsSentRef = useRef(false);
@@ -865,6 +887,15 @@ export default function SuccessCheckoutPage({
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
+
+  // No mostrar nada hasta verificar que la orden fue aprobada
+  if (!verified) {
+    return (
+      <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-[#009047]">
+        <div className="animate-spin h-8 w-8 border-4 border-white border-t-transparent rounded-full" />
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-[#009047]">

--- a/src/app/verify-purchase/[id]/page.tsx
+++ b/src/app/verify-purchase/[id]/page.tsx
@@ -96,16 +96,17 @@ export default function VerifyPurchase(props: Readonly<{ params: Readonly<Promis
       // Resetear contador si la transacción ya no está pendiente
       retryCountRef.current = 0;
 
-      // Verificar el status del body de la respuesta
-      // Solo redirigir a success si NO hay requiresAction, NO está PENDING, y el status es 200 o APPROVED
-      if ((data.status === 200 || data.status === "APPROVED") && data.orderStatus !== "PENDING") {
+      // Solo redirigir a success si orderStatus es explícitamente APPROVED
+      if (data.orderStatus === "APPROVED") {
         console.log("✅ [VERIFY] Transacción aprobada, redirigiendo a success...");
-        // Mantener animación visible durante la redirección
         router.push(`/success-checkout/${orderId}`);
+      } else if (data.orderStatus === "REJECTED") {
+        console.error("❌ [VERIFY] Transacción rechazada:", data.message);
+        const errParams = new URLSearchParams();
+        if (data.message) errParams.set("message", data.message);
+        router.push(`/error-checkout?${errParams.toString()}`);
       } else {
-        console.error("❌ [VERIFY] Verification failed with status:", data.status, "- orderStatus:", data.orderStatus);
-        console.error("❌ [VERIFY] Message:", data.message);
-        console.error("❌ [VERIFY] Redirigiendo a error-checkout...");
+        console.error("❌ [VERIFY] Estado inesperado:", data.status, "- orderStatus:", data.orderStatus);
         const errParams = new URLSearchParams();
         if (data.message) errParams.set("message", data.message);
         router.push(`/error-checkout?${errParams.toString()}`);


### PR DESCRIPTION
## Summary

**Bug critico**: Un pago rechazado por el banco ("Saldo insuficiente", código 51) mostraba "¡Tu compra ha sido exitosa!" en verde. El backend detectaba correctamente el rechazo, pero el frontend redirigía a success-checkout de todas formas.

**Causa raiz**: `verify-purchase` chequeaba `data.status === 200` para determinar éxito, pero el backend retorna `status: 200` para TODAS las órdenes resueltas (incluyendo rechazadas). El campo correcto es `data.orderStatus`.

### Cambios

| Archivo | Fix |
|---------|-----|
| `verify-purchase/[id]/page.tsx` | Chequear `orderStatus === "APPROVED"` en vez de `status === 200` |
| `ThreeDSecureModal.tsx` | Misma corrección en callback de verificación 3DS |
| `success-checkout/[orderId]/page.tsx` | Safety net: verificar estado de orden al cargar, redirigir a error si REJECTED |

### Flujo corregido

```
Pago → ePayco → 3DS → verify-purchase polling
  ├── orderStatus === "APPROVED" → success-checkout (verde)
  ├── orderStatus === "REJECTED" → error-checkout (con mensaje del banco)
  └── orderStatus === "PENDING"  → retry (max 5 intentos) → timeout → error-checkout
```

## Test plan

- [ ] Pago rechazado por banco → debe ir a error-checkout con mensaje, NO a success
- [ ] Pago aprobado → debe ir a success-checkout normalmente
- [ ] URL directa a `/success-checkout/[orden-rechazada]` → redirige a error-checkout
- [ ] 3DS timeout → error-checkout con mensaje de timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)