### PR TITLE
fix(seo): improve Google sitelinks and prevent cart/footer content in…

### DIFF
--- a/src/app/carrito/Step1.tsx
+++ b/src/app/carrito/Step1.tsx
@@ -937,7 +937,7 @@ export default function Step1({
               ))}
             </div>
           ) : cartProducts.length === 0 ? (
-            <div className="text-gray-500 text-center py-16 text-lg">
+            <div className="text-gray-500 text-center py-16 text-lg" data-nosnippet>
               No hay productos en el carrito.
             </div>
           ) : (

--- a/src/app/carrito/layout.tsx
+++ b/src/app/carrito/layout.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import { CheckoutAddressProvider } from "@/features/checkout";
 
 export const metadata: Metadata = {
-  robots: { index: false, follow: false },
+  title: "Carrito de compras",
+  description: "Tu carrito de compras en Imagiq Samsung Store.",
+  robots: { index: false, follow: false, nocache: true, noarchive: true, nosnippet: true },
 };
 
 export default function CarritoLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { Metadata } from "next";
-import { getSeoSettings } from "@/lib/seo-utils";
+import { getSeoSettings, buildOrganizationJsonLd, buildSiteNavigationJsonLd } from "@/lib/seo-utils";
 import { samsungSharpSans } from "./fonts";
 import { ThreeDSScript } from "@/components/ThreeDSScript";
 // Nota: eliminamos la importación de Inter desde next/font/google para evitar
@@ -161,6 +161,15 @@ export default function RootLayout({
         <link rel="preconnect" href="https://media.flixfacts.com" crossOrigin="anonymous" />
         <link rel="preconnect" href="https://media.flixcar.com" crossOrigin="anonymous" />
         <link rel="preload" href="//media.flixfacts.com/js/loader.js" as="script" />
+        {/* JSON-LD: SiteNavigationElement for Google sitelinks */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              buildSiteNavigationJsonLd(process.env.NEXT_PUBLIC_SITE_URL || "https://imagiq.com")
+            ),
+          }}
+        />
       </head>
       <body className="antialiased">
         <SecurityInitializer>

--- a/src/app/productos/[categoria]/layout.tsx
+++ b/src/app/productos/[categoria]/layout.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://imagiq.com";
+
+/** SEO metadata for each known product category */
+const CATEGORY_META: Record<string, { title: string; description: string }> = {
+  "dispositivos-moviles": {
+    title: "Dispositivos Móviles Samsung",
+    description:
+      "Descubre los últimos smartphones Galaxy, tablets, smartwatches y accesorios Samsung. Compra con envío gratis y garantía oficial en Imagiq Colombia.",
+  },
+  "tv-y-audio": {
+    title: "TV y Audio Samsung",
+    description:
+      "Televisores Samsung QLED, Neo QLED, barras de sonido y parlantes. La mejor experiencia de entretenimiento con garantía oficial en Imagiq Colombia.",
+  },
+  electrodomesticos: {
+    title: "Electrodomésticos Samsung",
+    description:
+      "Neveras, lavadoras, secadoras, lavavajillas y aspiradoras Samsung. Electrodomésticos de última tecnología con garantía oficial en Imagiq Colombia.",
+  },
+  monitores: {
+    title: "Monitores Samsung",
+    description:
+      "Monitores Samsung para gaming, productividad y diseño. Pantallas de alta resolución con garantía oficial en Imagiq Colombia.",
+  },
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ categoria: string }>;
+}): Promise<Metadata> {
+  const { categoria } = await params;
+  const meta = CATEGORY_META[categoria];
+
+  if (!meta) {
+    return {
+      title: "Productos Samsung",
+      description:
+        "Encuentra los mejores productos Samsung con garantía oficial, envío gratis y soporte especializado en Imagiq Colombia.",
+      alternates: { canonical: `${SITE_URL}/productos/${categoria}` },
+    };
+  }
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: { canonical: `${SITE_URL}/productos/${categoria}` },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: `${SITE_URL}/productos/${categoria}`,
+    },
+  };
+}
+
+export default function CategoriaLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -26,15 +26,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     [],
   );
 
-  // Static pages
+  // Static pages — navbar pages get highest priorities for sitelink visibility
   const staticPages: MetadataRoute.Sitemap = [
     { url: baseUrl, lastModified: new Date(), changeFrequency: 'daily', priority: 1 },
-    { url: `${baseUrl}/productos`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
-    { url: `${baseUrl}/ofertas`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.8 },
-    { url: `${baseUrl}/tiendas`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.6 },
-    { url: `${baseUrl}/soporte`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.5 },
-    { url: `${baseUrl}/login`, lastModified: new Date(), changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${baseUrl}/ofertas`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
+    { url: `${baseUrl}/productos/dispositivos-moviles`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
+    { url: `${baseUrl}/productos/tv-y-audio`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
+    { url: `${baseUrl}/productos/electrodomesticos`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
+    { url: `${baseUrl}/productos/monitores`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
+    { url: `${baseUrl}/tiendas`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${baseUrl}/soporte/inicio_de_soporte`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${baseUrl}/productos`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.7 },
+    { url: `${baseUrl}/soporte`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.6 },
     { url: `${baseUrl}/ventas-corporativas`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${baseUrl}/login`, lastModified: new Date(), changeFrequency: 'yearly', priority: 0.3 },
     { url: `${baseUrl}/ventas-corporativas/education`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.4 },
     { url: `${baseUrl}/ventas-corporativas/finance`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.4 },
     { url: `${baseUrl}/ventas-corporativas/government`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.4 },
@@ -52,13 +57,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.6,
     }));
 
-  // Category pages
-  const categoryPages: MetadataRoute.Sitemap = categories.map((c: any) => ({
-    url: `${baseUrl}/productos/${c.slug || c.id}`,
-    lastModified: new Date(),
-    changeFrequency: 'weekly' as const,
-    priority: 0.8,
-  }));
+  // Category pages (exclude ones already in staticPages to avoid duplicates)
+  const staticSlugs = new Set(['dispositivos-moviles', 'tv-y-audio', 'electrodomesticos', 'monitores']);
+  const categoryPages: MetadataRoute.Sitemap = categories
+    .filter((c: any) => !staticSlugs.has(c.slug))
+    .map((c: any) => ({
+      url: `${baseUrl}/productos/${c.slug || c.id}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    }));
 
   return [...staticPages, ...cmsPages, ...categoryPages];
 }

--- a/src/app/soporte/layout.tsx
+++ b/src/app/soporte/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Servicio Técnico y Soporte Samsung",
+  description:
+    "Servicio técnico autorizado Samsung en Colombia. Consulta tu orden de reparación, agenda servicio técnico y encuentra centros de soporte Imagiq.",
+  alternates: { canonical: "https://imagiq.com/soporte" },
+  openGraph: {
+    title: "Servicio Técnico Samsung - Imagiq",
+    description:
+      "Soporte técnico autorizado Samsung. Consulta órdenes, agenda reparaciones y encuentra centros de servicio.",
+    url: "https://imagiq.com/soporte",
+  },
+};
+
+export default function SoporteLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -56,6 +56,7 @@ function Footer() {
   return (
     <footer
       id="footer"
+      data-nosnippet
       className={`bg-white border-t border-gray-200 transition-all duration-700 scroll-mt-20 ${
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5"
       }`}

--- a/src/components/footer/FooterBottom.tsx
+++ b/src/components/footer/FooterBottom.tsx
@@ -32,7 +32,7 @@ export function FooterBottom({ isVisible }: FooterBottomProps) {
     >
       {/* Información de la compañía y Logo superintendencia */}
       <div className="flex flex-col md:flex-row justify-between items-start gap-6 mb-6">
-        <div className="space-y-1">
+        <div className="space-y-1" data-nosnippet>
           <p className="text-xs text-gray-500 font-bold">{companyInfo.copyright}</p>
           <p className="text-xs text-gray-500 font-bold">{companyInfo.address}</p>
           <p className="text-xs text-gray-500 font-bold">{companyInfo.contact}</p>

--- a/src/components/footer/footer-config.ts
+++ b/src/components/footer/footer-config.ts
@@ -160,7 +160,7 @@ export const getFooterSections = (
       title: "Cuenta",
       links: [
         { name: "Iniciar sesión", href: "/login" },
-        { name: "Pedidos", href: "/carrito/step1" },
+        { name: "Pedidos", href: "/perfil" },
       ],
     },
     // {

--- a/src/lib/seo-utils.ts
+++ b/src/lib/seo-utils.ts
@@ -94,6 +94,30 @@ export function buildProductJsonLd(product: {
   };
 }
 
+/** Build SiteNavigationElement JSON-LD for sitelinks */
+export function buildSiteNavigationJsonLd(siteUrl: string) {
+  const navItems = [
+    { name: "Ofertas", url: `${siteUrl}/ofertas` },
+    { name: "Dispositivos Móviles", url: `${siteUrl}/productos/dispositivos-moviles` },
+    { name: "TV y Audio", url: `${siteUrl}/productos/tv-y-audio` },
+    { name: "Electrodomésticos", url: `${siteUrl}/productos/electrodomesticos` },
+    { name: "Monitores", url: `${siteUrl}/productos/monitores` },
+    { name: "Tiendas", url: `${siteUrl}/tiendas` },
+    { name: "Servicio Técnico", url: `${siteUrl}/soporte/inicio_de_soporte` },
+  ];
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    itemListElement: navItems.map((item, i) => ({
+      "@type": "SiteNavigationElement",
+      position: i + 1,
+      name: item.name,
+      url: item.url,
+    })),
+  };
+}
+
 /** Build BreadcrumbList JSON-LD */
 export function buildBreadcrumbJsonLd(
   items: Array<{ name: string; url: string }>,


### PR DESCRIPTION
… search results

- Add data-nosnippet to footer to prevent Google using NIT/address as descriptions
- Reinforce cart noindex with nosnippet/nocache/noarchive and proper title/description
- Change footer "Pedidos" link from /carrito/step1 to /perfil to stop Google discovering cart
- Add SiteNavigationElement JSON-LD to guide Google sitelinks (navbar categories)
- Add metadata layouts for product categories and soporte pages
- Update sitemap priorities to match navbar structure and avoid duplicates