### PR TITLE
feat: PostHog client-side purchase tracking + fix revenue data

### DIFF
--- a/src/app/success-checkout/[orderId]/page.tsx
+++ b/src/app/success-checkout/[orderId]/page.tsx
@@ -20,6 +20,7 @@ import CheckoutSuccessOverlay from "../../carrito/CheckoutSuccessOverlay";
 import { useCart } from "@/hooks/useCart";
 import { apiClient } from "@/lib/api";
 import { useAnalyticsWithUser } from "@/lib/analytics";
+import { posthogUtils } from "@/lib/posthogClient";
 import { apiPost } from "@/lib/api-client";
 import { addBusinessDays, getNextBusinessDay } from "@/lib/dateUtils";
 import useSecureStorage from "@/hooks/useSecureStorage";
@@ -151,24 +152,45 @@ export default function SuccessCheckoutPage({
           const orderData = orderResponse.data;
           const items = orderData.order_items || [];
 
-          // Calcular el valor total de la orden
-          const totalValue = items.reduce(
-            (sum, item) => sum + (item.quantity || 0) * 1000000,
+          // Calcular el valor total usando precios reales
+          const totalValue = orderData.total_amount || items.reduce(
+            (sum, item) => sum + (Number(item.unit_price || item.precio) || 0) * (item.quantity || item.cantidad || 1),
             0
-          ); // Estimado
-
-          // Enviar evento de purchase
-          trackPurchase(
-            pathParams.orderId,
-            items.map((item) => ({
-              item_id: item.sku || "unknown",
-              item_name: item.product_name || "Producto",
-              item_brand: "Samsung",
-              price: 1000000, // Precio estimado, idealmente debería venir de la orden
-              quantity: item.quantity || 1,
-            })),
-            totalValue
           );
+
+          const mappedItems = items.map((item) => ({
+            item_id: item.sku || "unknown",
+            item_name: item.product_name || item.nombre || "Producto",
+            item_brand: "Samsung",
+            price: Number(item.unit_price || item.precio) || 0,
+            quantity: item.quantity || item.cantidad || 1,
+          }));
+
+          // Enviar evento de purchase a GA4/Meta/TikTok
+          trackPurchase(pathParams.orderId, mappedItems, totalValue);
+
+          // Enviar evento de purchase a PostHog (client-side, dedup via $insert_id en server)
+          try {
+            posthogUtils.capture("purchase", {
+              $insert_id: `purchase_${pathParams.orderId}`,
+              event_id: `purchase_${pathParams.orderId}`,
+              order_id: pathParams.orderId,
+              transaction_id: pathParams.orderId,
+              currency: "COP",
+              value: totalValue,
+              items: mappedItems.map((item) => ({
+                sku: item.item_id,
+                name: item.item_name,
+                brand: "Samsung",
+                price: item.price,
+                quantity: item.quantity,
+              })),
+              item_count: mappedItems.reduce((sum, i) => sum + i.quantity, 0),
+              source: "client",
+            });
+          } catch (e) {
+            console.error("[PostHog] Error capturing purchase:", e);
+          }
         }
       } catch (error) {
         console.error("[Analytics] Error sending purchase event:", error);


### PR DESCRIPTION
## Summary
- Add `posthogUtils.capture("purchase")` on success-checkout page with `$insert_id` deduplication
- Fix hardcoded prices (`1000000`) → now uses real `unit_price` / `total_amount` from the order API
- Revenue accuracy improvement affects GA4, Meta, and TikTok as well (not just PostHog)

## Why
PostHog had zero purchase events. Client-side capture serves as a backup to server-side tracking (payments-ms PR). Also fixes revenue data that was reporting ~$1M COP per item instead of real prices.

## Test plan
- [ ] Complete a test purchase and verify `purchase` event appears in PostHog
- [ ] Verify GA4/Meta events now show correct revenue values
- [ ] Confirm deduplication with server-side event (only 1 event per order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)