### PR TITLE
fix(seo): update Google Search Console verification token

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -108,7 +108,7 @@ export async function generateMetadata(): Promise<Metadata> {
       creator: "@imagiqstore",
     },
     verification: {
-      google: s.google_verification || process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION || "O0rmKClM5-HJ-pLC4H8LFHwVJsvQ44ALMcV2FpUiH5Q",
+      google: s.google_verification || process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION || "VscG5yDmCSt7SeSTCOxYRY592PE-a8DYRkLJt7bb_ac",
     },
     alternates: {
       canonical: s.site_url,


### PR DESCRIPTION
## Summary
- Reemplaza el token hardcodeado de `google-site-verification` en `src/app/layout.tsx` por el token actual que Google Search Console está solicitando para verificar la propiedad `https://imagiq.com/`.
- Token anterior: `O0rmKClM5-HJ-pLC4H8LFHwVJsvQ44ALMcV2FpUiH5Q` (obsoleto)
- Token nuevo: `VscG5yDmCSt7SeSTCOxYRY592PE-a8DYRkLJt7bb_ac`

## Contexto
El fallback sigue respetando la prioridad existente:
1. `s.google_verification` (CMS/backend)
2. `process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION`
3. Fallback hardcoded (este cambio)

Con esto, en cuanto el deploy llegue a producción, se puede presionar **Verificar** en Search Console y queda validada la propiedad.

## Test plan
- [ ] Deploy preview de Vercel levantado
- [ ] `curl -s <preview-url> | grep google-site-verification` muestra el token nuevo
- [ ] Tras merge a `develop` y promoción a producción, verificar en https://search.google.com/search-console