### PR TITLE
fix(seo): 410 Gone on legacy /products URLs + robots disallow

### DIFF
--- a/src/app/product/[[...slug]]/route.ts
+++ b/src/app/product/[[...slug]]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+const goneResponse = () =>
+  new NextResponse("Gone", {
+    status: 410,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Robots-Tag": "noindex, nofollow",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+
+export async function GET() {
+  return goneResponse();
+}
+
+export async function HEAD() {
+  return goneResponse();
+}

--- a/src/app/products/[[...slug]]/route.ts
+++ b/src/app/products/[[...slug]]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+const goneResponse = () =>
+  new NextResponse("Gone", {
+    status: 410,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Robots-Tag": "noindex, nofollow",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+
+export async function GET() {
+  return goneResponse();
+}
+
+export async function HEAD() {
+  return goneResponse();
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -17,6 +17,8 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
     '/tracking-service/',
     '/verify-purchase/',
     '/*?i=',
+    '/products/',
+    '/product/',
   ];
   let aiPolicy = 'block_training';
   let siteUrl = SITE_URL;


### PR DESCRIPTION
## Summary
Limpia el desastre de indexación reportado en Google Search Console:

- **951 mil** URLs con 404 en `/products/[id]/` y `/product/edit/[id]` del sitio anterior
- **56.4 mil** URLs con parámetro `?i=` generando redirects

### Cambios
1. **Route handlers que devuelven `410 Gone`** en:
   - `src/app/products/[[...slug]]/route.ts`
   - `src/app/product/[[...slug]]/route.ts`
   Como los IDs viejos **no matchean** con los actuales, un redirect 301 sería engañoso. Con 410 Gone Google retira las URLs del índice definitivamente (~30-60 días).

2. **Robots disallow** de `/products/` y `/product/` para detener el desperdicio de crawl budget en esas rutas.
   _Nota: las rutas reales del sitio usan `/productos/` (con 's', en español) y siguen permitidas._

### Lo que **NO** toca (deliberadamente)
- Sitemap — se queda con categorías + páginas estáticas, sin productos individuales (decisión de producto: que los sitelinks en Google prioricen categorías).
- PDPs — siguen indexables para tráfico long-tail (ej: "galaxy s24 ultra imagiq").
- Canonical del PDP ya está correcto (`src/app/productos/view/[id]/layout.tsx:36`) y la regla `/*?i=` ya existe en robots.

## Test plan
- [ ] Preview deploy levantado
- [ ] `curl -I <preview>/products/829855` → `HTTP/1.1 410`
- [ ] `curl -I <preview>/product/edit/65900535` → `HTTP/1.1 410`
- [ ] `curl -s <preview>/robots.txt | grep -E "products|product"` muestra ambas rutas
- [ ] Rutas legítimas `/productos/view/[id]` siguen respondiendo `200`
- [ ] Tras merge + deploy prod → usar **Retirada de URLs** en Search Console para acelerar la limpieza