### PR TITLE
fix(seo): noindex /login (it's the #2 indexed page)

### DIFF
--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -5,6 +5,11 @@ export const metadata: Metadata = {
   description:
     "Inicia sesion en tu cuenta Imagiq para acceder a tus pedidos, direcciones guardadas y ofertas exclusivas.",
   alternates: { canonical: "https://imagiq.com/login" },
+  robots: {
+    index: false,
+    follow: true,
+    googleBot: { index: false, follow: true },
+  },
 };
 
 export default function LoginLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
Search Console muestra `/login` como la **segunda página más vista** del sitio en resultados de búsqueda. Nadie googlea "imagiq" esperando un form de login — es una mala experiencia y desperdicia impresiones.

## Change
- Agrega `robots: { index: false, follow: true }` en `src/app/login/layout.tsx`.
- Se aplica por herencia a `/login/create-account` y `/login/password-recovery`.

## Por qué noindex y no robots.txt
Si bloqueamos en `robots.txt`, Google no puede crawlear la página para ver el meta `noindex` y paradójicamente **sigue mostrando la URL** en SERPs (sin snippet). Con `noindex` + crawl permitido, Google ve la señal y la retira.

## Test plan
- [ ] Preview deploy arriba
- [ ] `curl -s <preview>/login | grep -i 'noindex'` muestra la meta
- [ ] `curl -s <preview>/login/create-account | grep -i 'noindex'` también (herencia)
- [ ] Tras merge + prod, solicitar **Inspección de URL** en Search Console para acelerar recrawl