### PR TITLE
fix(seo): tune sitelink descriptions to match target SERP

### DIFF
--- a/src/app/ofertas/layout.tsx
+++ b/src/app/ofertas/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Ofertas y Promociones Samsung",
   description:
-    "Descubre las mejores ofertas y promociones en productos Samsung. Galaxy, tablets, wearables y electrodomésticos con descuentos exclusivos en Imagiq.",
+    "Descubre las mejores ofertas y promociones Samsung. Galaxy, tablets, wearables y electrodomésticos con descuentos exclusivos en Imagiq Colombia.",
   alternates: { canonical: "https://imagiq.com/ofertas" },
   openGraph: {
     title: "Ofertas Samsung - Samsung Store",

--- a/src/app/productos/[categoria]/layout.tsx
+++ b/src/app/productos/[categoria]/layout.tsx
@@ -7,22 +7,22 @@ const CATEGORY_META: Record<string, { title: string; description: string }> = {
   "dispositivos-moviles": {
     title: "Dispositivos Móviles Samsung",
     description:
-      "Descubre los últimos smartphones Galaxy, tablets, smartwatches y accesorios Samsung. Compra con envío gratis y garantía oficial en Imagiq Colombia.",
+      "Smartphones Galaxy, tablets, smartwatches y accesorios Samsung con envío gratis y garantía oficial en Imagiq Colombia.",
   },
   "tv-y-audio": {
     title: "TV y Audio Samsung",
     description:
-      "Televisores Samsung QLED, Neo QLED, barras de sonido y parlantes. La mejor experiencia de entretenimiento con garantía oficial en Imagiq Colombia.",
+      "Televisores QLED, Neo QLED, barras de sonido y parlantes Samsung con garantía oficial en Imagiq Colombia.",
   },
   electrodomesticos: {
     title: "Electrodomésticos Samsung",
     description:
-      "Neveras, lavadoras, aspiradoras y más. Electrodomésticos Samsung de última tecnología con garantía oficial en Imagiq Colombia.",
+      "Neveras, lavadoras, secadoras y aspiradoras Samsung con garantía oficial en Imagiq Colombia.",
   },
   monitores: {
     title: "Monitores Samsung",
     description:
-      "Monitores Samsung para gaming, productividad y diseño. Pantallas de alta resolución con garantía oficial en Imagiq Colombia.",
+      "Monitores Samsung para gaming, productividad y diseño con garantía oficial en Imagiq Colombia.",
   },
 };
 


### PR DESCRIPTION
## Summary
Ajusta las descriptions de las 5 páginas que aparecen como sitelinks bajo la búsqueda de marca \`imagiq\` para que el texto visible en Google arranque con el contenido fuerte (Smartphones Galaxy, Televisores QLED, Neveras, etc.) y no con frases genéricas como "Descubre los últimos...".

### Páginas tocadas y nuevo head del description
- \`/ofertas\` → "Descubre las mejores ofertas y promociones Samsung..."
- \`/productos/dispositivos-moviles\` → "Smartphones Galaxy, tablets, smartwatches y accesorios..."
- \`/productos/tv-y-audio\` → "Televisores QLED, Neo QLED, barras de sonido..."
- \`/productos/electrodomesticos\` → "Neveras, lavadoras, secadoras y aspiradoras Samsung..."
- \`/productos/monitores\` → "Monitores Samsung para gaming, productividad y diseño..."

### No se tocan
- Home: ya coincide con el mockup objetivo
- \`/tiendas\`: ya coincide
- \`/soporte\`: ya coincide

## Por qué
Google trunca snippets en ~150 chars y muestra el head del description. Al liderar con términos transaccionales mejora CTR y alineación con el mockup aprobado.

## Test plan
- [ ] Preview deploy levantado
- [ ] View-source de \`/ofertas\` muestra la description nueva
- [ ] View-source de \`/productos/dispositivos-moviles\`, \`/productos/tv-y-audio\`, \`/productos/electrodomesticos\`, \`/productos/monitores\` muestran la description nueva
- [ ] Tras merge + prod, pedir **Inspección de URL** en Search Console para cada una y solicitar indexación