### PR TITLE
feat(seo): metadata dinámica desde CMS y overrides por página/producto

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -31,6 +31,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description,
+    keywords: page.meta_keywords || undefined,
     alternates: { canonical: page.seo_canonical || url },
     robots: {
       index: !page.seo_no_index,
@@ -41,6 +42,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       description: page.seo_og_description || description,
       url,
       images: page.og_image ? [{ url: page.og_image }] : undefined,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.seo_og_title || title,
+      description: page.seo_og_description || description,
+      images: page.og_image ? [page.og_image] : undefined,
     },
   };
 }

--- a/src/app/productos/[categoria]/layout.tsx
+++ b/src/app/productos/[categoria]/layout.tsx
@@ -102,7 +102,6 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
       title: data?.seo_og_title || title,
       description: data?.seo_og_description || description,
       images: data?.og_image ? [data.og_image] : undefined,
->>>>>>> ea0d4517 (feat(seo): dynamic generateMetadata per category from dashboard CMS)
     },
   };
 }

--- a/src/app/productos/[categoria]/layout.tsx
+++ b/src/app/productos/[categoria]/layout.tsx
@@ -1,64 +1,112 @@
+/**
+ * Per-category SEO layout.
+ *
+ * Next.js invokes generateMetadata on every request to /productos/[categoria];
+ * we fetch the categorias_visibles list from the backend and resolve the
+ * slug to a category, then build the <head> tags from the per-category SEO
+ * fields edited in the dashboard (meta_title, meta_description, canonical,
+ * noindex/nofollow, OG overrides).
+ *
+ * If the category is missing, has no SEO overrides, or the fetch fails, we
+ * fall back to sensible defaults and let the root layout metadata take over.
+ */
+
 import type { Metadata } from "next";
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://imagiq.com";
 
-/** SEO metadata for each known product category */
-const CATEGORY_META: Record<string, { title: string; description: string }> = {
-  "dispositivos-moviles": {
-    title: "Dispositivos Móviles Samsung",
-    description:
-      "Smartphones Galaxy, tablets, smartwatches y accesorios Samsung con envío gratis y garantía oficial en Imagiq Colombia.",
-  },
-  "tv-y-audio": {
-    title: "TV y Audio Samsung",
-    description:
-      "Televisores QLED, Neo QLED, barras de sonido y parlantes Samsung con garantía oficial en Imagiq Colombia.",
-  },
-  electrodomesticos: {
-    title: "Electrodomésticos Samsung",
-    description:
-      "Neveras, lavadoras, secadoras y aspiradoras Samsung con garantía oficial en Imagiq Colombia.",
-  },
-  monitores: {
-    title: "Monitores Samsung",
-    description:
-      "Monitores Samsung para gaming, productividad y diseño con garantía oficial en Imagiq Colombia.",
-  },
-};
+interface CategoriaSeoPayload {
+  uuid: string;
+  nombre: string;
+  nombre_visible?: string | null;
+  descripcion?: string | null;
+  activo: boolean;
+  meta_title?: string | null;
+  meta_description?: string | null;
+  meta_keywords?: string | null;
+  og_image?: string | null;
+  seo_og_title?: string | null;
+  seo_og_description?: string | null;
+  seo_canonical?: string | null;
+  seo_no_index?: boolean;
+  seo_no_follow?: boolean;
+}
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ categoria: string }>;
-}): Promise<Metadata> {
-  const { categoria } = await params;
-  const meta = CATEGORY_META[categoria];
+/** Mirror the slug logic used by the dashboard editor and the navbar */
+function slugify(raw: string | null | undefined): string {
+  return (raw || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
 
-  if (!meta) {
-    return {
-      title: "Productos Samsung",
-      description:
-        "Encuentra los mejores productos Samsung con garantía oficial, envío gratis y soporte especializado en Imagiq Colombia.",
-      alternates: { canonical: `${SITE_URL}/productos/${categoria}` },
-    };
+async function findCategoriaBySlug(slug: string): Promise<CategoriaSeoPayload | null> {
+  try {
+    const res = await fetch(`${API_URL}/api/multimedia/categorias`, {
+      next: { revalidate: 300 }, // 5 min ISR cache
+    });
+    if (!res.ok) return null;
+    const categorias = (await res.json()) as CategoriaSeoPayload[];
+    if (!Array.isArray(categorias)) return null;
+    return (
+      categorias.find(
+        (c) =>
+          slugify(c.nombre_visible) === slug || slugify(c.nombre) === slug,
+      ) || null
+    );
+  } catch {
+    return null;
   }
+}
+
+interface LayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ categoria: string }>;
+}
+
+export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
+  const { categoria } = await params;
+  const data = await findCategoriaBySlug(categoria);
+
+  const displayName = data?.nombre_visible || data?.nombre || categoria;
+  const title = data?.meta_title || `${displayName} - IMAGIQ`;
+  const description =
+    data?.meta_description ||
+    data?.descripcion ||
+    `Explora nuestra selección de ${displayName} en IMAGIQ con envío a toda Colombia.`;
+  const url = `${SITE_URL}/productos/${categoria}`;
 
   return {
-    title: meta.title,
-    description: meta.description,
-    alternates: { canonical: `${SITE_URL}/productos/${categoria}` },
+    title,
+    description,
+    keywords: data?.meta_keywords || undefined,
+    alternates: { canonical: data?.seo_canonical || url },
+    robots: {
+      index: !(data?.seo_no_index ?? false),
+      follow: !(data?.seo_no_follow ?? false),
+    },
     openGraph: {
-      title: meta.title,
-      description: meta.description,
-      url: `${SITE_URL}/productos/${categoria}`,
+      type: "website",
+      url,
+      title: data?.seo_og_title || title,
+      description: data?.seo_og_description || description,
+      images: data?.og_image ? [{ url: data.og_image }] : undefined,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: data?.seo_og_title || title,
+      description: data?.seo_og_description || description,
+      images: data?.og_image ? [data.og_image] : undefined,
+>>>>>>> ea0d4517 (feat(seo): dynamic generateMetadata per category from dashboard CMS)
     },
   };
 }
 
-export default function CategoriaLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
+export default function CategoriaLayout({ children }: LayoutProps) {
+  return children;
 }

--- a/src/app/productos/view/[id]/layout.tsx
+++ b/src/app/productos/view/[id]/layout.tsx
@@ -8,6 +8,40 @@ interface Props {
   children: React.ReactNode;
 }
 
+interface ProductSeoOverride {
+  sku: string;
+  meta_title?: string | null;
+  meta_description?: string | null;
+  meta_keywords?: string | null;
+  og_image?: string | null;
+  seo_og_title?: string | null;
+  seo_og_description?: string | null;
+  seo_canonical?: string | null;
+  seo_no_index?: boolean;
+  seo_no_follow?: boolean;
+}
+
+/**
+ * Fetch per-product SEO overrides from the product_seo side table. Returns
+ * null when the product has no overrides (the common case).
+ */
+async function fetchProductSeoOverride(
+  sku: string,
+): Promise<ProductSeoOverride | null> {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/products/seo/overrides/${encodeURIComponent(sku)}`,
+      { next: { revalidate: 300 } }, // 5 min ISR cache
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data || !data.sku) return null;
+    return data as ProductSeoOverride;
+  } catch {
+    return null;
+  }
+}
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
 
@@ -23,28 +57,50 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
     if (!product?.nombre) return {};
 
-    const title = `${product.nombre}${product.marca ? ` - ${product.marca}` : ""}`;
-    const description = product.descripcion
+    // Load per-product SEO overrides (if any) using the product's sku. The
+    // route param is usually codigoMarket, which is different from sku, so
+    // we must wait on the product fetch before we can issue the override
+    // lookup.
+    const override = product.sku
+      ? await fetchProductSeoOverride(product.sku)
+      : null;
+
+    // Derived defaults from the catalog data
+    const defaultTitle = `${product.nombre}${product.marca ? ` - ${product.marca}` : ""}`;
+    const defaultDescription = product.descripcion
       ? product.descripcion.substring(0, 160)
       : `Compra ${product.nombre} en Imagiq - Distribuidor Oficial Samsung Colombia. Envio gratis y garantia oficial.`;
-    const image = product.imagenPrincipal || product.imagen || "/logo-og.png";
+    const defaultImage =
+      product.imagenPrincipal || product.imagen || "/logo-og.png";
     const url = `${SITE_URL}/productos/view/${id}`;
+
+    // Override precedence: admin-edited value > catalog-derived default
+    const title = override?.meta_title || defaultTitle;
+    const description = override?.meta_description || defaultDescription;
+    const image = override?.og_image || defaultImage;
+    const ogTitle = override?.seo_og_title || title;
+    const ogDescription = override?.seo_og_description || description;
 
     return {
       title,
       description,
-      alternates: { canonical: url },
+      keywords: override?.meta_keywords || undefined,
+      alternates: { canonical: override?.seo_canonical || url },
+      robots: {
+        index: !(override?.seo_no_index ?? false),
+        follow: !(override?.seo_no_follow ?? false),
+      },
       openGraph: {
-        title,
-        description,
+        title: ogTitle,
+        description: ogDescription,
         url,
         type: "website",
         images: [{ url: image, width: 800, height: 800, alt: product.nombre }],
       },
       twitter: {
         card: "summary_large_image",
-        title,
-        description,
+        title: ogTitle,
+        description: ogDescription,
         images: [image],
       },
     };

--- a/src/app/soporte/[slug]/page.tsx
+++ b/src/app/soporte/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getActivePageBySlug, type MultimediaPage, type LegalSection } from '@/services/multimedia-pages.service';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://imagiq.com';
 import { LegalDocumentLayout } from '@/components/legal/LegalDocumentLayout';
 import TiptapRenderer from '@/components/legal/TiptapRenderer';
 import { extractSectionsFromContent } from '@/lib/tiptap-utils';
@@ -21,17 +23,31 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   const { page } = data;
+  const title = page.meta_title || `${page.title} - IMAGIQ`;
+  const description = page.meta_description || `${page.title} - Términos y condiciones de IMAGIQ`;
+  const url = `${SITE_URL}/soporte/${slug}`;
 
   return {
-    title: page.meta_title || `${page.title} - IMAGIQ`,
-    description: page.meta_description || `${page.title} - Términos y condiciones de IMAGIQ`,
+    title,
+    description,
     keywords: page.meta_keywords || undefined,
+    alternates: { canonical: page.seo_canonical || url },
+    robots: {
+      index: !page.seo_no_index,
+      follow: !page.seo_no_follow,
+    },
     openGraph: {
-      title: page.meta_title || page.title,
-      description: page.meta_description || '',
+      title: page.seo_og_title || title,
+      description: page.seo_og_description || description,
+      url,
+      images: page.og_image ? [{ url: page.og_image }] : undefined,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.seo_og_title || title,
+      description: page.seo_og_description || description,
       images: page.og_image ? [page.og_image] : undefined,
     },
-    robots: 'index, follow',
   };
 }
 


### PR DESCRIPTION
## Resumen
- Genera metadata SEO de forma dinámica por categoría desde CMS
- Respeta overrides SEO por página
- Respeta overrides SEO por producto

## Cambios incluidos
- generateMetadata dinámico por categoría
- Superficie completa de campos SEO por página
- Prioridad a campos SEO específicos de producto cuando existen

## Validación sugerida
- Verificar title/description/canonical por categoría
- Verificar que páginas sin override mantienen fallback
- Verificar metadata de producto con y sin override
