### PR TITLE
chore(posthog): use canonical capture_heatmaps flag

### DIFF
--- a/src/lib/posthogClient.ts
+++ b/src/lib/posthogClient.ts
@@ -127,7 +127,7 @@ export const posthogConfig = {
       "a[href]",
     ],
   },
-  enable_heatmaps: true,
+  capture_heatmaps: true,
   disable_session_recording: false,
   enable_recording_console_log: false,
   advanced_disable_decide: false,


### PR DESCRIPTION
## Summary
- Swaps the legacy \`enable_heatmaps: true\` for \`capture_heatmaps: true\` in [src/lib/posthogClient.ts](src/lib/posthogClient.ts). Both are valid in posthog-js 1.318.2, but \`capture_heatmaps\` is the canonical option documented in \`@posthog/types/dist/posthog-config.d.ts:1076\` and can accept a \`HeatmapConfig\` object in the future if we want finer-grained control (sampling rate, flush interval, etc.).
- **Behavior unchanged** — both flags already resolved to the same \"capture heatmap data\" path. This is just a code hygiene change paired with the parallel PR on imagiq-frontend-quioscos that added heatmaps capture to the kiosk app.

## Context
- Sibling PR on the kiosk frontend: https://github.com/Davases22/imagiq-frontend-quioscos/pull/26
- Both apps (\`imagiq-frontend\` + \`imagiq-frontend-quioscos\`) write to the same PostHog project \`274592\` (\"App Imagiq\"). The server-side toggle \`heatmaps_opt_in\` is **project-scoped**, so enabling it once via PostHog UI → Heatmaps → **Configure** (or Project Settings → Autocapture → Heatmaps) activates heatmap ingestion for both apps simultaneously. No need to click twice.

## Test plan
- [ ] Merge + wait for Vercel preview/production deploy from develop.
- [ ] One-time: click **Configure** on https://us.posthog.com/project/274592/heatmaps to flip \`heatmaps_opt_in\` server-side.
- [ ] Browse \`www.imagiq.com\` a bit, then open PostHog → Heatmaps → **New heatmap** pointing at any page hit and confirm clicks render after the usual 1–3 min ingestion lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)