### PR TITLE
feat(analytics): identify PostHog session early on email blur across 12 forms

### DIFF
--- a/src/app/carrito/Step2.tsx
+++ b/src/app/carrito/Step2.tsx
@@ -21,7 +21,7 @@ import {
   getTradeInValidationMessage,
 } from "./utils/validateTradeIn";
 import { toast } from "sonner";
-import { associateEmailWithSession } from "@/lib/posthogClient";
+import { associateEmailWithSession, identifyEmailEarly } from "@/lib/posthogClient";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -284,10 +284,11 @@ export default function Step2({
   };
 
   const handleGuestBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    const { name } = e.target;
+    const { name, value } = e.target;
     if (!name) return;
     setFieldTouched((prev) => ({ ...prev, [name]: true }));
     setFieldErrors(validateFields(guestForm));
+    if (name === "email") identifyEmailEarly(value);
   };
 
   // Manejar cambios en Select de shadcn (usa onValueChange en lugar de onChange)

--- a/src/app/carrito/Step6.tsx
+++ b/src/app/carrito/Step6.tsx
@@ -13,7 +13,7 @@ import AddNewAddressForm from "./components/AddNewAddressForm";
 import { MapPin, Plus, Check, Trash2 } from "lucide-react";
 import { safeGetLocalStorage } from "@/lib/localStorage";
 import { useCart } from "@/hooks/useCart";
-import { associateEmailWithSession } from "@/lib/posthogClient";
+import { associateEmailWithSession, identifyEmailEarly } from "@/lib/posthogClient";
 import { validateTradeInProducts, getTradeInValidationMessage } from "./utils/validateTradeIn";
 import { toast } from "sonner";
 
@@ -988,6 +988,7 @@ export default function Step6({ onBack, onContinue }: Step6Props) {
                     type="email"
                     value={billingData.email}
                     onChange={(e) => handleInputChange("email", e.target.value)}
+                    onBlur={(e) => identifyEmailEarly(e.target.value)}
                     className={`w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-black ${
                       errors.email ? "border-red-500" : "border-gray-300"
                     }`}

--- a/src/app/login/create-account/components/OTPStep.tsx
+++ b/src/app/login/create-account/components/OTPStep.tsx
@@ -4,6 +4,7 @@ import { Label } from "@/components/ui/label";
 import { Edit3 } from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import { apiPost } from "@/lib/api-client";
+import { identifyEmailEarly } from "@/lib/posthogClient";
 
 // Componente de input OTP con cajas individuales
 function OTPInputBoxes({
@@ -312,6 +313,7 @@ export function OTPStep({
                     setTempEmail(e.target.value);
                     setValidationError(""); // Limpiar error al escribir
                   }}
+                  onBlur={(e) => identifyEmailEarly(e.target.value)}
                   disabled={disabled || isValidating}
                   className="text-sm"
                 />

--- a/src/app/login/create-account/components/PersonalInfoStep.tsx
+++ b/src/app/login/create-account/components/PersonalInfoStep.tsx
@@ -4,6 +4,7 @@ import { Separator } from "@/components/ui/separator";
 import { Eye, EyeOff } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 import { apiPost } from "@/lib/api-client";
+import { identifyEmailEarly } from "@/lib/posthogClient";
 
 interface PersonalInfoData {
   nombre: string;
@@ -304,6 +305,7 @@ export function PersonalInfoStep({ formData, onChange, disabled, onValidationCha
             placeholder="tu@email.com"
             value={formData.email}
             onChange={(e) => onChange({ email: e.target.value })}
+            onBlur={(e) => identifyEmailEarly(e.target.value)}
             disabled={disabled}
             autoComplete="email"
             autoCapitalize="none"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAuthContext } from "@/features/auth/context";
-import { posthogUtils } from "@/lib/posthogClient";
+import { posthogUtils, identifyEmailEarly } from "@/lib/posthogClient";
 import { Cart, Usuario } from "@/types/user";
 import { Eye, EyeOff } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -207,6 +207,7 @@ export default function LoginPage() {
               onChange={(e) =>
                 setFormData({ ...formData, email: e.target.value })
               }
+              onBlur={(e) => identifyEmailEarly(e.target.value)}
               disabled={isLoading}
               autoComplete="username"
             />

--- a/src/app/login/password-recovery/components/EmailStep.tsx
+++ b/src/app/login/password-recovery/components/EmailStep.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Button from "@/components/Button";
 import { Loader } from "lucide-react";
 import Link from "next/link";
+import { identifyEmailEarly } from "@/lib/posthogClient";
 
 interface EmailStepProps {
   onEmailSubmit: (email: string) => Promise<void>;
@@ -78,6 +79,7 @@ export default function EmailStep({
                 setEmail(e.target.value);
                 setEmailError("");
               }}
+              onBlur={(e) => identifyEmailEarly(e.target.value)}
               placeholder="ejemplo@correo.com"
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent text-black placeholder-gray-400 text-base"
               disabled={isLoading}

--- a/src/app/productos/components/GuestDataModal.tsx
+++ b/src/app/productos/components/GuestDataModal.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import React, { useState } from "react";
+import { identifyEmailEarly } from "@/lib/posthogClient";
 
 interface GuestUserData {
   nombre: string;
@@ -124,6 +125,7 @@ const GuestDataModal: React.FC<GuestDataModalProps> = ({
               name="email"
               value={formData.email}
               onChange={handleChange}
+              onBlur={(e) => identifyEmailEarly(e.target.value)}
               className="w-full border border-gray-300 rounded-md px-3 py-2 mt-1 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 transition duration-200"
             />
             {errors.email && (

--- a/src/app/soporte/correo_electronico/page.tsx
+++ b/src/app/soporte/correo_electronico/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { associateEmailWithSession } from "@/lib/posthogClient";
+import { associateEmailWithSession, identifyEmailEarly } from "@/lib/posthogClient";
 
 export default function CorreoElectronicoPage() {
   const [formData, setFormData] = useState({
@@ -109,6 +109,7 @@ export default function CorreoElectronicoPage() {
                   name="email"
                   value={formData.email}
                   onChange={handleInputChange}
+                  onBlur={(e) => identifyEmailEarly(e.target.value)}
                   placeholder="Dirección de correo electrónico"
                   required
                   className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"

--- a/src/components/StockNotificationModal.tsx
+++ b/src/components/StockNotificationModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Modal from './Modal';
 import { useAuthContext } from '@/features/auth/context';
+import { identifyEmailEarly } from '@/lib/posthogClient';
 
 interface StockNotificationModalProps {
   isOpen: boolean;
@@ -153,6 +154,7 @@ export default function StockNotificationModal({
                   setEmail(e.target.value);
                   setError('');
                 }}
+                onBlur={(e) => identifyEmailEarly(e.target.value)}
                 placeholder="tu@email.com"
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 required

--- a/src/components/sections/ventas-corporativas/ContactFormSection.tsx
+++ b/src/components/sections/ventas-corporativas/ContactFormSection.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useRef } from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 import { ContactFormData } from "@/types/corporate-sales";
+import { identifyEmailEarly } from "@/lib/posthogClient";
 
 interface ContactFormSectionProps {
   onSubmit?: (data: ContactFormData) => void;
@@ -124,6 +125,7 @@ export default function ContactFormSection({
             type="email"
             value={formData.email}
             onChange={(e) => handleInputChange("email", e.target.value)}
+            onBlur={(e) => identifyEmailEarly(e.target.value)}
             className={`w-full px-4 py-3 border-b-2 bg-transparent focus:outline-none transition-colors ${
               errors.email
                 ? "border-red-500"

--- a/src/components/sections/ventas-corporativas/SpecializedConsultationModal.tsx
+++ b/src/components/sections/ventas-corporativas/SpecializedConsultationModal.tsx
@@ -9,6 +9,7 @@ import {
   SpecializedConsultationFormData,
   SolutionInterestOption,
 } from "@/types/corporate-sales";
+import { identifyEmailEarly } from "@/lib/posthogClient";
 
 interface SpecializedConsultationModalProps {
   isOpen: boolean;
@@ -174,6 +175,7 @@ export default function SpecializedConsultationModal({
               type="email"
               value={formData.email}
               onChange={(e) => handleInputChange("email", e.target.value)}
+              onBlur={(e) => identifyEmailEarly(e.target.value)}
               className={`${INPUT_CLASS} ${errors.email ? "border-red-500" : ""}`}
               disabled={isLoading}
             />

--- a/src/features/profile/components/modals/EditProfileModal.tsx
+++ b/src/features/profile/components/modals/EditProfileModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Modal from "@/components/Modal";
 import { ProfileUser } from "../../types";
+import { identifyEmailEarly } from "@/lib/posthogClient";
 
 interface EditProfileModalProps {
   isOpen: boolean;
@@ -131,6 +132,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
             name="email"
             value={formData.email}
             onChange={handleChange}
+            onBlur={(e) => identifyEmailEarly(e.target.value)}
             className="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-black focus:outline-none transition-colors"
             placeholder="correo@ejemplo.com"
             required

--- a/src/lib/posthogClient.ts
+++ b/src/lib/posthogClient.ts
@@ -204,6 +204,24 @@ export function associateEmailWithSession(
   }
 }
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Associate email with the current PostHog session as soon as the user finishes
+ * typing a plausibly-valid email (typically called on input blur). Trims and
+ * lowercases the value, skips invalid/partial inputs so we don't pollute the
+ * session with strings like "ab@".
+ */
+export function identifyEmailEarly(
+  email: string | null | undefined,
+  extraProperties?: Record<string, unknown>
+) {
+  if (!email) return;
+  const normalized = email.trim().toLowerCase();
+  if (!EMAIL_REGEX.test(normalized)) return;
+  associateEmailWithSession(normalized, extraProperties);
+}
+
 // Utilidades para interactuar con PostHog
 export const posthogUtils = {
   /**


### PR DESCRIPTION
## Problema

Ya existía el helper \`associateEmailWithSession\` en [src/lib/posthogClient.ts](src/lib/posthogClient.ts), pero se llamaba **solo en el submit** de los formularios (checkout Step2/Step6, soporte, etc.). Si un usuario escribía su correo y abandonaba antes de enviar (drop-off en checkout, ticket de soporte, registro), la sesión quedaba anónima en PostHog y no se podía atribuir el replay ni correlacionar con ventas perdidas.

## Fix

1. Nuevo helper **\`identifyEmailEarly(email, extraProps?)\`** en [src/lib/posthogClient.ts](src/lib/posthogClient.ts) que:
   - Hace \`trim()\` + \`toLowerCase()\`.
   - Valida con regex básico (\`/^[^\s@]+@[^\s@]+\.[^\s@]+$/\`) antes de disparar.
   - Llama a \`associateEmailWithSession\` (idempotente, usa \`setPersonProperties\` con \`$email\` + \`$initial_email\`).
   - Skip silencioso en SSR y si el email no valida → nunca mandamos \`ab@\` a PostHog.

2. **\`onBlur={(e) => identifyEmailEarly(e.target.value)}\`** añadido a cada input de email donde el correo pertenece al dueño de la sesión:
   - **Login**: sign in, create account (PersonalInfo + OTP edit), password recovery.
   - **Checkout**: Step2 invitado (encadenado en \`handleGuestBlur\` existente), Step6 billing.
   - **Soporte**: formulario de correo.
   - **Producto**: StockNotificationModal, GuestDataModal.
   - **Perfil**: EditProfileModal.
   - **Ventas corporativas**: ContactFormSection, SpecializedConsultationModal.

## Excluidos a propósito

- **\`carrito/components/DeliveryMethodSelector.tsx\`**: ese email es del **tercero** que recibe el pedido, no del comprador. Identificar la sesión con ese correo sería misattribution.
- **\`app/soporte/inicio_de_soporte/page.tsx\`**: ya identifica lo más temprano posible para ese flujo — el email sale de la consulta SOAP por documento, no de un input.

## Verificación

- \`tsc --noEmit\` limpio en los 13 archivos editados (errores pre-existentes en otros archivos sobre importación de imágenes no relacionados).
- No rompe ninguna llamada existente a \`associateEmailWithSession\` en submit — sigue ahí como backstop.
- El efecto en PostHog: tan pronto como el usuario sale del campo de email, el \`distinct_id\` queda ligado al person profile con \`\$email\`, y cualquier evento subsecuente (incluyendo abandono) se atribuye.

## Impacto esperado

En los próximos funnels de checkout y soporte, vamos a ver reducción drástica de sesiones anónimas para usuarios que alcanzaron a escribir su email. Órdenes rechazadas o abandonadas podrán cruzarse con el email del lead incluso si el usuario cierra la pestaña.

🤖 Generated with [Claude Code](https://claude.com/claude-code)