### PR TITLE
feat(soporte): send posthog session id when paying support ticket

### DIFF
--- a/src/app/soporte/inicio_de_soporte/page.tsx
+++ b/src/app/soporte/inicio_de_soporte/page.tsx
@@ -18,6 +18,7 @@ import pseLogo from "@/img/iconos/logo-pse.png";
 import cardValidator from "card-validator";
 import AnimatedCard from "@/components/ui/AnimatedCard";
 import { associateEmailWithSession } from "@/lib/posthogClient";
+import posthog from "posthog-js";
 
 type DocumentoWithRegistro = Documento & { registro?: string };
 
@@ -397,6 +398,16 @@ export default function InicioDeSoportePage() {
       // Siempre enviar abreviación (CC, CE, etc.). Default CC si no se reconoce.
       const tipo_documento = getDocumentAbbreviation(tipoDocRaw) ?? "CC";
 
+      // Session-replay id de PostHog. Permite que el correo "Pago Rechazado -
+      // Soporte" incluya un link directo al replay para ops — antes había
+      // que adivinar el usuario por email y abrir PostHog manualmente.
+      // Safe-access: `__loaded` evita crashes cuando adblockers impiden
+      // cargar el SDK.
+      const posthogSessionId =
+        typeof window !== "undefined" && posthog.__loaded
+          ? posthog.get_session_id?.() || undefined
+          : undefined;
+
       const payloadBase: Record<string, unknown> = {
         numero_orden: numeroOrden,
         usuario_email: (doc.email || "").toLowerCase().trim(),
@@ -408,6 +419,7 @@ export default function InicioDeSoportePage() {
         tipo_documento: tipo_documento,
         estado: doc.estadoCodigo ?? "",
         valor: normalizedValor,
+        ...(posthogSessionId && { posthogSessionId }),
       };
 
       // Campos específicos según medio de pago


### PR DESCRIPTION
## Problema

El flujo \"paga tu soporte\" (\`/soporte/inicio_de_soporte\`) **NO envía el session-id de PostHog al backend**. Resultado: cuando un pago de soporte se rechaza, el correo que recibe ops (\"Pago Rechazado - Soporte\") queda sin link al session-replay.

Con ~10 rechazos PSE en 2 días (mayoría \"usuario no finalizo la transaccion en el banco\"), ops no puede auditar qué hizo el cliente realmente.

El flujo de carrito principal ya envía PostHog session desde Feb 2026 ([\`carrito/utils/index.ts:11\`](src/app/carrito/utils/index.ts#L11)) — este PR replica el patrón en el page de soporte.

## Cambio

[\`soporte/inicio_de_soporte/page.tsx\`](src/app/soporte/inicio_de_soporte/page.tsx):

\`\`\`ts
const posthogSessionId =
  typeof window !== \"undefined\" && posthog.__loaded
    ? posthog.get_session_id?.() || undefined
    : undefined;

const payloadBase: Record<string, unknown> = {
  // ...campos existentes
  ...(posthogSessionId && { posthogSessionId }),
};
\`\`\`

Safe-access vía \`posthog.__loaded\` para no crashear cuando adblockers bloquean el SDK (en ese caso el campo queda \`undefined\` y el backend persiste null).

## Depende de

**[imagiq-backend#578](https://github.com/Davases22/imagiq-backend/pull/578)** — mergear primero:
1. \`PaySupportTicketDto\` acepta \`posthogSessionId\`
2. \`ordenes_soporte\` tiene nuevas columnas (self-healing ALTER)
3. \`handleSupportRejection\` emite \`clientIp\` + \`posthogSessionId\` al correo

Hasta el merge de backend, el campo extra es ignorado silenciosamente — nada se rompe.

## Por qué inline y no utility

Dos consumidores (\`carrito/utils\` y ahora \`soporte\`). Tres líneas cada uno — no vale la pena extraer. Memory del proyecto ya marca \"three similar lines is better than a premature abstraction\". Si aparece un tercer consumidor, ahí sí toca refactor.

## Test plan

- [ ] Backend #578 mergeado y desplegado
- [ ] Ir a \`/soporte/inicio_de_soporte\` en staging
- [ ] DevTools Network → request a \`/api/orders/support-ticket/pay\` debe tener \`posthogSessionId: \"01xxx...\"\` en el body
- [ ] Si el pago se rechaza, el correo a ops incluye la fila \"Ver sesion en PostHog\" con link clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)