### PR TITLE
develop → main: ship PostHog session id on support-ticket pay + early email identify

### DIFF
--- a/src/app/soporte/inicio_de_soporte/page.tsx
+++ b/src/app/soporte/inicio_de_soporte/page.tsx
@@ -18,6 +18,7 @@ import pseLogo from "@/img/iconos/logo-pse.png";
 import cardValidator from "card-validator";
 import AnimatedCard from "@/components/ui/AnimatedCard";
 import { associateEmailWithSession } from "@/lib/posthogClient";
+import posthog from "posthog-js";
 
 type DocumentoWithRegistro = Documento & { registro?: string };
 
@@ -397,6 +398,16 @@ export default function InicioDeSoportePage() {
       // Siempre enviar abreviación (CC, CE, etc.). Default CC si no se reconoce.
       const tipo_documento = getDocumentAbbreviation(tipoDocRaw) ?? "CC";
 
+      // Session-replay id de PostHog. Permite que el correo "Pago Rechazado -
+      // Soporte" incluya un link directo al replay para ops — antes había
+      // que adivinar el usuario por email y abrir PostHog manualmente.
+      // Safe-access: `__loaded` evita crashes cuando adblockers impiden
+      // cargar el SDK.
+      const posthogSessionId =
+        typeof window !== "undefined" && posthog.__loaded
+          ? posthog.get_session_id?.() || undefined
+          : undefined;
+
       const payloadBase: Record<string, unknown> = {
         numero_orden: numeroOrden,
         usuario_email: (doc.email || "").toLowerCase().trim(),
@@ -408,6 +419,7 @@ export default function InicioDeSoportePage() {
         tipo_documento: tipo_documento,
         estado: doc.estadoCodigo ?? "",
         valor: normalizedValor,
+        ...(posthogSessionId && { posthogSessionId }),
       };
 
       // Campos específicos según medio de pago

--- a/src/app/soporte/inicio_de_soporte/page.tsx
+++ b/src/app/soporte/inicio_de_soporte/page.tsx
@@ -18,6 +18,27 @@ import pseLogo from "@/img/iconos/logo-pse.png";
 import cardValidator from "card-validator";
 import AnimatedCard from "@/components/ui/AnimatedCard";
 import { associateEmailWithSession } from "@/lib/posthogClient";
+import posthog from "posthog-js";
+
+/**
+ * Safely grab PostHog session/distinct ids so the support-ticket payment
+ * payload lands in `ordenes_soporte.posthog_session_id`. Returns empty
+ * strings if PostHog hasn't loaded yet so the backend can still accept
+ * the request (DTO fields are optional).
+ */
+function getPostHogIds(): { posthogSessionId: string; posthogDistinctId: string } {
+  try {
+    if (typeof window !== "undefined" && posthog.__loaded) {
+      return {
+        posthogSessionId: posthog.get_session_id?.() || "",
+        posthogDistinctId: posthog.get_distinct_id?.() || "",
+      };
+    }
+  } catch {
+    /* PostHog not available */
+  }
+  return { posthogSessionId: "", posthogDistinctId: "" };
+}
 
 type DocumentoWithRegistro = Documento & { registro?: string };
 
@@ -397,6 +418,8 @@ export default function InicioDeSoportePage() {
       // Siempre enviar abreviación (CC, CE, etc.). Default CC si no se reconoce.
       const tipo_documento = getDocumentAbbreviation(tipoDocRaw) ?? "CC";
 
+      const { posthogSessionId, posthogDistinctId } = getPostHogIds();
+
       const payloadBase: Record<string, unknown> = {
         numero_orden: numeroOrden,
         usuario_email: (doc.email || "").toLowerCase().trim(),
@@ -408,6 +431,11 @@ export default function InicioDeSoportePage() {
         tipo_documento: tipo_documento,
         estado: doc.estadoCodigo ?? "",
         valor: normalizedValor,
+        // Persist the PostHog session id on `ordenes_soporte` so the admin
+        // detail page can deep-link to the session replay. Empty-string
+        // values are skipped server-side.
+        ...(posthogSessionId ? { posthogSessionId } : {}),
+        ...(posthogDistinctId ? { posthogDistinctId } : {}),
       };
 
       // Campos específicos según medio de pago


### PR DESCRIPTION
## Qué va a producción

Merge estándar develop→main con 2 commits pendientes:

- \`662e0aa0\` Merge PR [#940](https://github.com/Davases22/imagiq-frontend/pull/940)
- \`bc730ce4\` feat(soporte): send posthog session id when paying support ticket

## Por qué urgente

El correo \"Pago Rechazado - Soporte\" **sigue sin incluir link al session-replay** en producción (aunque el backend ya despliegó [#578](https://github.com/Davases22/imagiq-backend/pull/578) que lo acepta) porque el cambio del frontend está solo en \`develop\`.

Con ~10 rechazos PSE en los últimos días, ops no tiene forma de ir directo a PostHog para entender qué hizo el usuario.

## Test plan

- [ ] Mergear
- [ ] Vercel despliega main
- [ ] Ir a \`imagiq.com/soporte/inicio_de_soporte\` en producción
- [ ] DevTools Network → payload de \`/api/orders/support-ticket/pay\` debe tener \`posthogSessionId: \"01xxx...\"\`
- [ ] Próximo rechazo de soporte → email incluye fila \"Ver sesion en PostHog\" clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)