### PR TITLE
fix(banners): preserve aspect ratio, serve at original quality

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -19,35 +19,41 @@ export default function Banner({ config, className = "" }: Readonly<BannerProps>
     return null;
   }
 
+  // Dimensiones por defecto cuando el CMS/config no las informa. Mantener
+  // una proporción aproximada evita CLS hasta que la imagen carga y el
+  // navegador reemplaza el placeholder con las dimensiones reales.
+  const desktopWidth = config.imageWidth ?? 1440;
+  const desktopHeight = config.imageHeight ?? 560;
+  const mobileWidth = config.imageWidthMobile ?? config.imageWidth ?? 828;
+  const mobileHeight = config.imageHeightMobile ?? config.imageHeight ?? 620;
+
   const content = (
     <div
       className={`relative w-full overflow-hidden rounded-lg ${className}`}
-      style={{
-        backgroundColor: config.backgroundColor || "#000000",
-        height: config.heightMobile || "180px",
-      }}
+      style={{ backgroundColor: config.backgroundColor || "transparent" }}
     >
-      {/* Desktop Image */}
-      <div
-        className="hidden md:block relative w-full h-full"
-        style={{ height: config.height || "280px" }}
-      >
+      {/* Desktop — se muestra en su proporción natural, sin crop */}
+      <div className="hidden md:block w-full">
         <Image
           src={config.imageUrl}
           alt={config.title || "Banner"}
-          fill
-          className="object-cover"
+          width={desktopWidth}
+          height={desktopHeight}
+          sizes="100vw"
+          className="block w-full h-auto"
           priority
         />
       </div>
 
-      {/* Mobile Image */}
-      <div className="md:hidden relative w-full h-full">
+      {/* Mobile — idem, preserva aspect ratio del archivo */}
+      <div className="md:hidden w-full">
         <Image
           src={config.imageUrlMobile || config.imageUrl}
           alt={config.title || "Banner"}
-          fill
-          className="object-cover"
+          width={mobileWidth}
+          height={mobileHeight}
+          sizes="100vw"
+          className="block w-full h-auto"
           priority
         />
       </div>

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -571,14 +571,14 @@ export default function HeroSection() {
                 )}
               </div>
 
-              {/* Mobile media */}
-              <div className="block md:hidden w-full h-screen relative">
+              {/* Mobile media — alto automático según aspect del archivo (no se recorta) */}
+              <div className="block md:hidden w-full relative">
                 {shouldShowVideoMobile ? (
                   <>
                     {/* Mobile video */}
                     <video
                       key={`hero-mobile-video-${index}`}
-                      className="block w-full h-full object-cover"
+                      className="block w-full h-auto"
                       autoPlay={isActive}
                       muted
                       loop={config.loop}
@@ -598,7 +598,7 @@ export default function HeroSection() {
                       <img
                         src={getCloudinaryUrl(config.mobileImageSrc, 'mobile-banner')}
                         alt={config.heading || "Banner"}
-                        className="absolute inset-0 w-full h-full object-cover"
+                        className="block absolute inset-0 w-full h-full object-contain"
                         style={{
                           opacity: bannerVideoEnded ? 1 : 0,
                           transition: "opacity 0.5s ease-in-out",
@@ -613,7 +613,7 @@ export default function HeroSection() {
                       key={`hero-mobile-image-${index}`}
                       src={getCloudinaryUrl(config.mobileImageSrc, 'mobile-banner')}
                       alt={config.heading || "Banner"}
-                      className="block w-full h-full object-cover"
+                      className="block w-full h-auto"
                     />
                   )
                 )}

--- a/src/config/banners/types.ts
+++ b/src/config/banners/types.ts
@@ -14,7 +14,18 @@ export interface BannerConfig {
   backgroundColor?: string;
   textColor?: string;
   enabled: boolean;
+  /**
+   * Natural dimensions of the uploaded banner. Used to reserve aspect-ratio
+   * space (avoids CLS) and let the image render at its real proportion
+   * instead of a fixed height crop.
+   */
+  imageWidth?: number;
+  imageHeight?: number;
+  imageWidthMobile?: number;
+  imageHeightMobile?: number;
+  /** @deprecated Use natural image dimensions; kept for backwards compatibility. */
   height?: string;
+  /** @deprecated Use natural image dimensions; kept for backwards compatibility. */
   heightMobile?: string;
 }
 

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -62,31 +62,28 @@ const TRANSFORM_CONFIGS: Record<ImageTransformType, string> = {
   // Comparación - 400x400, calidad óptima
   comparison: 'f_auto,q_90,c_pad,g_auto,w_400,h_400,b_auto:predominant',
 
-  // Hero/Banner legacy - 1600x800, alta calidad (mantener para compatibilidad)
-  hero: 'f_auto,q_95,c_pad,g_auto,w_1600,h_800,fl_progressive',
+  // Hero/Banner legacy - capado a 1600 de ancho, sin crop (mantener para compatibilidad).
+  // c_limit: NO hace upscale ni crop; baja-escala sólo si el original excede el cap.
+  hero: 'f_auto,q_100,c_limit,w_1600,fl_progressive',
 
-  // Banner Hero/Principal - 1440x810, calidad premium para banners principales
-  // c_fill: Relleno completo evitando espacios vacíos
-  // g_auto: Auto-enfoque en contenido importante
-  'hero-banner': 'f_auto,q_95,c_fill,g_auto,w_1440,h_810,fl_progressive',
+  // Banner Hero/Principal - sirve la imagen en su proporción natural.
+  // c_limit + w_2880: cap retina-friendly para desktops 4K, sin recortar.
+  // Sin g_auto porque ya no recortamos — la composición queda intacta.
+  'hero-banner': 'f_auto,q_100,c_limit,w_2880,fl_progressive',
 
-  // Banner Catálogo HORIZONTAL - 800x600, banners intercalados en grids de productos
-  // Calidad balanceada para múltiples banners por página
-  'catalog-banner': 'f_auto,q_90,c_fill,g_auto,w_800,h_600,fl_progressive',
+  // Banner Catálogo HORIZONTAL - banners intercalados en grids de productos.
+  // Cap 1600 suficiente para la posición que ocupan dentro del grid.
+  'catalog-banner': 'f_auto,q_100,c_limit,w_1600,fl_progressive',
 
-  // Banner VERTICAL - 600x1067 (aspect ratio 9:16), banners verticales tipo stories
-  // c_fit: Mantiene imagen completa sin recortar, escala para caber dentro de las dimensiones
-  // Sin g_auto porque c_fit no necesita gravity
-  'vertical-banner': 'f_auto,q_90,c_fit,w_600,h_1067,fl_progressive',
+  // Banner VERTICAL - banners verticales tipo stories.
+  // c_fit mantiene la imagen completa dentro del cap.
+  'vertical-banner': 'f_auto,q_100,c_limit,w_1200,fl_progressive',
 
-  // Banner Landing - 1210x310px, dimensiones del dashboard
-  // c_fill: Escala y recorta para llenar exactamente 1210x310, enfocando contenido importante
-  // g_auto: Auto-enfoque en contenido importante para recorte inteligente
-  'landing-banner': 'f_auto,q_100,c_pad,w_2520,h_620,fl_progressive',
+  // Banner Landing - cap de 2520 para pantallas anchas.
+  'landing-banner': 'f_auto,q_100,c_limit,w_2520,fl_progressive',
 
-  // Banner Mobile - 414x310px, dimensiones del dashboard
-  // c_fill: Escala y recorta para llenar exactamente las dimensiones móviles
-  'mobile-banner': 'f_auto,q_100,c_pad,w_828,h_620,fl_progressive',
+  // Banner Mobile - cap 1200 para dispositivos con DPR 3x (iPhones de 390dp ~ 1170 reales).
+  'mobile-banner': 'f_auto,q_100,c_limit,w_1200,fl_progressive',
 
   // Original - alta calidad sin transformación de tamaño
   original: 'f_auto,q_95,fl_progressive',


### PR DESCRIPTION
## Summary

Marketing reportó dos problemas con los banners:

1. **Se ven recortados** — Cloudinary aplicaba \`c_fill,g_auto\` a \`hero-banner\`, \`catalog-banner\`, y \`landing\`/\`mobile-banner\` tenían \`c_pad\` forzando aspect ratios fijos.
2. **Se cortan en mobile** — el hero tenía \`h-screen\` + \`object-cover\`, lo que recortaba los lados cuando el aspect del archivo no coincidía con el viewport.

## Cambios

- \`lib/cloudinary.ts\`: los 5 presets de banner (\`hero-banner\`, \`catalog-banner\`, \`landing-banner\`, \`mobile-banner\`, \`vertical-banner\`) pasan de \`c_fill\`/\`c_pad\` a **\`c_limit\`**. Esto capóa el ancho máximo pero NO hace upscale ni crop. Se quita \`g_auto\` (no hace falta sin crop). Se sube \`q\` a 100 en todos.
- \`components/Banner.tsx\`: se reemplaza el \`fill\` + \`object-cover\` + altura fija del contenedor por \`width/height\` explícitos del \`next/image\` con \`w-full h-auto\`. El contenedor ahora crece a lo que pida el aspect ratio del archivo.
- \`components/sections/HeroSection.tsx\`: el wrapper mobile deja de ser \`h-screen\`; se quita \`object-cover\` de las imágenes mobile. Desktop se deja igual (ya era \`w-full h-auto\` en su path normal).
- \`config/banners/types.ts\`: se agregan \`imageWidth/Height(Mobile)\` opcionales para que el admin pueda pasar dimensiones reales. \`height\`/\`heightMobile\` quedan marcados \`@deprecated\` pero se mantienen por retrocompatibilidad.

## Test plan

- [ ] Deploy a preview. Abrir home desktop: hero se ve completo, composición intacta.
- [ ] Emular iPhone SE (aspect angosto) e iPad (aspect ancho) en DevTools — el banner se redimensiona a su aspect natural en ambos, sin cortarse los lados.
- [ ] DevTools Network → URL del banner ya no tiene \`c_fill,g_auto\` sino \`c_limit,q_100\`.
- [ ] Abrir una landing page o catálogo con banner intercalado — renderiza completo.
- [ ] Lighthouse LCP: confirmar que no se degrada > 200ms (q_100 puede pesar algo más que q_95 pero c_limit también reduce cuando el original era mayor al cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)