### PR TITLE
fix(viewpremium): empty gap, fallback images, robust sticky swap

### DIFF
--- a/src/app/productos/viewpremium/[id]/page.tsx
+++ b/src/app/productos/viewpremium/[id]/page.tsx
@@ -324,37 +324,12 @@ export default function ProductViewPage({ params }) {
     (seg) => seg?.toUpperCase() === "PREMIUM"
   );
 
-  // Validar que tenga contenido premium (imagenPremium o videoPremium)
-  // Verificar tanto en apiProduct como en los colores del producto
-  // imagenPremium/videoPremium vienen como string[][] (array de arrays)
-  const checkArrayOfArrays = (arr?: string[][]): boolean => {
-    if (!arr || !Array.isArray(arr)) return false;
-    return arr.some((innerArray: string[]) => {
-      if (!Array.isArray(innerArray) || innerArray.length === 0) return false;
-      return innerArray.some(item => item && typeof item === 'string' && item.trim() !== '');
-    });
-  };
-
-  const hasPremiumContent =
-    // Verificar en apiProduct (imagenPremium/videoPremium o sus alias)
-    checkArrayOfArrays(productToUse.apiProduct?.imagenPremium) ||
-    checkArrayOfArrays(productToUse.apiProduct?.videoPremium) ||
-    checkArrayOfArrays(productToUse.apiProduct?.imagen_premium) ||
-    checkArrayOfArrays(productToUse.apiProduct?.video_premium) ||
-    // Verificar en los colores del producto (imagen_premium/video_premium)
-    // En los colores vienen como string[] (array simple)
-    productToUse.colors?.some(color => {
-      const hasColorImages = color.imagen_premium && Array.isArray(color.imagen_premium) &&
-        color.imagen_premium.length > 0 &&
-        color.imagen_premium.some(img => img && typeof img === 'string' && img.trim() !== '');
-      const hasColorVideos = color.video_premium && Array.isArray(color.video_premium) &&
-        color.video_premium.length > 0 &&
-        color.video_premium.some(vid => vid && typeof vid === 'string' && vid.trim() !== '');
-      return hasColorImages || hasColorVideos;
-    }) || false;
-
-  // Si NO es PREMIUM o NO tiene contenido premium, redirigir a la vista normal
-  if (!isPremiumProduct || !hasPremiumContent) {
+  // Nota: antes redirigíamos a /productos/view cuando el producto no tenía
+  // imagenPremium/videoPremium, pero eso causaba que productos PREMIUM sin
+  // assets premium no mostraran imágenes. Ahora el ProductCarousel cae a las
+  // imágenes del color seleccionado si premiumImages está vacío, así que el
+  // único gate que queda es el segmento PREMIUM del producto.
+  if (!isPremiumProduct) {
     router.replace(`/productos/view/${id}`);
     return <ViewPremiumSkeleton />;
   }
@@ -433,8 +408,11 @@ export default function ProductViewPage({ params }) {
             />
           </div>
 
-          {/* Columna derecha: Información del producto con márgenes normales - SCROLLEABLE */}
-          <div className="lg:col-span-3 px-4 md:px-6 lg:px-12 mt-0 lg:mt-0 lg:min-h-[200vh]">
+          {/* Columna derecha: Información del producto con márgenes normales - SCROLLEABLE.
+              lg:min-h-[120vh]: colchón para que el sticky (lg:sticky lg:top-24) de la
+              columna izquierda tenga recorrido sin generar un gap vacío gigante antes
+              de la sección Flixmedia (antes era 200vh, quedaban 800-1200px en blanco). */}
+          <div className="lg:col-span-3 px-4 md:px-6 lg:px-12 mt-0 lg:mt-0 lg:min-h-[120vh]">
             <div className="max-w-7xl mx-auto">
               <ProductInfo
                 ref={specsRef}

--- a/src/app/productos/viewpremium/components/ProductCarousel.tsx
+++ b/src/app/productos/viewpremium/components/ProductCarousel.tsx
@@ -149,8 +149,14 @@ const ProductCarousel = forwardRef<HTMLDivElement, ProductCarouselProps>(({
     const distance = touchStartX.current - touchEndX.current;
     const minSwipeDistance = 50; // Distancia mínima para considerar un swipe
 
-    // Determinar qué imágenes usar
-    const currentImages = showStickyCarousel ? premiumImages : productImages;
+    // Determinar qué imágenes usar.
+    // Si el carrusel sticky (premium) está activo pero el producto no tiene
+    // contenido premium, caemos a las imágenes del color seleccionado para
+    // que el carrusel nunca quede vacío. Mismo criterio que en el render.
+    const currentImages =
+      showStickyCarousel && premiumImages.length > 0
+        ? premiumImages
+        : productImages;
 
     if (currentImages.length <= 1) return;
 
@@ -174,12 +180,15 @@ const ProductCarousel = forwardRef<HTMLDivElement, ProductCarouselProps>(({
       {/* Carrusel premium - estilo Samsung más grande */}
       <div className={`relative w-full pt-8 md:pt-6 transition-all duration-700 ease-in-out ${showStickyCarousel ? 'opacity-100 scale-100' : 'opacity-0 scale-95 pointer-events-none'}`}>
         {(() => {
-          // Determinar qué imágenes usar según el estado del scroll
-          // Para el carrusel premium, usar SOLO las imágenes del API (sin contenido mockeado)
-          const currentImages = showStickyCarousel
-            ? premiumImages
-            : productImages;
-          const currentImageSet = showStickyCarousel ? 'premium' : 'product';
+          // Determinar qué imágenes usar según el estado del scroll.
+          // Si el producto no tiene contenido premium (allVideos/allImages
+          // vacíos en useProductLogic.getPremiumImages), el carrusel sticky
+          // cae a productImages para que nunca quede vacío.
+          const hasPremium = premiumImages.length > 0;
+          const currentImages =
+            showStickyCarousel && hasPremium ? premiumImages : productImages;
+          const currentImageSet =
+            showStickyCarousel && hasPremium ? 'premium' : 'product';
 
           return currentImages.length > 0 ? (() => {
             const currentSrc = currentImages[currentImageIndex];

--- a/src/app/productos/viewpremium/hooks/useProductLogic.ts
+++ b/src/app/productos/viewpremium/hooks/useProductLogic.ts
@@ -172,23 +172,32 @@ export const useProductLogic = (product: ProductCardProps | null) => {
   const productImages = getProductImages();
   const detailImages = getDetailImages();
 
-  // Detectar scroll para ocultar/mostrar el carrusel sticky
+  // Swap entre carrusel premium (sticky) y carrusel de producto (por color).
+  // Antes se usaba un umbral fijo de 19% del scroll total, lo que era frágil:
+  // en páginas largas caía en medio del bloque de specs; en páginas cortas
+  // disparaba demasiado pronto. Ahora observamos si el bloque ProductInfo
+  // (specsRef) entra en viewport — más robusto y alineado con lo que el
+  // usuario realmente ve.
   React.useEffect(() => {
-    const handleScroll = () => {
-      const scrollY = window.scrollY;
-      const documentHeight = document.documentElement.scrollHeight - window.innerHeight;
-      
-      // Calcular el porcentaje de scroll (0-100)
-      const scrollPercentage = (scrollY / documentHeight) * 100;
-      
-      // Cambiar al segundo carrusel cuando el scroll llegue al 19%
-      const shouldHideCarousel = scrollPercentage > 19;
-      setShowStickyCarousel(!shouldHideCarousel);
-    };
+    const target = specsRef.current;
+    if (!target) return;
 
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    handleScroll(); // Ejecutar una vez al montar
-    return () => window.removeEventListener('scroll', handleScroll);
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        // Mientras ProductInfo esté visible, mostrar el carrusel de producto
+        // (showStickyCarousel = false). Cuando no esté visible (usuario está
+        // arriba, en la zona premium), volver al premium (= true).
+        setShowStickyCarousel(!entry.isIntersecting);
+      },
+      {
+        // rootMargin negativo en top: dispara ANTES de que specs toque el
+        // borde superior, para que el swap ocurra con algo de anticipación.
+        rootMargin: '-20% 0px -30% 0px',
+        threshold: 0,
+      },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
   }, []);
 
   // Resetear índice de imagen cuando cambie el color seleccionado


### PR DESCRIPTION
## Summary

Tres problemas de UX en \`/productos/viewpremium/[id]\` reportados juntos:

1. **Espacio largo antes de características.** La columna derecha tenía \`lg:min-h-[200vh]\` forzando 2× viewport aún cuando el ProductInfo era corto → gap vacío de 800-1200px antes de Flixmedia. Reducido a \`lg:min-h-[120vh]\`.
2. **Imágenes premium no se ven en algunos productos.** Si un producto era PREMIUM pero no tenía \`imagen_premium\`/\`video_premium\` cargados, la página redirigía a \`/view\`. Ahora el carrusel sticky cae a las imágenes del color seleccionado, el usuario se queda en \`/viewpremium\`.
3. **Swap carrusel premium ↔ producto frágil.** Trigger era \`scrollPercentage > 19%\` (dependía del alto total de la página). Reemplazado por \`IntersectionObserver\` sobre \`specsRef\` — swap ocurre cuando el bloque de specs entra en viewport.

## Archivos tocados

- \`src/app/productos/viewpremium/[id]/page.tsx\`:
  - Línea 437: \`lg:min-h-[200vh]\` → \`lg:min-h-[120vh]\`
  - Se elimina el gate \`hasPremiumContent\` + la helper \`checkArrayOfArrays\`; se conserva el gate por segmento PREMIUM.
- \`src/app/productos/viewpremium/components/ProductCarousel.tsx\`: si \`premiumImages\` está vacío → usar \`productImages\` tanto en render como en el handler de swipe.
- \`src/app/productos/viewpremium/hooks/useProductLogic.ts\`: reemplazar listener de scroll por \`IntersectionObserver\` sobre \`specsRef\` con \`rootMargin: '-20% 0px -30% 0px'\`.

## Test plan

- [ ] Producto PREMIUM con abundante premium content (ej. S24 Ultra): sin gap, premium visible, al scroll → swap a imágenes de color.
- [ ] Producto PREMIUM sin premium content: ahora renderiza en \`/viewpremium\` mostrando imágenes del color (antes redirigía a \`/view\`).
- [ ] Producto NO premium: sigue redirigiendo a \`/view\` (segment gate intacto).
- [ ] Medir gap desktop entre \`#comprar-section\` y \`#detalles-section\` con DevTools → ≤ 200px (antes 800-1200px).
- [ ] Scroll progresivo: la transición entre carruseles ocurre cuando las specs entran en viewport, sin estado vacío intermedio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)