### PR TITLE
feat(seo): fetch product SEO override by codigoMarket

### DIFF
--- a/src/app/productos/view/[id]/layout.tsx
+++ b/src/app/productos/view/[id]/layout.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 interface ProductSeoOverride {
-  sku: string;
+  codigoMarket: string;
   meta_title?: string | null;
   meta_description?: string | null;
   meta_keywords?: string | null;
@@ -23,19 +23,20 @@ interface ProductSeoOverride {
 
 /**
  * Fetch per-product SEO overrides from the product_seo side table. Returns
- * null when the product has no overrides (the common case).
+ * null when the product has no overrides (the common case). Keyed by
+ * `codigoMarket` — one row per product group, shared across all variants.
  */
 async function fetchProductSeoOverride(
-  sku: string,
+  codigoMarket: string,
 ): Promise<ProductSeoOverride | null> {
   try {
     const res = await fetch(
-      `${API_URL}/api/products/seo/overrides/${encodeURIComponent(sku)}`,
+      `${API_URL}/api/products/seo/overrides/${encodeURIComponent(codigoMarket)}`,
       { next: { revalidate: 300 } }, // 5 min ISR cache
     );
     if (!res.ok) return null;
     const data = await res.json();
-    if (!data || !data.sku) return null;
+    if (!data || !data.codigoMarket) return null;
     return data as ProductSeoOverride;
   } catch {
     return null;
@@ -45,25 +46,22 @@ async function fetchProductSeoOverride(
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
 
+  // The route param `id` is the product's `codigoMarket` (see
+  // /productos/view/[id]). We fire the override lookup against that key
+  // directly and the product fetch in parallel — no need to wait on the
+  // product to resolve the override key anymore.
+  const [productRes, override] = await Promise.all([
+    fetch(`${API_URL}/api/products/${id}`, { next: { revalidate: 3600 } }),
+    fetchProductSeoOverride(id),
+  ]);
+
   try {
-    const res = await fetch(`${API_URL}/api/products/${id}`, {
-      next: { revalidate: 3600 },
-    });
+    if (!productRes.ok) return {};
 
-    if (!res.ok) return {};
-
-    const data = await res.json();
+    const data = await productRes.json();
     const product = data?.product || data;
 
     if (!product?.nombre) return {};
-
-    // Load per-product SEO overrides (if any) using the product's sku. The
-    // route param is usually codigoMarket, which is different from sku, so
-    // we must wait on the product fetch before we can issue the override
-    // lookup.
-    const override = product.sku
-      ? await fetchProductSeoOverride(product.sku)
-      : null;
 
     // Derived defaults from the catalog data
     const defaultTitle = `${product.nombre}${product.marca ? ` - ${product.marca}` : ""}`;


### PR DESCRIPTION
## Summary

Follow-up a:
- \`Davases22/imagiq-backend#587\` (backend: PK del product_seo pasa de sku a codigoMarket)
- \`Davases22/imagiq-dashboard#182\` (admin UI adaptada al nuevo key)

El layout del detalle de producto ahora pide el override por \`codigoMarket\`, que es exactamente el param \`[id]\` de la ruta \`/productos/view/[id]\`. Antes se serializaba: primero fetch del producto, luego lookup del override por \`product.sku\`. Ahora los dos fetches corren en paralelo (\`Promise.all\`) — el override se pide con \`id\` directamente.

## Cambios

- \`src/app/productos/view/[id]/layout.tsx\`:
  - Type \`ProductSeoOverride.sku\` → \`codigoMarket\`.
  - \`fetchProductSeoOverride(id)\` (param de ruta directamente) en paralelo al fetch del producto.
  - Sanity check del response body: \`!data.codigoMarket\` (antes \`!data.sku\`).

## Orden de deploy

**Mergear DESPUÉS** de los PRs de backend y dashboard:
1. \`imagiq-backend#587\` (backend — migración de schema)
2. \`imagiq-dashboard#182\` (admin UI)
3. **Este PR** — frontend consumidor

## Test plan

- [ ] Admin crea un override SEO para un producto (\`codigoMarket=ABC123\`) con un meta_title custom desde el dashboard.
- [ ] Abrir \`/productos/view/ABC123\` en el storefront → \`view-source:\` muestra el meta_title custom.
- [ ] Probar dos variantes de color del mismo producto (p.ej. querystring ?color=negro vs ?color=blanco): ambos muestran el mismo SEO porque \`generateMetadata\` es de nivel layout y el key del override es el codigoMarket compartido.
- [ ] Producto sin override: el meta_title cae al default derivado del catálogo (\`product.nombre\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)