### PR TITLE
fix(viewpremium): restore color gallery in secondary carousel

### DIFF
--- a/src/app/productos/viewpremium/hooks/useProductLogic.ts
+++ b/src/app/productos/viewpremium/hooks/useProductLogic.ts
@@ -98,21 +98,14 @@ export const useProductLogic = (product: ProductCardProps | null) => {
     return premiumImages;
   };
 
-  // Obtener imágenes del producto del color seleccionado (carrusel secundario)
-  // Usa la imagen preview en lugar de las imágenes detail
-  const getProductImages = () => {
-    if (!product || !selectedColor) return [];
-
-    // Usar la imagen preview del color seleccionado
-    const selectedColorData = product.colors?.find(c => c.name === selectedColor);
-    if (selectedColorData?.imagePreviewUrl) {
-      return [selectedColorData.imagePreviewUrl];
-    }
-
-    return [];
-  };
-
-  // Obtener imágenes detail para el modal "Ver más"
+  // Galería completa del color seleccionado: varias fotos del producto en
+  // distintos ángulos/posiciones. Fuente de verdad para el carrusel
+  // secundario y el modal "Ver más".
+  //
+  // Cascade de resolución:
+  //   1. imageDetailsUrls[variantIndex] (array de arrays del API)
+  //   2. imageDetailsUrls plano + filtro por nombre del color en la URL
+  //   3. imagePreviewUrl del color como último recurso
   const getDetailImages = () => {
     if (!product || !selectedColor) return [];
 
@@ -167,6 +160,20 @@ export const useProductLogic = (product: ProductCardProps | null) => {
 
     return [];
   };
+
+  // Imágenes para el carrusel secundario (el que muestra el teléfono en el
+  // color seleccionado).
+  //
+  // Histórico: entre may-2025 y oct-2025 esta función devolvía la galería
+  // completa del color — varios ángulos/posiciones. El commit e319c4f5
+  // (2025-10-23) la restringió a `[imagePreviewUrl]` y movió la galería
+  // completa a `getDetailImages()`, que solo se usaba en el modal "Ver más".
+  // Eso dejó el carrusel secundario con una sola foto por color, regresión
+  // reportada por negocio.
+  //
+  // Ahora el carrusel y el modal comparten la misma fuente — lo cual tiene
+  // sentido semántico: el modal es el mismo contenido en grande.
+  const getProductImages = getDetailImages;
 
   const premiumImages = getPremiumImages();
   const productImages = getProductImages();


### PR DESCRIPTION
## Summary

En \`/productos/viewpremium/[id]\` el carrusel secundario (el que aparece cuando se scrollea y muestra el teléfono en el color seleccionado) solo estaba mostrando **una** imagen por color. Antes mostraba la galería completa — el teléfono en varias posiciones/ángulos. Reportado por negocio.

## Causa raíz

Commit **\`e319c4f5\` del 23-oct-2025** (\"modificacion seccion y añadir sku stock\") restringió \`getProductImages()\` en \`useProductLogic.ts\` a devolver \`[imagePreviewUrl]\` y movió la cascada completa (imageDetailsUrls por variant index → filtro por nombre del color en URL → preview como último recurso) a una nueva función \`getDetailImages()\` que solo alimentaba el modal \"Ver más\". El carrusel secundario consume \`productImages\`, así que silenciosamente colapsó a 1 imagen por color.

## Fix

\`const getProductImages = getDetailImages\` — ambas superficies (carrusel secundario y modal \"Ver más\") comparten ahora la misma fuente color-específica. \`getDetailImages\` ya cae a \`imagePreviewUrl\` cuando no hay detail images, así que ningún producto queda peor que hoy.

Se reordena para declarar \`getDetailImages\` primero (claridad; no había riesgo de TDZ porque ambas se invocan tras las declaraciones).

## Test plan

- [ ] Deploy a preview. Abrir \`/productos/viewpremium/<codigoMarket>\` para un premium con varios colores (ej. Galaxy Z Fold 7).
- [ ] Scrollear hasta que el carrusel swapee al \"carrusel de producto\". Pasar por varias imágenes con los botones flecha / swipe.
- [ ] Cambiar el color seleccionado: la galería se actualiza con las fotos del nuevo color.
- [ ] Abrir modal \"Ver más\": mismas imágenes que el carrusel (consistencia).
- [ ] Producto sin \`imageDetailsUrls\` poblado: el carrusel cae al \`imagePreviewUrl\` del color (no queda en blanco).

🤖 Generated with [Claude Code](https://claude.com/claude-code)