### PR TITLE
feat(soporte): collect missing customer phone in payment modal

### DIFF
--- a/src/app/soporte/inicio_de_soporte/page.tsx
+++ b/src/app/soporte/inicio_de_soporte/page.tsx
@@ -96,6 +96,8 @@ export default function InicioDeSoportePage() {
   const [isProcessingPayment, setIsProcessingPayment] = useState(false);
   const [submittedCedula, setSubmittedCedula] = useState<string | null>(null);
   const [submittedOrder, setSubmittedOrder] = useState<string | null>(null);
+  const [userMovil, setUserMovil] = useState("");
+  const [movilError, setMovilError] = useState<string | null>(null);
   const { pay } = usePaySupportTicket();
   const { logout, user } = useAuthContext();
   const router = useRouter();
@@ -155,6 +157,20 @@ export default function InicioDeSoportePage() {
 
   // Silent user ensure state (invisible to user)
   const [ensuredUserId, setEnsuredUserId] = useState<string | null>(null);
+
+  // ePayco PSE rejects "0", empty or non-Colombian-mobile phones with E006
+  // ("Teléfono o Celular Requerido"). Treat anything that isn't a 10-digit
+  // number starting with 3 as missing and ask the customer to provide it.
+  const isValidColombianMobile = (s: string | null | undefined): boolean => {
+    if (!s) return false;
+    return /^3\d{9}$/.test(s.replace(/\D/g, ""));
+  };
+  const soapMovil =
+    result?.obtenerDocumentosResult?.documentos?.[0]?.movil || "";
+  const needsMovilInput = !isValidColombianMobile(soapMovil);
+  const effectiveMovil = needsMovilInput
+    ? userMovil.replace(/\D/g, "")
+    : soapMovil.replace(/\D/g, "");
 
   // Read support verification results from query params (status, orderId)
   const searchParams = useSearchParams();
@@ -348,7 +364,6 @@ export default function InicioDeSoportePage() {
 
     const missingFields: string[] = [];
     if (!doc.email?.trim()) missingFields.push("email");
-    if (!doc.movil?.trim()) missingFields.push("teléfono");
     if (!doc.estadoCodigo?.trim()) missingFields.push("estado del documento");
     if (!doc.cliente?.trim()) missingFields.push("nombre del cliente");
     if (!cedulaDigits) missingFields.push("documento de identidad");
@@ -360,6 +375,12 @@ export default function InicioDeSoportePage() {
       );
       return;
     }
+
+    if (!isValidColombianMobile(effectiveMovil)) {
+      setMovilError("Ingresa un celular colombiano válido (10 dígitos, empieza por 3).");
+      return;
+    }
+    setMovilError(null);
 
     setIsProcessingPayment(true);
 
@@ -419,7 +440,7 @@ export default function InicioDeSoportePage() {
         usuario_email: (doc.email || "").toLowerCase().trim(),
         nombre_cliente: doc.cliente || "",
         concepto: doc.concepto || "Pago soporte",
-        movil_usuario: doc.movil || "",
+        movil_usuario: effectiveMovil,
         medio_pago: paymentMethod === "tarjeta" ? 2 : 3,
         documento_usuario: cedulaDigits,
         tipo_documento: tipo_documento,
@@ -514,6 +535,8 @@ export default function InicioDeSoportePage() {
     setSelectedBank("");
     resetCardForm();
     setEnsuredUserId(null);
+    setUserMovil("");
+    setMovilError(null);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -622,6 +645,7 @@ export default function InicioDeSoportePage() {
     if (!submittedCedula) return false;
     // Also require that a orden was submitted
     if (!submittedOrder) return false;
+    if (!isValidColombianMobile(effectiveMovil)) return false;
     if (paymentMethod === "pse" && !selectedBank) return false;
     if (paymentMethod === "tarjeta") {
       // Verificar que todos los campos de tarjeta estén completos
@@ -1110,6 +1134,41 @@ export default function InicioDeSoportePage() {
                   </span>
                 </div>
               </div>
+
+              {/* Captura de celular cuando el SOAP no trae uno válido (PSE/CC requieren celular) */}
+              {needsMovilInput && (
+                <div className="mb-4">
+                  <label
+                    htmlFor="user-movil"
+                    className="block text-xs font-medium text-gray-700 mb-1"
+                  >
+                    Celular de contacto
+                  </label>
+                  <input
+                    id="user-movil"
+                    type="tel"
+                    inputMode="numeric"
+                    autoComplete="tel"
+                    value={userMovil}
+                    onChange={(e) => {
+                      const digits = e.target.value.replace(/\D/g, "").slice(0, 10);
+                      setUserMovil(digits);
+                      if (movilError) setMovilError(null);
+                    }}
+                    placeholder="3001234567"
+                    className={cn(
+                      "w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-black focus:border-transparent text-sm",
+                      movilError ? "border-red-500" : "border-gray-300"
+                    )}
+                  />
+                  <p className="text-[11px] text-gray-500 mt-1">
+                    No tenemos tu celular registrado. Lo necesitamos para procesar el pago.
+                  </p>
+                  {movilError && (
+                    <p className="text-red-500 text-xs mt-0.5">{movilError}</p>
+                  )}
+                </div>
+              )}
 
               {/* Opciones de pago */}
               <div className="space-y-2 mb-4">


### PR DESCRIPTION
## Summary
When VirtualMedios SOAP returns \`movil=\"0\"\` (dirty data for some support customers), the payment modal sent \"0\" verbatim to the backend → ePayco rejected with **E006 \"Teléfono o Celular Requerido\"**. Customer Cristian retried 14× over 25 min; 4 guest users have been silently hitting this since March.

This PR:
- Adds \`isValidColombianMobile()\` helper (10 digits, starts with 3).
- Renders a \"Celular de contacto\" input in the payment-method modal step **only when** the SOAP-returned phone is invalid.
- Blocks \"Pagar\" until the effective mobile is valid (SOAP or user-typed).
- Sends a normalized digit-only \`movil_usuario\` in the payload.
- Removes the prior blocking \`alert()\` when the SOAP didn't bring a phone — customer can fix it inline now.

## Companion
imagiq-backend PR #592 fixes the upstream PSE branch (which was reading \`usuario.telefono\` instead of the request payload) and heals the stored \`usuarios.telefono\` row when the request brings a valid phone.

## Test plan
- [ ] Submit a support order whose SOAP doc has \`movil=\"0\"\` (or empty) → modal renders the input, \"Pagar\" is disabled until a valid 10-digit cell starting with 3 is entered.
- [ ] Submit a support order with a valid SOAP \`movil\` → no input shown, payment proceeds as before.
- [ ] Type an invalid number (e.g. starts with 2, less than 10 digits) → inline error shown, button stays disabled.
- [ ] Close + reopen the modal → input state resets cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)