### PR TITLE
feat(soporte): bank selector + celular input on a single row

### DIFF
--- a/src/app/soporte/inicio_de_soporte/page.tsx
+++ b/src/app/soporte/inicio_de_soporte/page.tsx
@@ -1461,12 +1461,24 @@ export default function InicioDeSoportePage() {
                     />
                   </label>
 
-                  {/* Selector de banco */}
+                </div>
+              </div>
+
+              {/* Banco + Celular en la misma fila cuando ambos aplican.
+                  Queda justo arriba del botón "Pagar" para que el cliente vea
+                  juntos los dos campos pendientes antes de actuar. */}
+              {(paymentMethod === "pse" || needsMovilInput) && (
+                <div className={cn(
+                  "mb-3",
+                  paymentMethod === "pse" && needsMovilInput
+                    ? "flex flex-row gap-3"
+                    : ""
+                )}>
                   {paymentMethod === "pse" && (
-                    <div className="mt-2 ml-7">
+                    <div className="flex-1 min-w-0">
                       <label
                         htmlFor="bank-select"
-                        className="block text-xs font-medium text-gray-700 mb-1"
+                        className="block text-sm font-semibold text-gray-800 mb-1.5"
                       >
                         Selecciona tu banco
                       </label>
@@ -1476,7 +1488,7 @@ export default function InicioDeSoportePage() {
                           value={selectedBank}
                           onChange={(e) => setSelectedBank(e.target.value)}
                           disabled={isLoadingBanks}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-black focus:border-black bg-white appearance-none cursor-pointer text-sm"
+                          className="w-full px-3 py-2 border border-gray-400 rounded-lg focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent bg-white appearance-none cursor-pointer text-sm"
                         >
                           <option value="">
                             {isLoadingBanks
@@ -1493,42 +1505,38 @@ export default function InicioDeSoportePage() {
                       </div>
                     </div>
                   )}
-                </div>
-              </div>
-
-              {/* Captura de celular cuando el SOAP no trae uno válido (PSE/CC requieren celular).
-                  Posicionado justo arriba del botón "Pagar" para que el cliente lo vea
-                  inmediatamente cuando esté listo a pagar. */}
-              {needsMovilInput && (
-                <div className="mb-3">
-                  <label
-                    htmlFor="user-movil"
-                    className="block text-sm font-semibold text-gray-800 mb-1.5"
-                  >
-                    Celular de contacto
-                  </label>
-                  <input
-                    id="user-movil"
-                    type="tel"
-                    inputMode="numeric"
-                    autoComplete="tel"
-                    value={userMovil}
-                    onChange={(e) => {
-                      const digits = e.target.value.replace(/\D/g, "").slice(0, 10);
-                      setUserMovil(digits);
-                      if (movilError) setMovilError(null);
-                    }}
-                    placeholder="3001234567"
-                    className={cn(
-                      "w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-black focus:border-transparent text-sm",
-                      movilError ? "border-red-500" : "border-gray-400"
-                    )}
-                  />
-                  <p className="text-xs text-gray-500 mt-1">
-                    No tenemos tu celular registrado. Lo necesitamos para procesar el pago.
-                  </p>
-                  {movilError && (
-                    <p className="text-red-500 text-xs mt-0.5">{movilError}</p>
+                  {needsMovilInput && (
+                    <div className="flex-1 min-w-0">
+                      <label
+                        htmlFor="user-movil"
+                        className="block text-sm font-semibold text-gray-800 mb-1.5"
+                      >
+                        Celular de contacto
+                      </label>
+                      <input
+                        id="user-movil"
+                        type="tel"
+                        inputMode="numeric"
+                        autoComplete="tel"
+                        value={userMovil}
+                        onChange={(e) => {
+                          const digits = e.target.value.replace(/\D/g, "").slice(0, 10);
+                          setUserMovil(digits);
+                          if (movilError) setMovilError(null);
+                        }}
+                        placeholder="3001234567"
+                        className={cn(
+                          "w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-black focus:border-transparent text-sm",
+                          movilError ? "border-red-500" : "border-gray-400"
+                        )}
+                      />
+                      <p className="text-xs text-gray-500 mt-1">
+                        No tenemos tu celular registrado. Lo necesitamos para procesar el pago.
+                      </p>
+                      {movilError && (
+                        <p className="text-red-500 text-xs mt-0.5">{movilError}</p>
+                      )}
+                    </div>
                   )}
                 </div>
               )}


### PR DESCRIPTION
Collapses the bank dropdown and the celular input into a single row that sits right above \"Pagar\". Previously they were stacked in two separate sections, eating vertical space and making the form feel longer than it is.

## Layout matrix

| Method  | Movil needed? | Row layout              |
|---------|---------------|-------------------------|
| PSE     | yes           | **bank \| celular** (50/50, both viewports) |
| PSE     | no            | bank alone, full width |
| Tarjeta | yes           | celular alone, full width |
| Tarjeta | no            | (row not rendered)     |

The flex row is \`flex-row gap-3\` on both mobile and desktop — even at 412px viewport each column gets ~176px which fits both \"BANCO AV VILLAS\" and the 10-digit phone placeholder.

## Also
- Bank label \`text-xs font-medium text-gray-700\` → \`text-sm font-semibold text-gray-800\` to match the celular field.
- Bank select border \`border-gray-300\` → \`border-gray-400\` for visual consistency.
- Removed the bank-specific \`mt-2 ml-7\` indent (no longer nested under the PSE radio).

## Test plan
- [ ] Mobile (412px) + PSE selected + missing phone: bank and celular sit side by side, each ~50% width, both readable.
- [ ] Desktop + PSE + missing phone: same — bank | celular row, equal widths.
- [ ] Desktop + PSE + valid SOAP phone: bank alone, full width.
- [ ] Desktop + Tarjeta + missing phone: celular alone, full width above Pagar.
- [ ] Switching between PSE and Tarjeta with the radio: row morphs correctly each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)