### PR TITLE
fix(navbar): clean up Servicio Técnico submenu visual style

### DIFF
--- a/src/components/dropdowns/servicio_tecnico/ServicioTecnicoDropdownDesktop.tsx
+++ b/src/components/dropdowns/servicio_tecnico/ServicioTecnicoDropdownDesktop.tsx
@@ -11,7 +11,7 @@ export default function ServicioTecnicoDropdownDesktop({ onItemClick }: Props) {
   return (
     <div className="bg-white shadow-lg rounded-b-lg border-t border-gray-200">
       <div className="max-w-7xl mx-auto px-8 py-6">
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-2">
           {SERVICIO_TECNICO_MENU_ITEMS.map((item) => {
             const IconComponent = item.icon;
 
@@ -20,20 +20,19 @@ export default function ServicioTecnicoDropdownDesktop({ onItemClick }: Props) {
                 key={item.title}
                 href={item.href}
                 onClick={() => onItemClick(item.title, item.href)}
-                className="block text-left w-full"
+                className="flex items-start gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors group"
               >
-                <div className="flex items-start gap-4 p-4 rounded-lg hover:bg-gray-50 transition-colors group">
-                  <div className="flex-shrink-0 w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center group-hover:bg-gray-200 transition-colors">
-                    <IconComponent className="w-6 h-6 text-gray-700" />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="text-sm font-semibold text-gray-900 group-hover:text-black transition-colors">
-                      {item.title}
-                    </h3>
-                    <p className="text-xs text-gray-600 mt-1 line-clamp-2">
-                      {item.description}
-                    </p>
-                  </div>
+                <IconComponent
+                  className="flex-shrink-0 w-5 h-5 text-gray-500 mt-0.5 group-hover:text-black transition-colors"
+                  strokeWidth={1.75}
+                />
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm font-medium text-gray-900 group-hover:text-black transition-colors">
+                    {item.title}
+                  </h3>
+                  <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">
+                    {item.description}
+                  </p>
                 </div>
               </Link>
             );

--- a/src/components/dropdowns/servicio_tecnico/ServicioTecnicoDropdownMobile.tsx
+++ b/src/components/dropdowns/servicio_tecnico/ServicioTecnicoDropdownMobile.tsx
@@ -9,35 +9,35 @@ type Props = {
 
 export default function ServicioTecnicoDropdownMobile({ onItemClick }: Props) {
   return (
-    <div className="bg-gray-50 px-4 py-3">
-      <div className="space-y-2">
+    <div className="px-2 py-1">
+      <ul className="divide-y divide-gray-100">
         {SERVICIO_TECNICO_MENU_ITEMS.map((item) => {
           const IconComponent = item.icon;
 
           return (
-            <Link
-              key={item.title}
-              href={item.href}
-              onClick={() => onItemClick(item.title, item.href)}
-              className="block text-left w-full"
-            >
-              <div className="flex items-center gap-3 p-3 bg-white rounded-lg hover:bg-gray-100 transition-colors active:bg-gray-200">
-                <div className="flex-shrink-0 w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center">
-                  <IconComponent className="w-5 h-5 text-gray-700" />
-                </div>
+            <li key={item.title}>
+              <Link
+                href={item.href}
+                onClick={() => onItemClick(item.title, item.href)}
+                className="flex items-center gap-3 px-2 py-3 rounded-md hover:bg-gray-50 active:bg-gray-100 transition-colors"
+              >
+                <IconComponent
+                  className="flex-shrink-0 w-5 h-5 text-gray-500"
+                  strokeWidth={1.75}
+                />
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-sm font-semibold text-gray-900">
+                  <h3 className="text-sm font-medium text-gray-900">
                     {item.title}
                   </h3>
-                  <p className="text-xs text-gray-600 mt-0.5 line-clamp-1">
+                  <p className="text-xs text-gray-500 mt-0.5 line-clamp-1">
                     {item.description}
                   </p>
                 </div>
-              </div>
-            </Link>
+              </Link>
+            </li>
           );
         })}
-      </div>
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removed the gray rounded square (`bg-gray-100`) behind each icon in both the mobile and desktop **Servicio Técnico** submenus — it gave the items a default/AI-generated look that didn't match the rest of the navbar.
- Removed the gray section background (`bg-gray-50`) and the redundant white card wrapper from the mobile submenu. Items now sit directly on the menu's white surface, separated by hairline dividers.
- Same flat treatment applied to the desktop megamenu for visual consistency.
- Icons rendered with `strokeWidth={1.75}` and a softer gray to fit a cleaner aesthetic; titles use `font-medium` instead of `font-semibold`.

## Before / After
The "before" mobile layout had three nested gray surfaces (section bg → white card → gray icon box) which made the submenu stand out from the rest of the menu items. After: clean rows with just an icon, title and description.

## Test plan
- [ ] Open mobile menu on home, expand **Servicio Técnico** — verify there are no gray boxes around icons and no gray tinted background behind the items.
- [ ] Tap each item — verify the link navigates correctly (`/soporte/inicio_de_soporte`, `/tiendas`, `/soporte/whatsapp`) and the active state is visible on tap.
- [ ] Hover the desktop megamenu **Servicio Técnico** — verify icons no longer sit on a gray square and hover state still highlights the row.
- [ ] Verify on multiple phone widths (320, 375, 390, 414, 430 px) that the title/description don't overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)