### PR TITLE
fix(banners): match mobile container aspect to image to stop edge crop

### DIFF
--- a/src/components/banners/DynamicBannerClean.tsx
+++ b/src/components/banners/DynamicBannerClean.tsx
@@ -542,7 +542,7 @@ export default function DynamicBannerClean({
 
   const content = (
     <div className={`relative w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-8 ${className}`}>
-      <div className="relative w-full min-h-[580px] md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden">
+      <div className="relative w-full aspect-[1080/1400] md:aspect-auto md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden">
         {showOverlay && <div className="absolute inset-0 bg-black/30 z-10" />}
 
         {/* Todos los banners en posición absoluta con transición fade + slide */}


### PR DESCRIPTION
## Summary
Verified live with Playwright on a Galaxy S20 viewport (360×800): the title \"Galaxy S26 Ultra | Buds4 Pro\" baked into the home-2 banner image was being cropped at the right edge because the mobile container has `min-h-[580px]` with `object-cover`, but the image is 1080×1400 (aspect 0.771).

**Math:**
- Container: 332×580 → aspect 0.572
- Image natural: 1080×1400 → aspect 0.771
- `object-cover` scales image to fill height (580) → image becomes 447px wide → (447−332)/2 = **57.5px cropped from each side**

That ate the \"o\" in \"Pro\" on the S20 and any text near the horizontal edges of the source image.

## Fix
Switch the mobile container from `min-h-[580px]` to `aspect-[1080/1400]` so its height follows the image's natural aspect. On a 360px viewport the container becomes 332×430 and the image fits exactly with no cropping. Desktop unchanged (`md:aspect-auto md:min-h-[500px] lg:min-h-[800px]`).

## Verified
- ✅ S20 (360×800): home-2 banners now render at 332×430, container aspect 0.771 = image aspect 0.771, **no cropping**.
- ✅ iPhone 14 Pro Max (430×932): containers 402×521, also matched, no cropping.
- ✅ Desktop 1440×900: containers 1384×800 (lg breakpoint preserved), unchanged.

## Known follow-up (CMS, not code)
Banners that have HTML `content_blocks` overlays (description text + CTA) had their `position.y` calibrated assuming a 580px-tall container. With the new 430px height, those overlays land ~26% higher relative to the image. On the S26 Ultra banner that produces a small (~7px) overlap between the description and the \"Galaxy AI+\" subtitle baked into the image. CMS authors may want to nudge `position_mobile.y` down a bit on affected banners. The cropping fix takes priority — the previous behavior cut text out of the design entirely.

## Test plan
- [ ] Verify home-2 / home-3 / home-4 mobile banners are no longer cropped at narrow widths (320, 360, 375, 414, 430).
- [ ] Verify desktop megamenus / hero look identical to current production at ≥768px.
- [ ] Spot-check banners with content_blocks overlays — flag any layout that needs CMS reposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)