### PR TITLE
fix(banners): anchor mobile image at top to remove content_block overlap

### DIFF
--- a/src/components/banners/DynamicBannerClean.tsx
+++ b/src/components/banners/DynamicBannerClean.tsx
@@ -542,7 +542,7 @@ export default function DynamicBannerClean({
 
   const content = (
     <div className={`relative w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-8 ${className}`}>
-      <div className="relative w-full aspect-[1080/1400] md:aspect-auto md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden">
+      <div className="relative w-full min-h-[580px] md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden bg-white">
         {showOverlay && <div className="absolute inset-0 bg-black/30 z-10" />}
 
         {/* Todos los banners en posición absoluta con transición fade + slide */}
@@ -618,7 +618,7 @@ export default function DynamicBannerClean({
                 playsInline
                 preload="metadata"
                 poster={optimizedMobilePoster}
-                className="w-full h-full object-cover"
+                className="w-full h-full object-contain object-top md:object-cover"
                 onEnded={isActive ? controller.handleVideoEnd : undefined}
                 key={`mobile-video-${banner.id}-${index}`}
               >
@@ -633,7 +633,7 @@ export default function DynamicBannerClean({
               <img
                 src={optimizedMobileImageUrl}
                 alt={banner.name || 'Banner'}
-                className="w-full h-full object-cover"
+                className="w-full h-full object-contain object-top md:object-cover"
                 key={`mobile-image-${banner.id}-${index}`}
               />
             );


### PR DESCRIPTION
## Summary
PR #964 (`aspect-[1080/1400]`) eliminated horizontal cropping on mobile banners but as a side effect shrunk the container from 580px to ~430px on a 360px viewport. CMS-positioned `content_blocks` (description text + CTAs) were authored for the 580px height, so on the new shorter container they land 20–30px higher than intended and overlap with text baked into the image — most visibly the description \"Estrena hoy con 0% de interés…\" overlapping the \"Galaxy AI+\" subtitle on the **Galaxy S26 Ultra | Buds4 Pro** home-2 banner.

## What changed
- Restore `min-h-[580px]` on the mobile container so `content_blocks` land where the CMS author placed them.
- Switch the mobile `<img>` and `<video>` to `object-contain object-top md:object-cover` — the image fits its natural aspect at the **top** of the container without cropping, and the ~150px gap below becomes a clean `bg-white` letterbox that sits behind any low-positioned content_blocks (CTAs).
- Desktop (`md:` / `lg:`) keeps `object-cover` and the same heights — **unchanged**.

## Verified live with Playwright at 360×800 (Galaxy S20)
- ✅ Title \"Galaxy S26 Ultra | Buds4 Pro\" fully visible — no horizontal crop.
- ✅ Description sits cleanly below the \"Galaxy AI+\" image subtitle — no overlap.
- ✅ CTA \"Compra ahora\" visible.
- ✅ Bottom of the image meets the white letterbox; CTAs in the lower part of the container land in that area cleanly (matches the existing \"Inteligencia Asombrosa / Nuevos Galaxy A57 | A37\" layout pattern).

## Why not just adjust the CMS positions
That works but requires manual repositioning of every banner that has both image-baked subtitles and CTAs/descriptions overlaid. This code change makes the layout robust against the existing CMS data so authors don't need to redo positions.

## Note
The **Hero** (HeroSection.tsx) is a separate component using `h-screen` and is not affected by this change. If the hero shows similar overlap on narrow phones it can be fixed in a follow-up — the current PR addresses the home-2/3/4 dynamic banners which were the source of the user-visible bug.

## Test plan
- [ ] Verify home-2 / home-3 / home-4 mobile banners across 320, 360, 375, 414, 430 px — title fully visible, no overlap between content_block descriptions and image subtitles.
- [ ] Verify desktop megamenus / banners look identical to current production at ≥768px.
- [ ] Confirm white letterbox below the image isn't visually jarring against the surrounding page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)