### PR TITLE
fix(banners): match dashboard preview aspect (21/29) with object-cover

### DIFF
--- a/src/components/banners/DynamicBannerClean.tsx
+++ b/src/components/banners/DynamicBannerClean.tsx
@@ -542,7 +542,7 @@ export default function DynamicBannerClean({
 
   const content = (
     <div className={`relative w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-8 ${className}`}>
-      <div className="relative w-full min-h-[580px] md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden bg-white">
+      <div className="relative w-full aspect-[21/29] md:aspect-auto md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden">
         {showOverlay && <div className="absolute inset-0 bg-black/30 z-10" />}
 
         {/* Todos los banners en posición absoluta con transición fade + slide */}
@@ -618,7 +618,7 @@ export default function DynamicBannerClean({
                 playsInline
                 preload="metadata"
                 poster={optimizedMobilePoster}
-                className="w-full h-full object-contain object-top md:object-cover"
+                className="w-full h-full object-cover"
                 onEnded={isActive ? controller.handleVideoEnd : undefined}
                 key={`mobile-video-${banner.id}-${index}`}
               >
@@ -633,7 +633,7 @@ export default function DynamicBannerClean({
               <img
                 src={optimizedMobileImageUrl}
                 alt={banner.name || 'Banner'}
-                className="w-full h-full object-contain object-top md:object-cover"
+                className="w-full h-full object-cover"
                 key={`mobile-image-${banner.id}-${index}`}
               />
             );


### PR DESCRIPTION
## Summary
PR #966 stopped horizontal cropping on home-* mobile banners but rendered the image with `object-contain` inside a `min-h-[580px]` container, producing a white letterbox below the image. The user reported the banner looked vertically squished and **didn't match the CMS dashboard preview**.

## Root cause
The CMS dashboard preview component (`imagiq-dashboard` → `src/components/banners/preview/banner-preview.tsx:117`) renders home-* placements with **`aspect-[21/29] max-w-[420px] object-cover`**. The frontend was diverging from that.

## Fix
Match the dashboard exactly:
- Container: `aspect-[21/29] md:aspect-auto md:min-h-[500px] lg:min-h-[800px]` — the 21/29 ratio is the canonical 580/420 (original min-h × max-w of the dashboard preview).
- Mobile image/video: revert to `object-cover` so the image fills the container as in the preview.
- Drop the `bg-white` letterbox — no longer needed.

Desktop is unchanged.

## Why this works
- **Container aspect = image-friendly**: 21/29 ≈ 0.724, image natural is 1080/1400 ≈ 0.771 → object-cover crops only ~10–13px each side at any mobile width. Old behavior was cropping ~58px on a 360px viewport because the container was `min-h-[580px]` (aspect 0.572 at 332 wide).
- **Frontend ≡ Dashboard**: same aspect, same `object-cover`, so what the CMS author sees while positioning content_blocks is what ships.
- **No letterbox**: image fills the container.

## Verified live with Playwright (env pointed at prod API)
- ✅ 412×915 (Galaxy S20 Ultra): container 384×530, ~12px crop each side, title \"Galaxy S26 Ultra | Buds4 Pro\" fully visible, description + CTA correctly placed.
- ✅ 360×800 (Galaxy S20): container 332×458, ~10px crop each side, title fully visible.

## Caveat
On the **narrowest viewports** (≤360px) the description's first line still grazes the \"Galaxy AI+\" subtitle baked into the image (~15px overlap). The image text scales linearly with viewport width while HTML text uses `clamp()` with a floor — so on very narrow screens the HTML text takes proportionally more space. This can be improved further in a follow-up by either nudging the CMS `position_mobile.y` down a couple of percent on the affected banners, or by tightening the `fluidFontSize` floor. Not addressed here to keep the diff minimal and the dashboard match exact.

## Test plan
- [ ] Verify home-2 / home-3 / home-4 mobile banners match the dashboard preview at 320, 360, 412, 430 px.
- [ ] Verify desktop banners look identical to current production at ≥768px.
- [ ] Spot-check S26 Ultra | Buds4 Pro banner at 360px — title fully visible, no major overlap with content_blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)