### PR TITLE
fix(banners): reserve safe padding so mobile CTAs clear the chat widget

### DIFF
--- a/src/components/banners/DynamicBannerClean.tsx
+++ b/src/components/banners/DynamicBannerClean.tsx
@@ -669,7 +669,7 @@ export default function DynamicBannerClean({
                 {bannerMobileMedia}
               </div>
 
-              <div className="absolute inset-0 z-20">
+              <div className="absolute inset-0 z-20 pl-3 pr-16 md:p-0">
                 {hasContentBlocks ? (
                   <>
                     {!forceMobileView && <ContentBlocksOverlay blocks={contentBlocks} isMobile={false} bannerLinkUrl={banner.link_url} />}


### PR DESCRIPTION
## Summary
On mobile (412×915 Samsung S20 Ultra) the home-* banner CTA \"¡Compra Galaxy A37!\" was being covered by the floating chat avatar in the bottom-right of the viewport — looked like the button text was cut off (\"Galaxy A3\"). The dashboard preview doesn't render the chat widget, so the CMS author can't see the conflict while authoring positions.

## Fix
Add `pl-3 pr-16 md:p-0` to the absolute content_blocks wrapper inside DynamicBanner. On mobile this reserves ~12px on the left and ~64px on the right of the banner area — enough to keep CTAs clear of the standard fixed bottom-right chat widget. Desktop is unchanged.

## Verified live with Playwright
- ✅ **A57|A37 slide at 412×915**: both \"¡Compra Galaxy A57!\" and \"¡Compra Galaxy A37!\" fully visible, no clipping. Avatar bubble sits below the banner without covering either button.
- ✅ **S26 Ultra | Buds4 Pro slide**: title + AI+ + description + CTA all visible, no overlap with chat avatar.

## Why padding (option B) over moving the chat widget (option A)
Padding is local to the banner — predictable, zero risk to other floating UI elements (cookie banner, error toasts, etc). Moving the chat widget would require auditing every other UI surface that floats over the page.

## Caveat
This shifts content_blocks ~30–32px to the left on mobile, so the banner won't look pixel-identical to the dashboard preview anymore (the dashboard doesn't simulate the chat widget zone). Acceptable tradeoff to ship — long-term the dashboard preview should also reserve the chat-widget safe area so authors can position around it.

## Test plan
- [ ] Verify home-2 / home-3 / home-4 mobile banners — CTAs and avatar widget don't overlap at 320, 360, 412, 430 px.
- [ ] Verify desktop (≥768px) renders identical to current production.
- [ ] Spot-check slides with multiple CTAs (A57|A37 dual CTA layout) — both visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)