### PR TITLE
refactor(banners): container queries (cqi) + product grids 2-col on tablet

### DIFF
--- a/src/components/banners/DynamicBannerClean.tsx
+++ b/src/components/banners/DynamicBannerClean.tsx
@@ -226,9 +226,11 @@ function ContentBlocksOverlay({
         }
 
         // Estilos del título: usar mobile si existe, sino desktop
+        // fluidFontSize con `cqi` escala con el ancho del @container/banner
+        // (referencia: 420px mobile preview / 1440px desktop max-w del frontend)
         const rawTitleSize = block.title && ((isMobile && block.title_mobile?.fontSize) || block.title.fontSize || '2rem');
         const titleStyles = block.title && {
-          fontSize: isMobile ? fluidFontSize(rawTitleSize) : rawTitleSize,
+          fontSize: isMobile ? fluidFontSize(rawTitleSize, 420) : fluidFontSize(rawTitleSize, 1440, 0.5),
           fontWeight: (isMobile && block.title_mobile?.fontWeight) || block.title.fontWeight || '700',
           color: (isMobile && block.title_mobile?.color) || block.title.color || '#ffffff',
           lineHeight: (isMobile && block.title_mobile?.lineHeight) || block.title.lineHeight || '1.2',
@@ -278,7 +280,7 @@ function ContentBlocksOverlay({
               {block.subtitle && (() => {
                 const rawSubtitleSize = (isMobile && block.subtitle_mobile?.fontSize) || block.subtitle.fontSize || '1.5rem';
                 const subtitleStyles = {
-                  fontSize: isMobile ? fluidFontSize(rawSubtitleSize) : rawSubtitleSize,
+                  fontSize: isMobile ? fluidFontSize(rawSubtitleSize, 420) : fluidFontSize(rawSubtitleSize, 1440, 0.5),
                   fontWeight: (isMobile && block.subtitle_mobile?.fontWeight) || block.subtitle.fontWeight || '600',
                   color: (isMobile && block.subtitle_mobile?.color) || block.subtitle.color || '#ffffff',
                   lineHeight: (isMobile && block.subtitle_mobile?.lineHeight) || block.subtitle.lineHeight || '1.3',
@@ -302,7 +304,7 @@ function ContentBlocksOverlay({
               {block.description && (() => {
                 const rawDescSize = (isMobile && block.description_mobile?.fontSize) || block.description.fontSize || '1rem';
                 const descriptionStyles = {
-                  fontSize: isMobile ? fluidFontSize(rawDescSize) : rawDescSize,
+                  fontSize: isMobile ? fluidFontSize(rawDescSize, 420) : fluidFontSize(rawDescSize, 1440, 0.5),
                   fontWeight: (isMobile && block.description_mobile?.fontWeight) || block.description.fontWeight || '400',
                   color: (isMobile && block.description_mobile?.color) || block.description.color || '#ffffff',
                   lineHeight: (isMobile && block.description_mobile?.lineHeight) || block.description.lineHeight || '1.5',
@@ -327,11 +329,11 @@ function ContentBlocksOverlay({
                 const rawCtaSize = (isMobile && block.cta_mobile?.fontSize) || block.cta.fontSize || '1rem';
                 const rawCtaPadding = (isMobile && block.cta_mobile?.padding) || block.cta.padding || '12px 24px';
                 const ctaStyles = {
-                  fontSize: isMobile ? fluidFontSize(rawCtaSize) : rawCtaSize,
+                  fontSize: isMobile ? fluidFontSize(rawCtaSize, 420) : fluidFontSize(rawCtaSize, 1440, 0.5),
                   fontWeight: (isMobile && block.cta_mobile?.fontWeight) || block.cta.fontWeight || '600',
                   backgroundColor: (isMobile && block.cta_mobile?.backgroundColor) || block.cta.backgroundColor || '#ffffff',
                   color: (isMobile && block.cta_mobile?.color) || block.cta.color || '#000000',
-                  padding: isMobile ? fluidPadding(rawCtaPadding) : rawCtaPadding,
+                  padding: isMobile ? fluidPadding(rawCtaPadding, 420) : fluidPadding(rawCtaPadding, 1440, 0.5),
                   borderRadius: (isMobile && block.cta_mobile?.borderRadius) || block.cta.borderRadius || '8px',
                   border: (isMobile && block.cta_mobile?.border) || block.cta.border || 'none',
                   textTransform: (isMobile && block.cta_mobile?.textTransform) || block.cta.textTransform || 'none',
@@ -542,7 +544,7 @@ export default function DynamicBannerClean({
 
   const content = (
     <div className={`relative w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-8 ${className}`}>
-      <div className="relative w-full aspect-[21/29] md:aspect-auto md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden">
+      <div className="relative w-full aspect-[21/29] md:aspect-auto md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden @container/banner">
         {showOverlay && <div className="absolute inset-0 bg-black/30 z-10" />}
 
         {/* Todos los banners en posición absoluta con transición fade + slide */}

--- a/src/components/sections/AppliancesProductsGrid.tsx
+++ b/src/components/sections/AppliancesProductsGrid.tsx
@@ -108,7 +108,7 @@ export default function AppliancesProductsGrid({ initialProducts }: AppliancesPr
     return (
       <section className="w-full flex justify-center bg-white pt-[25px] pb-0">
         <div className="w-full" style={{ maxWidth: "1440px" }}>
-          <div className="hidden md:grid md:grid-cols-4 gap-[25px]">
+          <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-[25px]">
             {Array.from({ length: 4 }, (_, i) => (
               <div key={`skeleton-${i}`} className="w-full">
                 <SkeletonCard />
@@ -140,7 +140,7 @@ export default function AppliancesProductsGrid({ initialProducts }: AppliancesPr
   return (
     <section className="w-full flex justify-center bg-white pt-[25px] pb-0">
       <div className="w-full" style={{ maxWidth: "1440px" }}>
-        <div className="hidden md:grid md:grid-cols-4 gap-[25px]">
+        <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-[25px]">
           {allProducts.map((product) => (
             <ProductCard
               key={product.id}

--- a/src/components/sections/ProductShowcase.tsx
+++ b/src/components/sections/ProductShowcase.tsx
@@ -135,7 +135,7 @@ export default function ProductShowcase({ initialProducts }: ProductShowcaseProp
       <section className="w-full flex justify-center bg-white pt-[25px] pb-0">
         <div className="w-full" style={{ maxWidth: "1440px" }}>
           {/* Desktop: Grid 4 columnas */}
-          <div className="hidden md:grid md:grid-cols-4 gap-[25px]">
+          <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-[25px]">
             {[...Array(4)].map((_, i) => (
               <div key={i} className="w-full">
                 <SkeletonCard />
@@ -166,7 +166,7 @@ export default function ProductShowcase({ initialProducts }: ProductShowcaseProp
     <section className="w-full flex justify-center bg-white pt-[25px] pb-0">
       <div className="w-full" style={{ maxWidth: "1440px" }}>
         {/* Desktop: Grid 4 columnas */}
-        <div className="hidden md:grid md:grid-cols-4 gap-[25px]">
+        <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-[25px]">
           {products.map((product) => (
             <ProductCard
               key={product.id}

--- a/src/components/sections/TVProductsGrid.tsx
+++ b/src/components/sections/TVProductsGrid.tsx
@@ -108,7 +108,7 @@ export default function TVProductsGrid({ initialProducts }: TVProductsGridProps 
     return (
       <section className="w-full flex justify-center bg-white pt-[25px] pb-0">
         <div className="w-full" style={{ maxWidth: "1440px" }}>
-          <div className="hidden md:grid md:grid-cols-4 gap-[25px]">
+          <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-[25px]">
             {Array.from({ length: 4 }, (_, i) => (
               <div key={`skeleton-${i}`} className="w-full">
                 <SkeletonCard />
@@ -137,7 +137,7 @@ export default function TVProductsGrid({ initialProducts }: TVProductsGridProps 
   return (
     <section className="w-full flex justify-center bg-white pt-[25px] pb-0">
       <div className="w-full" style={{ maxWidth: "1440px" }}>
-        <div className="hidden md:grid md:grid-cols-4 gap-[25px]">
+        <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-[25px]">
           {tvProducts.map((product) => (
             <ProductCard
               key={product.id}

--- a/src/components/sections/TVProductsGrid/index.tsx
+++ b/src/components/sections/TVProductsGrid/index.tsx
@@ -35,7 +35,7 @@ export default function TVProductsGrid() {
       <div className="w-full bg-white pt-8 pb-0">
         <div className="w-full mx-auto" style={{ maxWidth: "1440px" }}>
           {/* Desktop: Grid 4 columnas */}
-          <div className="hidden md:grid md:grid-cols-4 gap-[25px]">
+          <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-[25px]">
             {Array.from({ length: 4 }, (_, i) => (
               <div key={`skeleton-${i}`} className="w-full">
                 <SkeletonCard />
@@ -70,7 +70,7 @@ export default function TVProductsGrid() {
     <div className="w-full bg-white pt-8 pb-0">
       <div className="w-full mx-auto" style={{ maxWidth: "1440px" }}>
         {/* Desktop: Grid 4 columnas */}
-        <div className="hidden md:grid md:grid-cols-4 gap-[25px]">
+        <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-[25px]">
           {displayProducts.map((product) => (
             <ProductCard
               key={product.id}

--- a/src/utils/bannerCoordinates.ts
+++ b/src/utils/bannerCoordinates.ts
@@ -105,25 +105,29 @@ export function parseTextStyles(textStylesJson: string | null | undefined): Bann
 
 /**
  * Convierte un valor de fontSize/padding (px, rem, em) a una expresión `clamp()`
- * que escala con el ancho del viewport.
+ * que escala proporcionalmente con el ancho del **contenedor** (`cqi`) o del
+ * **viewport** (`vw`).
  *
- * Diseñado para textos de banners cuyo `fontSize` viene fijo del CMS y se
- * desbordan en pantallas estrechas (ej. Galaxy S20 a 360px) sin hacerse más
- * grandes que el diseño en pantallas anchas (ej. iPhone 14 Pro Max a 430px).
+ * Para banners conviene `cqi`: el padre se marca con `@container/banner` y todo
+ * dentro escala con el ancho del banner — así el render en producción y en el
+ * preview del dashboard coincide cuando ambos contenedores tienen el mismo
+ * ancho, y escala proporcionalmente cuando difieren.
  *
- * - `designVwPx` = ancho de viewport para el cual el valor original es el "natural".
- *   Por defecto 420px: a partir de 420px de viewport, el texto ya no crece.
- * - `minRatio`   = cota inferior como fracción del valor original (default 0.55).
+ * - `designPx` = ancho de referencia para el cual el valor original es el "natural".
+ *   Para mobile: 420px (max-w del preview del dashboard). Para desktop: 1440px.
+ * - `minRatio` = cota inferior como fracción del valor original (default 0.55).
+ * - `unit`     = `'cqi'` (recomendado, container-relative) o `'vw'` (legacy).
  *
  * @example
- * fluidFontSize("32px") // "clamp(17.60px, 7.62vw, 32.00px)"
- * fluidFontSize("2rem") // "clamp(17.60px, 7.62vw, 32.00px)"
+ * fluidFontSize("32px") // "clamp(17.60px, 7.62cqi, 32.00px)"  (cqi por defecto)
+ * fluidFontSize("32px", 420, 0.55, 12, 'vw') // "clamp(17.60px, 7.62vw, 32.00px)"
  */
 export function fluidFontSize(
   value: string | number | undefined | null,
-  designVwPx = 420,
+  designPx = 420,
   minRatio = 0.55,
   minPx = 12,
+  unit: 'cqi' | 'vw' = 'cqi',
 ): string | undefined {
   if (value === null || value === undefined || value === '') return undefined;
   const raw = typeof value === 'number' ? `${value}px` : String(value).trim();
@@ -132,32 +136,32 @@ export function fluidFontSize(
   if (!match) return raw;
 
   const num = parseFloat(match[1]);
-  const unit = match[2] || 'px';
+  const sizeUnit = match[2] || 'px';
   if (!Number.isFinite(num) || num <= 0) return raw;
 
-  const px = unit === 'px' ? num : num * 16;
-  const vw = (px / designVwPx) * 100;
+  const px = sizeUnit === 'px' ? num : num * 16;
+  const ratio = (px / designPx) * 100;
   const min = Math.max(px * minRatio, minPx);
 
   if (min >= px) return `${px.toFixed(2)}px`;
 
-  return `clamp(${min.toFixed(2)}px, ${vw.toFixed(2)}vw, ${px.toFixed(2)}px)`;
+  return `clamp(${min.toFixed(2)}px, ${ratio.toFixed(2)}${unit}, ${px.toFixed(2)}px)`;
 }
 
 /**
  * Aplica `fluidFontSize` a cada valor numérico (px/rem/em) dentro de una cadena
- * de padding tipo `"12px 24px"`. Útil para CTAs cuyo padding viene del CMS y
- * podría apretar el botón contra el borde en celulares pequeños.
+ * de padding tipo `"12px 24px"`.
  */
 export function fluidPadding(
   value: string | undefined | null,
-  designVwPx = 420,
+  designPx = 420,
   minRatio = 0.6,
+  unit: 'cqi' | 'vw' = 'cqi',
 ): string | undefined {
   if (!value) return undefined;
   return value
     .trim()
     .split(/\s+/)
-    .map((part) => fluidFontSize(part, designVwPx, minRatio, 4) ?? part)
+    .map((part) => fluidFontSize(part, designPx, minRatio, 4, unit) ?? part)
     .join(' ');
 }


### PR DESCRIPTION
## Why
After 4 PRs of patches (#962, #964, #966, #968, #970) the banner code was diverging from the dashboard preview and accumulating ad-hoc fixes (`pl-3 pr-16` chat-widget reservation, `aspect-[1080/1400]` aspect-fit, `object-[center_top]`). The user pushed back: \"piensa por más tiempo, hagamos las cosas bien\". Research turned up that the right architectural answer is **container queries** — banners should size their content from the *container* width, not the viewport.

## What changed

### Banner refactor (`DynamicBannerClean.tsx` + `bannerCoordinates.ts`)
- Banner inner div is now `@container/banner` (Tailwind v4 native).
- `fluidFontSize()` and `fluidPadding()` take a `unit: 'cqi' | 'vw'` parameter — defaults to `cqi` so font/padding scale with the *banner* width, not the viewport.
- Mobile content_blocks: `designPx=420` (matches dashboard mobile preview).
- Desktop content_blocks: `designPx=1440` with `minRatio=0.5` floor (shrinks to ~50% at md/tablet so they don't overflow at 768px instead of staying at literal 60px and breaking).
- Removed the `pl-3 pr-16 md:p-0` chat-widget reservation patch — divergence from dashboard preview wasn't worth it. Author should reposition CTAs that conflict with the chat widget at narrow viewports.

### Product grids (4 showcase components)
`md:grid-cols-4` → `md:grid-cols-2 lg:grid-cols-4`. At iPad mini (768px) cards now show in 2 columns at usable size, instead of being crammed into 4 columns of ~173px each (illegible).

## Why container queries (cqi) over viewport units (vw)
1. **Same component, different containers**: a banner placed in a sidebar would scale correctly. With `vw` it would always size to the viewport regardless of how wide its actual container is.
2. **Dashboard / production parity**: the dashboard preview renders the banner at e.g. 420px. With `vw`, fontSize at 420px-preview would still be calculated against the user's full-screen viewport. With `cqi`, the preview shows what production actually shows at the same container width.
3. **Tailwind v4 native** — no plugin, no migration cost.

## Companion PR
**`imagiq-dashboard`** ships an updated banner preview that uses the same `cqi` logic + adds a viewport-width selector (320 / 360 / 390 / 412 / 430). With both PRs merged, dashboard preview at preset 360 = production at 360 viewport, pixel-for-pixel.

## Test plan
- [ ] 320 / 360 / 412 / 768 / 1024 / 1440 banners look proportionally consistent (font scales with container, no overflow).
- [ ] Product cards readable on iPad mini (2 cols) and full at lg+ (4 cols).
- [ ] Desktop ≥1024px renders identical to current production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)