### PR TITLE
feat(analytics): currency fixes + full checkout funnel + unique events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "lodash": "^4.17.21",
         "lodash.debounce": "^4.0.8",
         "lucide-react": "^0.535.0",
-        "next": "^16.0.7",
+        "next": "16.0.10",
         "next-themes": "^0.4.6",
         "pdfjs-dist": "^5.4.449",
         "posthog-js": "^1.318.2",
@@ -230,25 +230,25 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@16.0.7", "", {}, "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw=="],
+    "@next/env": ["@next/env@16.0.10", "", {}, "sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.4.3", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-wYYbP29uZlm9lqD1C6HDgW9WNNt6AlTogYKYpDyATs0QrKYIv/rPueoIDRH6qttXGCe3zNrb7hxfQx4w8OSkLA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.0.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LlDtCYOEj/rfSnEn/Idi+j1QKHxY9BJFmxx7108A6D8K0SB+bNgfYQATPk/4LqOl4C0Wo3LACg2ie6s7xqMpJg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.0.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.0.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.0.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.0.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.0.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.0.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.0.10", "", { "os": "linux", "cpu": "x64" }, "sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.0.7", "", { "os": "linux", "cpu": "x64" }, "sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.0.10", "", { "os": "linux", "cpu": "x64" }, "sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.0.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.0.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.0.7", "", { "os": "win32", "cpu": "x64" }, "sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.0.10", "", { "os": "win32", "cpu": "x64" }, "sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1172,7 +1172,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "next": ["next@16.0.7", "", { "dependencies": { "@next/env": "16.0.7", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.0.7", "@next/swc-darwin-x64": "16.0.7", "@next/swc-linux-arm64-gnu": "16.0.7", "@next/swc-linux-arm64-musl": "16.0.7", "@next/swc-linux-x64-gnu": "16.0.7", "@next/swc-linux-x64-musl": "16.0.7", "@next/swc-win32-arm64-msvc": "16.0.7", "@next/swc-win32-x64-msvc": "16.0.7", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A=="],
+    "next": ["next@16.0.10", "", { "dependencies": { "@next/env": "16.0.10", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.0.10", "@next/swc-darwin-x64": "16.0.10", "@next/swc-linux-arm64-gnu": "16.0.10", "@next/swc-linux-arm64-musl": "16.0.10", "@next/swc-linux-x64-gnu": "16.0.10", "@next/swc-linux-x64-musl": "16.0.10", "@next/swc-win32-arm64-msvc": "16.0.10", "@next/swc-win32-x64-msvc": "16.0.10", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 

--- a/src/app/carrito/Step2.tsx
+++ b/src/app/carrito/Step2.tsx
@@ -21,7 +21,8 @@ import {
   getTradeInValidationMessage,
 } from "./utils/validateTradeIn";
 import { toast } from "sonner";
-import { associateEmailWithSession, identifyEmailEarly } from "@/lib/posthogClient";
+import { associateEmailWithSession, identifyEmailEarly, posthogUtils } from "@/lib/posthogClient";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -119,6 +120,9 @@ export default function Step2({
 
   // Estado para verificar si ya se registró como invitado
   const [isRegisteredAsGuest, setIsRegisteredAsGuest] = useState(false);
+
+  // Analytics: garantiza un único evento CheckoutStep2 por avance del paso 2
+  const step2TrackedRef = useRef(false);
 
   // Estados para el flujo OTP
   const [guestStep, setGuestStep] = useState<'form' | 'otp' | 'verified'>('form');
@@ -749,6 +753,22 @@ export default function Step2({
     }
   }, [cartProducts]);
 
+  // Analytics: Step2 NO tiene AddPaymentInfo — solo tracking de progreso (una vez)
+  const trackStep2Completed = () => {
+    if (step2TrackedRef.current) return;
+    step2TrackedRef.current = true;
+    const userType = isRegisteredAsGuest ? "guest" : "registered";
+    fbqTrackCustom("CheckoutStep2_UserData", {
+      user_type: userType,
+      step: 2,
+      currency: "COP",
+    });
+    posthogUtils.capture("checkout_step2_completed", {
+      user_type: userType,
+      step: 2,
+    });
+  };
+
   // Wrapper function to handle both form validation and continue action
   const handleContinue = async () => {
     // Validar Trade-In antes de continuar
@@ -762,6 +782,7 @@ export default function Step2({
     // Esto cubre tanto usuarios invitados como regulares que agregaron dirección
     if (hasAddedAddress && typeof onContinue === "function") {
       // console.log("✅ [STEP2 handleContinue] Usuario con dirección agregada, avanzando a Step3");
+      trackStep2Completed();
       onContinue();
       return;
     }
@@ -1314,6 +1335,7 @@ export default function Step2({
         setHasAddedAddress(true);
         setIsSavingAddress(false);
         if (typeof onContinue === "function") {
+          trackStep2Completed();
           onContinue();
         }
         return;
@@ -1429,6 +1451,7 @@ export default function Step2({
 
       if (typeof onContinue === "function") {
         // console.log("✅ Avanzando automáticamente a Step3");
+        trackStep2Completed();
         onContinue();
       } else {
         console.warn("⚠️ No se puede avanzar - onContinue no es una función");
@@ -1446,6 +1469,7 @@ export default function Step2({
       setHasAddedAddress(true);
       setIsSavingAddress(false);
       if (typeof onContinue === "function") {
+        trackStep2Completed();
         onContinue();
       }
     }

--- a/src/app/carrito/Step3.tsx
+++ b/src/app/carrito/Step3.tsx
@@ -12,7 +12,8 @@ import {
 import Step4OrderSummary from "./components/Step4OrderSummary";
 import TradeInCompletedSummary from "@/app/productos/dispositivos-moviles/detalles-producto/estreno-y-entrego/TradeInCompletedSummary";
 import type { Address } from "@/types/address";
-import { useAnalyticsWithUser } from "@/lib/analytics";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
+import { posthogUtils } from "@/lib/posthogClient";
 import { tradeInEndpoints } from "@/lib/api";
 import { validateTradeInProducts, getTradeInValidationMessage } from "./utils/validateTradeIn";
 import { useTradeInVerification } from "@/hooks/useTradeInVerification";
@@ -35,7 +36,6 @@ export default function Step3({
 }) {
   const router = useRouter();
   const { products, calculations } = useCart();
-  const { trackAddPaymentInfo } = useAnalyticsWithUser();
   const { user, login } = useAuthContext();
   const { selectedAddress, selectAddress } = useCheckoutAddress();
 
@@ -1028,22 +1028,24 @@ export default function Step3({
         }
       }
 
-      // Track del evento add_payment_info para analytics
-      trackAddPaymentInfo(
-        products.map((p) => ({
-          item_id: p.sku,
-          item_name: p.name,
-          price: Number(p.price),
-          quantity: p.quantity,
-        })),
-        calculations.subtotal
-      );
+      // Correcto: aquí el usuario confirma ENVÍO, no ingresa datos de pago
+      fbqTrackCustom('SelectDeliveryMethod', {
+        delivery_method: deliveryMethod || 'domicilio',
+        step: 3,
+        value: calculations.subtotal,
+        currency: 'COP',
+      });
+      posthogUtils.capture('checkout_step3_delivery_selected', {
+        delivery_method: deliveryMethod || 'domicilio',
+        value: calculations.subtotal,
+        step: 3,
+      });
 
       if (typeof onContinue === "function") {
         onContinue();
       }
     }
-  }, [isWaitingForCanPickUp, storesLoading, products, deliveryMethod, calculations.subtotal, onContinue, trackAddPaymentInfo]);
+  }, [isWaitingForCanPickUp, storesLoading, products, deliveryMethod, calculations.subtotal, onContinue]);
 
   // UX: Navegación al siguiente paso
   // Estado para validación de Trade-In
@@ -1129,16 +1131,18 @@ export default function Step3({
       }
     }
 
-    // Track del evento add_payment_info para analytics
-    trackAddPaymentInfo(
-      products.map((p) => ({
-        item_id: p.sku,
-        item_name: p.name,
-        price: Number(p.price),
-        quantity: p.quantity,
-      })),
-      calculations.subtotal
-    );
+    // Correcto: aquí el usuario confirma ENVÍO, no ingresa datos de pago
+    fbqTrackCustom('SelectDeliveryMethod', {
+      delivery_method: deliveryMethod || 'domicilio',
+      step: 3,
+      value: calculations.subtotal,
+      currency: 'COP',
+    });
+    posthogUtils.capture('checkout_step3_delivery_selected', {
+      delivery_method: deliveryMethod || 'domicilio',
+      value: calculations.subtotal,
+      step: 3,
+    });
 
     if (typeof onContinue === "function") {
       onContinue();

--- a/src/app/carrito/Step4.tsx
+++ b/src/app/carrito/Step4.tsx
@@ -16,6 +16,8 @@ import {
 import { toast } from "sonner";
 import useSecureStorage from "@/hooks/useSecureStorage";
 import { User } from "@/types/user";
+import { fbqTrackCustom, fbqAddPaymentInfo } from "@/lib/meta-pixel";
+import { posthogUtils } from "@/lib/posthogClient";
 
 export default function Step4({
   onBack,
@@ -26,7 +28,7 @@ export default function Step4({
 }) {
   const router = useRouter();
   const authContext = useAuthContext();
-  const { products } = useCart();
+  const { products, calculations } = useCart();
   const {
     isProcessing,
     paymentMethod,
@@ -336,6 +338,42 @@ export default function Step4({
     setIsValidatingCard(false); // Reset here in case validation failed or we are just moving on
     if (isValid && onContinue) {
       // console.log("💳 [Step4] isValid is true, calling onContinue()");
+      const cartValue = calculations?.total || calculations?.subtotal || 0;
+
+      // AddPaymentInfo REAL — aquí sí el usuario está en el paso de pago
+      fbqAddPaymentInfo({
+        value: cartValue,
+        currency: "COP",
+        content_ids: products?.map((p) => p.sku || p.id) || [],
+      });
+
+      fbqTrackCustom("SelectPaymentMethod", {
+        payment_method: paymentMethod,
+        step: 4,
+        value: cartValue,
+        currency: "COP",
+        is_saved_card: !!selectedCardId && !useNewCard,
+      });
+
+      if (paymentMethod === "addi") {
+        fbqTrackCustom("ADDIFinancingSelected", { value: cartValue, currency: "COP" });
+      }
+
+      if (paymentMethod === "pse" && selectedBank) {
+        fbqTrackCustom("PSEBankSelected", {
+          bank: selectedBank,
+          value: cartValue,
+          currency: "COP",
+        });
+      }
+
+      posthogUtils.capture("checkout_step4_payment_method_selected", {
+        payment_method: paymentMethod,
+        is_saved_card: !!selectedCardId && !useNewCard,
+        step: 4,
+        value: cartValue,
+      });
+
       onContinue();
     } else {
       console.warn("💳 [Step4] Validation failed or onContinue missing", { isValid, hasOnContinue: !!onContinue });

--- a/src/app/carrito/Step5.tsx
+++ b/src/app/carrito/Step5.tsx
@@ -9,6 +9,8 @@ import { toast } from "sonner";
 import { CheckZeroInterestResponse } from "./types";
 import { DBCard } from "@/features/profile/types";
 import CardBrandLogo from "@/components/ui/CardBrandLogo";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
+import { posthogUtils } from "@/lib/posthogClient";
 
 interface Step5Props {
   onBack?: () => void;
@@ -295,6 +297,31 @@ export default function Step5({ onBack, onContinue }: Step5Props) {
 
     // Guardar cuotas seleccionadas en localStorage
     localStorage.setItem("checkout-installments", selectedInstallments.toString());
+
+    const hasZeroInterest =
+      selectedInstallments !== null &&
+      selectedInstallments > 1 &&
+      isInstallmentEligibleForZeroInterest(selectedInstallments);
+
+    fbqTrackCustom("InstallmentsSelected", {
+      installments: selectedInstallments || 1,
+      zero_interest: hasZeroInterest,
+      currency: "COP",
+      step: 5,
+    });
+
+    if (hasZeroInterest && selectedInstallments && selectedInstallments > 1) {
+      fbqTrackCustom("CeroInteresActivated", {
+        installments: selectedInstallments,
+        currency: "COP",
+      });
+    }
+
+    posthogUtils.capture("checkout_step5_installments_selected", {
+      installments: selectedInstallments || 1,
+      zero_interest: hasZeroInterest,
+      step: 5,
+    });
 
     if (onContinue) {
       onContinue();

--- a/src/app/carrito/Step6.tsx
+++ b/src/app/carrito/Step6.tsx
@@ -13,7 +13,8 @@ import AddNewAddressForm from "./components/AddNewAddressForm";
 import { MapPin, Plus, Check, Trash2 } from "lucide-react";
 import { safeGetLocalStorage } from "@/lib/localStorage";
 import { useCart } from "@/hooks/useCart";
-import { associateEmailWithSession, identifyEmailEarly } from "@/lib/posthogClient";
+import { associateEmailWithSession, identifyEmailEarly, posthogUtils } from "@/lib/posthogClient";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
 import { validateTradeInProducts, getTradeInValidationMessage } from "./utils/validateTradeIn";
 import { toast } from "sonner";
 
@@ -594,6 +595,27 @@ export default function Step6({ onBack, onContinue }: Step6Props) {
       if (billingToSave.email) {
         associateEmailWithSession(billingToSave.email, {
           $name: billingToSave.nombre,
+        });
+      }
+
+      fbqTrackCustom("BillingTypeSelected", {
+        billing_type: billingType,
+        is_b2b: billingType === "juridica",
+        step: 6,
+        currency: "COP",
+      });
+
+      posthogUtils.capture("checkout_step6_billing_selected", {
+        billing_type: billingType,
+        is_b2b: billingType === "juridica",
+        step: 6,
+        $set: { billing_type_preference: billingType },
+      });
+
+      if (billingType === "juridica") {
+        fbqTrackCustom("B2BCheckoutStarted", { step: 6, currency: "COP" });
+        posthogUtils.capture("b2b_checkout_started", {
+          $set: { is_b2b_checkout: true },
         });
       }
 

--- a/src/app/carrito/Step7.tsx
+++ b/src/app/carrito/Step7.tsx
@@ -34,6 +34,8 @@ import { productEndpoints, deliveryEndpoints, tradeInEndpoints } from "@/lib/api
 import useSecureStorage from "@/hooks/useSecureStorage";
 import { User } from "@/types/user";
 import RegisterGuestPasswordModal from "./components/RegisterGuestPasswordModal";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
+import { posthogUtils } from "@/lib/posthogClient";
 
 declare global {
   interface Window {
@@ -1191,6 +1193,15 @@ export default function Step7({ onBack }: Step7Props) {
           (data.MessageType === "profile.completed" && data.Status === false)
         ) {
           console.error("❌ [Step7] 3DS Fallido/Rechazado:", data);
+          fbqTrackCustom("ThreeDSFailed", {
+            value: calculations?.total || 0,
+            currency: "COP",
+            reason: "auth_failed",
+          });
+          posthogUtils.capture("three_ds_failed", {
+            value: calculations?.total || 0,
+            reason: "auth_failed",
+          });
           toast.error("La autenticación 3D Secure falló. Por favor intenta con otro medio de pago.");
           localStorage.removeItem('pending_order_id');
           setIsProcessing(false);
@@ -1248,6 +1259,19 @@ export default function Step7({ onBack }: Step7Props) {
         }, 100); // Verificar cada 100ms
       });
     }
+
+    const reviewTotal = calculations?.total || 0;
+    fbqTrackCustom("CheckoutReviewCompleted", {
+      value: reviewTotal,
+      currency: "COP",
+      step: 7,
+      payment_method: paymentData?.method || "unknown",
+    });
+    posthogUtils.capture("checkout_step7_pay_clicked", {
+      value: reviewTotal,
+      payment_method: paymentData?.method || "unknown",
+      step: 7,
+    });
 
     setIsProcessing(true);
     let waiting3DS = false;
@@ -1649,6 +1673,16 @@ export default function Step7({ onBack }: Step7Props) {
               // console.log("📦 RESPUESTA COMPLETA DEL BACKEND:", JSON.stringify(res, null, 2));
 
               const data3DS = res.data3DS as { resultCode?: string; ref_payco?: number; franquicia?: string; '3DS'?: { success: boolean; data: unknown } };
+
+              fbqTrackCustom("ThreeDSStarted", {
+                value: calculations?.total || 0,
+                currency: "COP",
+                franchise: data3DS?.franquicia || "unknown",
+              });
+              posthogUtils.capture("three_ds_started", {
+                value: calculations?.total || 0,
+                franchise: data3DS?.franquicia || "unknown",
+              });
 
               // Guardar orderId para verificación posterior
               const orderId = res.orderId || "";

--- a/src/app/carrito/components/CouponInput.tsx
+++ b/src/app/carrito/components/CouponInput.tsx
@@ -2,6 +2,8 @@
 import React, { useState } from "react";
 import { apiPost } from "@/lib/api-client";
 import type { CartProduct, CouponRequirements } from "@/hooks/useCart";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
+import { posthogUtils } from "@/lib/posthogClient";
 
 interface CouponValidationResponse {
   couponCode: string;
@@ -47,6 +49,18 @@ export default function CouponInput({
         eligibleIdentifiers: result.eligibleIdentifiers || [],
         requiredCompanionIdentifiers: result.requiredCompanionIdentifiers || [],
       });
+
+      fbqTrackCustom("CouponApplied", {
+        coupon_code: result.couponCode,
+        discount_amount: result.discountAmount || 0,
+        currency: "COP",
+      });
+      posthogUtils.capture("coupon_applied", {
+        coupon_code: result.couponCode,
+        discount_amount: result.discountAmount || 0,
+        currency: "COP",
+      });
+
       setCode("");
       setError(null);
       setIsOpen(false);

--- a/src/app/error-checkout/page.tsx
+++ b/src/app/error-checkout/page.tsx
@@ -16,6 +16,8 @@ import { useCardsCache } from "@/app/carrito/hooks/useCardsCache";
 import CardBrandLogo from "@/components/ui/CardBrandLogo";
 import pseLogo from "@/img/iconos/logo-pse.png";
 import addiLogo from "@/img/iconos/addi_negro.png";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
+import { posthogUtils } from "@/lib/posthogClient";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -105,6 +107,30 @@ function ErrorCheckoutContent() {
       titleRef.current.focus();
     }
   }, [mounted]);
+
+  // Analytics: un evento por rechazo de pago (solo al montar)
+  useEffect(() => {
+    fbqTrackCustom("PaymentRejected", {
+      error_code: rawCode || "unknown",
+      error_category: errorInfo.category,
+      can_retry: errorInfo.canRetry,
+      currency: "COP",
+    });
+
+    posthogUtils.capture("payment_rejected", {
+      error_code: rawCode || "unknown",
+      error_category: errorInfo.category,
+      error_title: errorInfo.title,
+      can_retry: errorInfo.canRetry,
+      primary_action: errorInfo.primaryCta.action,
+      currency: "COP",
+      $set: {
+        last_payment_rejection_code: rawCode || "unknown",
+        last_payment_rejection_category: errorInfo.category,
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function handleAction(action: string) {
     switch (action as CtaAction) {

--- a/src/app/productos/[categoria]/page.tsx
+++ b/src/app/productos/[categoria]/page.tsx
@@ -10,6 +10,7 @@
 import { useEffect, Suspense, use, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { posthogUtils } from "@/lib/posthogClient";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
 import { useDeviceType } from "@/components/responsive";
 import { useCurrentMenu } from "@/hooks/useCurrentMenu";
 import { useVisibleCategories } from "@/hooks/useVisibleCategories";
@@ -78,6 +79,10 @@ function CategoriaPageContent({ categoria }: CategoriaPageContentProps) {
         categoria: dynamicCategory.nombre,
         section: activeSection,
         device,
+      });
+      fbqTrackCustom("ViewItemList", {
+        content_category: dynamicCategory.nombre,
+        currency: "COP",
       });
     }
   }, [dynamicCategory, activeSection, device]);

--- a/src/app/productos/components/ProductCard.tsx
+++ b/src/app/productos/components/ProductCard.tsx
@@ -20,6 +20,7 @@ import { Heart, Loader } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { posthogUtils } from "@/lib/posthogClient";
 import { useAnalytics } from "@/lib/analytics/hooks/useAnalytics";
+import { fbqAddToWishlist } from "@/lib/meta-pixel";
 import { useCloudinaryImage } from "@/hooks/useCloudinaryImage";
 import { useProductSelection, type ActiveFilterHints } from "@/hooks/useProductSelection";
 import { useChatbot } from "@/contexts/ChatbotContext";
@@ -434,6 +435,18 @@ export default function ProductCard({
       product_name: name,
       action: isFavorite ? "remove" : "add",
     });
+
+    // Meta AddToWishlist solo cuando se AGREGA (isFavorite refleja el estado previo al click)
+    const willBeAdded = !isFavorite;
+    if (willBeAdded) {
+      fbqAddToWishlist({
+        content_name: name,
+        content_ids: [currentSku || id],
+        content_category: apiProduct?.categoria || "Samsung",
+        value: currentPrice || 0,
+        currency: "COP",
+      });
+    }
   };
 
   const handleRequestStockNotification = async (email: string) => {

--- a/src/app/productos/dispositivos-moviles/detalles-producto/estreno-y-entrego/TradeInModal.tsx
+++ b/src/app/productos/dispositivos-moviles/detalles-producto/estreno-y-entrego/TradeInModal.tsx
@@ -14,6 +14,8 @@ import { useTradeInDataFromCache } from "@/hooks/useTradeInPrefetch";
 import { useTradeInValue } from "./hooks/useTradeInValue";
 import { useTradeInHandlers } from "./hooks/useTradeInHandlers";
 import { isStepValid } from "./utils/stepValidation";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
+import { posthogUtils } from "@/lib/posthogClient";
 
 interface TradeInModalProps {
   readonly isOpen: boolean;
@@ -94,6 +96,26 @@ export default function TradeInModal({
     productSku,
   });
 
+  // Analytics: rastrear Trade-In completado justo antes de notificar al padre
+  const handleCompleteTradeIn = (deviceName: string, value: number) => {
+    fbqTrackCustom("TradeInCompleted", {
+      device_name: deviceName,
+      trade_in_value: value,
+      currency: "COP",
+    });
+    posthogUtils.capture("trade_in_completed", {
+      device_name: deviceName,
+      trade_in_value: value,
+      currency: "COP",
+      $set: {
+        has_used_trade_in: true,
+        last_trade_in_value: value,
+        last_trade_in_device: deviceName,
+      },
+    });
+    onCompleteTradeIn?.(deviceName, value);
+  };
+
   const { handleClose, getStepTitle, getContinueHandler, getBackHandler } =
     useTradeInHandlers({
       setCurrentStep,
@@ -103,7 +125,7 @@ export default function TradeInModal({
       onClose,
       onContinue,
       onCancelWithoutCompletion,
-      onCompleteTradeIn,
+      onCompleteTradeIn: handleCompleteTradeIn,
       tradeInValue,
       imeiInput,
       selectedBrand: formState.selectedBrand,
@@ -126,6 +148,13 @@ export default function TradeInModal({
     setMounted(true);
     return () => setMounted(false);
   }, []);
+
+  // Analytics: Trade-In iniciado al abrir el modal
+  useEffect(() => {
+    if (!isOpen) return;
+    fbqTrackCustom("TradeInStarted", { currency: "COP" });
+    posthogUtils.capture("trade_in_started", { source: "product_detail_page" });
+  }, [isOpen]);
 
   if (!isOpen || !mounted) return null;
 

--- a/src/app/productos/viewpremium/[id]/page.tsx
+++ b/src/app/productos/viewpremium/[id]/page.tsx
@@ -14,6 +14,7 @@ import fallbackImage from "@/img/dispositivosmoviles/cel1.png";
 import StockNotificationModal from "@/components/StockNotificationModal";
 import { useStockNotification } from "@/hooks/useStockNotification";
 import { useTradeInPrefetch } from "@/hooks/useTradeInPrefetch";
+import { useAnalytics } from "@/lib/analytics/hooks/useAnalytics";
 
 // Componentes
 import ProductCarousel from "../components/ProductCarousel";
@@ -114,6 +115,28 @@ export default function ProductViewPage({ params }) {
 
   // Usar producto del API si está listo, sino usar el inicial de localStorage
   const product = apiProduct || initialProduct;
+
+  // 🔥 Track View Item (ViewContent) apenas carga el producto premium — PDP principal
+  const { trackViewItem } = useAnalytics();
+  React.useEffect(() => {
+    if (product && !loading) {
+      const productPrice =
+        typeof product.price === "number"
+          ? product.price
+          : Number.parseFloat(String(product.price)) || 0;
+      if (!productPrice) return;
+
+      trackViewItem({
+        item_id: product.id,
+        item_name: product.name,
+        item_brand: "Samsung",
+        item_category: product.apiProduct?.categoria || "Sin categoría",
+        price: productPrice,
+        currency: "COP",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [product?.id, loading]);
 
   const [showContent, setShowContent] = React.useState(false);
 

--- a/src/lib/gtm.ts
+++ b/src/lib/gtm.ts
@@ -108,7 +108,7 @@ export function gtmPurchase(transactionData: {
   gtmPush({
     event: 'purchase',
     ecommerce: {
-      currency: transactionData.currency || 'USD',
+      currency: transactionData.currency || 'COP',
       transaction_id: transactionData.transaction_id,
       value: transactionData.value,
       tax: transactionData.tax || 0,
@@ -223,7 +223,7 @@ export function gtmBeginCheckout(checkoutData: {
   gtmPush({
     event: 'begin_checkout',
     ecommerce: {
-      currency: checkoutData.currency || 'USD',
+      currency: checkoutData.currency || 'COP',
       value: checkoutData.value,
       items: checkoutData.items,
     },

--- a/src/lib/meta-pixel.ts
+++ b/src/lib/meta-pixel.ts
@@ -90,7 +90,7 @@ export function fbqViewContent(params: {
 }): void {
   safeFbq('track', 'ViewContent', {
     content_type: params.content_type || 'product',
-    currency: params.currency || 'USD',
+    currency: params.currency || 'COP',
     ...params,
   });
 }
@@ -107,7 +107,7 @@ export function fbqSearch(params: {
   currency?: string;
 }): void {
   safeFbq('track', 'Search', {
-    currency: params.currency || 'USD',
+    currency: params.currency || 'COP',
     ...params,
   });
 }
@@ -125,7 +125,7 @@ export function fbqAddToCart(params: {
 }): void {
   safeFbq('track', 'AddToCart', {
     content_type: params.content_type || 'product',
-    currency: params.currency || 'USD',
+    currency: params.currency || 'COP',
     ...params,
   });
 }
@@ -142,7 +142,7 @@ export function fbqAddToWishlist(params: {
   currency?: string;
 }): void {
   safeFbq('track', 'AddToWishlist', {
-    currency: params.currency || 'USD',
+    currency: params.currency || 'COP',
     ...params,
   });
 }
@@ -159,7 +159,7 @@ export function fbqInitiateCheckout(params: {
   currency?: string;
 }): void {
   safeFbq('track', 'InitiateCheckout', {
-    currency: params.currency || 'USD',
+    currency: params.currency || 'COP',
     ...params,
   });
 }
@@ -175,7 +175,7 @@ export function fbqAddPaymentInfo(params: {
   currency?: string;
 }): void {
   safeFbq('track', 'AddPaymentInfo', {
-    currency: params.currency || 'USD',
+    currency: params.currency || 'COP',
     ...params,
   });
 }
@@ -204,7 +204,7 @@ export function fbqPurchase(params: {
 }): void {
   safeFbq('track', 'Purchase', {
     content_type: params.content_type || 'product',
-    currency: params.currency || 'USD',
+    currency: params.currency || 'COP',
     ...params,
   });
 }
@@ -220,7 +220,7 @@ export function fbqLead(params?: {
   currency?: string;
 }): void {
   safeFbq('track', 'Lead', {
-    currency: params?.currency || 'USD',
+    currency: params?.currency || 'COP',
     ...params,
   });
 }
@@ -236,7 +236,7 @@ export function fbqCompleteRegistration(params?: {
   currency?: string;
 }): void {
   safeFbq('track', 'CompleteRegistration', {
-    currency: params?.currency || 'USD',
+    currency: params?.currency || 'COP',
     ...params,
   });
 }
@@ -259,7 +259,7 @@ export function fbqSubscribe(params?: {
   predicted_ltv?: number;
 }): void {
   safeFbq('track', 'Subscribe', {
-    currency: params?.currency || 'USD',
+    currency: params?.currency || 'COP',
     ...params,
   });
 }

--- a/src/types/meta-pixel.d.ts
+++ b/src/types/meta-pixel.d.ts
@@ -8,16 +8,19 @@ declare global {
     /**
      * Meta Pixel (Facebook Pixel) global function
      */
+    // NOTE: This shape must stay structurally identical to the Window.fbq
+    // declaration in src/lib/analytics/types/dataLayer.ts. TypeScript merges
+    // both global augmentations; divergent shapes break emit.meta.ts.
     fbq?: {
-  (command: 'track', eventName: string, parameters?: MetaPixelEventParams): void;
-  (command: 'trackCustom', eventName: string, parameters?: MetaPixelEventParams): void;
-  (command: 'init', pixelId: string, options?: { [key: string]: string | number | boolean | undefined }): void;
+      (command: 'track', eventName: string, parameters?: Record<string, unknown>, options?: Record<string, unknown>): void;
+      (command: 'trackCustom', eventName: string, parameters?: Record<string, unknown>, options?: Record<string, unknown>): void;
+      (command: 'init', pixelId: string, options?: Record<string, unknown>): void;
       (command: 'consent', action: 'grant' | 'revoke'): void;
-  callMethod?: (...args: [command: string, ...params: unknown[]]) => void;
-  queue?: [command: string, ...params: unknown[]][];
-  loaded?: boolean;
-  version?: string;
-  push?: (...args: [command: string, ...params: unknown[]]) => void;
+      callMethod?: (...args: unknown[]) => void;
+      queue?: unknown[];
+      loaded?: boolean;
+      version?: string;
+      push?: (...args: unknown[]) => void;
     };
 
     /**


### PR DESCRIPTION
## Context

Imagiq's analytics core (`controller.ts` → GA4 + Meta Pixel + TikTok + CAPI) works, but the checkout funnel and several high-value surfaces were blind or buggy. This fixes 3 bugs and adds 25+ events **without touching the working core**.

## Bugs fixed
- **Currency**: Meta Pixel (10×) and GTM fell back to `'USD'` → now `'COP'` (Colombia-only store; every untagged conversion was mis-valued).
- **Step3 wrong event**: delivery-selection step fired `AddPaymentInfo` (polluted Meta's payment-intent signal) → replaced with `SelectDeliveryMethod` custom event at **both** call sites.

## New events
| Surface | Events |
|---|---|
| `viewpremium/[id]` (main PDP) | ViewItem/ViewContent — was completely blind |
| Step2 | `CheckoutStep2_UserData` (guest vs registered, `useRef`-deduped across 4 advance paths) |
| Step4 | real `AddPaymentInfo` + `SelectPaymentMethod` + `ADDIFinancingSelected` + `PSEBankSelected` |
| Step5 | `InstallmentsSelected` + `CeroInteresActivated` (reuses existing `isInstallmentEligibleForZeroInterest`) |
| Step6 | `BillingTypeSelected` + `B2BCheckoutStarted` |
| Step7 | `CheckoutReviewCompleted` + `ThreeDSStarted` + `ThreeDSFailed` |
| error-checkout | `PaymentRejected` (ePayco code + category) |
| TradeInModal | `TradeInStarted` + `TradeInCompleted` |
| ProductCard | `AddToWishlist` (Meta) on favorite add |
| CouponInput | `CouponApplied` |
| `[categoria]` | `ViewItemList` |

## Incidental fixes required to build
- **`meta-pixel.d.ts`**: harmonized the `Window.fbq` global declaration with the divergent one in `dataLayer.ts`. The two shapes (3-arg vs 4-arg) merge-conflicted once the new `@/lib/meta-pixel` imports changed TS global-merge resolution order, breaking `emit.meta.ts`. Type-only change, zero runtime impact.
- **`bun.lock`**: synced to `package.json`'s pinned `next@16.0.10` (the committed lockfile on develop was stale at `16.0.7`, which also fails `bun install --frozen-lockfile`).

## Verification
- `bun run build`: ✅ exit 0, **0 TypeScript errors**, all 49 static pages generated. Clean `develop` baseline also builds (the `emit.meta.ts` break was introduced by the new imports and is fixed here).
- Static checklist: all 14 event-presence assertions pass.

## Conventions
Currency always `COP`; `posthogUtils.capture` for PostHog (`$set` for persistent profile props); `fbqTrackCustom` for Meta custom events. Untouched: `controller.ts`, `mappers/`, `CartContext.tsx`, `success-checkout`, `view/[id]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)