### PR TITLE
fix(analytics): InitiateCheckout on /carrito/step1 mount (once)

### DIFF
--- a/src/app/carrito/Step1.tsx
+++ b/src/app/carrito/Step1.tsx
@@ -31,6 +31,12 @@ import { useTradeInVerification } from "@/hooks/useTradeInVerification";
  * Paso 1 del carrito de compras
  * Recibe onContinue para avanzar al paso 2
  */
+// InitiateCheckout (Meta) debe dispararse UNA sola vez al ENTRAR al checkout
+// (mount de Step1 con carrito), no en cada clic de "Continuar". Guard a nivel
+// de módulo: sobrevive remounts/StrictMode dentro del mismo contexto JS; un
+// reload completo cuenta como una nueva sesión de checkout.
+let initiateCheckoutFired = false;
+
 export default function Step1({
   onContinue,
 }: {
@@ -467,6 +473,32 @@ export default function Step1({
   // Usar cálculos del hook centralizado
   const total = calculations.total;
 
+  // InitiateCheckout: una sola vez por sesión de checkout. Se dispara al
+  // montar Step1 cuando el carrito ya tiene items + total (lo que el Pixel de
+  // Meta espera al entrar al checkout — antes solo disparaba en el clic de
+  // "Continuar", por eso Pixel Helper solo mostraba PageView en /carrito/step1).
+  // Los clics de "Continuar" reutilizan este helper guardado: si ya disparó en
+  // mount son no-op (sin doble disparo); si Step1 no llegó a montar (p.ej.
+  // usuarios autenticados que saltan a step3) sirven de fallback.
+  const fireInitiateCheckoutOnce = useCallback(() => {
+    if (initiateCheckoutFired) return;
+    if (cartProducts.length === 0 || !total) return;
+    initiateCheckoutFired = true;
+    trackBeginCheckout(
+      cartProducts.map((p) => ({
+        item_id: p.sku,
+        item_name: p.name,
+        price: Number(p.price),
+        quantity: p.quantity,
+      })),
+      total
+    );
+  }, [cartProducts, total, trackBeginCheckout]);
+
+  useEffect(() => {
+    fireInitiateCheckoutOnce();
+  }, [fireInitiateCheckoutOnce]);
+
   // Calcular ahorro total por descuentos de productos (para mostrar en sticky bar mobile)
   const productSavings = useMemo(() => {
     return cartProducts.reduce((acc, product) => {
@@ -657,22 +689,12 @@ export default function Step1({
         // Validar Trade-In antes de continuar
         const validation = validateTradeInProducts(cartProducts);
         if (validation.isValid) {
-          // Track del evento begin_checkout para analytics
-          trackBeginCheckout(
-            cartProducts.map((p) => ({
-              item_id: p.sku,
-              item_name: p.name,
-              price: Number(p.price),
-              quantity: p.quantity,
-            })),
-            total
-          );
-          
+          fireInitiateCheckoutOnce();
           onContinue();
         }
       }
     },
-    [userClickedWhileLoading, cartProducts, total, onContinue, trackBeginCheckout]
+    [userClickedWhileLoading, cartProducts, onContinue, fireInitiateCheckoutOnce]
   );
 
   // Función para manejar el click en continuar pago
@@ -697,15 +719,7 @@ export default function Step1({
     }
 
     // Si ya se calculó o no está cargando, continuar normalmente
-    trackBeginCheckout(
-      cartProducts.map((p) => ({
-        item_id: p.sku,
-        item_name: p.name,
-        price: Number(p.price),
-        quantity: p.quantity,
-      })),
-      total
-    );
+    fireInitiateCheckoutOnce();
 
     onContinue();
   };
@@ -1064,16 +1078,7 @@ export default function Step1({
                 return;
               }
 
-              // Track del evento begin_checkout para analytics
-              trackBeginCheckout(
-                cartProducts.map((p) => ({
-                  item_id: p.sku,
-                  item_name: p.name,
-                  price: Number(p.price),
-                  quantity: p.quantity,
-                })),
-                total
-              );
+              fireInitiateCheckoutOnce();
 
               onContinue();
             }}

--- a/src/lib/analytics/emitters/emit.meta.ts
+++ b/src/lib/analytics/emitters/emit.meta.ts
@@ -2,10 +2,134 @@
  * Emisor de eventos para Meta Pixel (Facebook Pixel)
  *
  * Envía eventos a Meta Pixel usando fbq() cuando el consentimiento de ads está activo.
+ *
+ * Resiliencia ante carrera de carga: el pixel de Meta (fbevents.js) se inyecta
+ * de forma asíncrona y SOLO tras el consentimiento de marketing. Eventos que
+ * disparan temprano (p.ej. InitiateCheckout en el mount de /carrito/step1)
+ * pueden ejecutarse antes de que `fbq` exista o antes de que el consentimiento
+ * esté resuelto. Antes esos eventos se descartaban silenciosamente; ahora se
+ * encolan y se reintentan (acotado) hasta que `fbq` esté disponible Y el
+ * consentimiento sea afirmativo.
+ *
+ * Privacidad: un evento encolado SOLO se entrega cuando canSendAds() es true en
+ * el momento de entrega (se revalida cada intento). Si el consentimiento se
+ * deniega o nunca se concede, el evento expira en memoria sin enviarse jamás.
  */
 
 import type { MetaEvent } from '../mappers';
 import { canSendAds, logConsentBlocked } from '../utils';
+
+interface PendingMetaEvent {
+  /** Nombre del evento (para logs) */
+  label: string;
+  /** Realiza el envío real vía fbq() — solo se invoca con fbq listo + consentimiento */
+  send: () => void;
+  /** Intentos restantes antes de expirar */
+  attemptsLeft: number;
+}
+
+const RETRY_INTERVAL_MS = 400;
+const MAX_ATTEMPTS = 25; // ~10s: cubre resolución de consentimiento + carga async de fbevents.js
+
+const pendingMetaEvents: PendingMetaEvent[] = [];
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+let consentListenerAttached = false;
+
+/** ¿Está el pixel de Meta listo (cargado + consentimiento) para enviar ahora? */
+function isMetaReady(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.fbq === 'function' &&
+    canSendAds()
+  );
+}
+
+function stopFlushTimer(): void {
+  if (flushTimer !== null) {
+    clearInterval(flushTimer);
+    flushTimer = null;
+  }
+}
+
+/** Intenta entregar la cola; revalida consentimiento en cada intento. */
+function flushPendingMetaEvents(): void {
+  if (pendingMetaEvents.length === 0) {
+    stopFlushTimer();
+    return;
+  }
+
+  if (isMetaReady()) {
+    while (pendingMetaEvents.length > 0) {
+      const item = pendingMetaEvents.shift() as PendingMetaEvent;
+      try {
+        item.send();
+      } catch (error) {
+        console.error('[Meta Pixel] Failed to send queued event:', item.label, error);
+      }
+    }
+    stopFlushTimer();
+    return;
+  }
+
+  // Aún no listo: decrementar intentos y expirar los agotados.
+  for (let i = pendingMetaEvents.length - 1; i >= 0; i--) {
+    pendingMetaEvents[i].attemptsLeft -= 1;
+    if (pendingMetaEvents[i].attemptsLeft <= 0) {
+      // Distinguir "sin consentimiento" (telemetría) de "pixel nunca cargó".
+      if (!canSendAds()) {
+        logConsentBlocked('Meta Pixel', pendingMetaEvents[i].label);
+      } else {
+        console.warn(
+          '[Meta Pixel] Dropping event (fbq never became available):',
+          pendingMetaEvents[i].label,
+        );
+      }
+      pendingMetaEvents.splice(i, 1);
+    }
+  }
+
+  if (pendingMetaEvents.length === 0) {
+    stopFlushTimer();
+  }
+}
+
+function ensureFlushScheduled(): void {
+  if (typeof window === 'undefined') return;
+
+  if (flushTimer === null && pendingMetaEvents.length > 0) {
+    flushTimer = setInterval(flushPendingMetaEvents, RETRY_INTERVAL_MS);
+  }
+
+  // Flush inmediato cuando cambia el consentimiento (MetaPixelScript reinyecta
+  // el pixel ante 'consentChange'): evita esperar al próximo tick.
+  if (!consentListenerAttached) {
+    consentListenerAttached = true;
+    window.addEventListener('consentChange', () => {
+      setTimeout(flushPendingMetaEvents, 50); // defer: deja que fbevents.js termine de inyectarse
+    });
+  }
+}
+
+/**
+ * Entrega ahora si Meta está listo (camino rápido, sin cambio de comportamiento
+ * para el caso común); si no, encola y reintenta de forma acotada hasta que
+ * `fbq` + consentimiento estén disponibles.
+ */
+function deliverOrQueue(label: string, send: () => void): void {
+  if (typeof window === 'undefined') return; // SSR: no-op
+
+  if (isMetaReady()) {
+    try {
+      send();
+    } catch (error) {
+      console.error('[Meta Pixel] Failed to send event:', label, error);
+    }
+    return;
+  }
+
+  pendingMetaEvents.push({ label, send, attemptsLeft: MAX_ATTEMPTS });
+  ensureFlushScheduled();
+}
 
 /**
  * Envía un evento a Meta Pixel vía fbq()
@@ -13,50 +137,22 @@ import { canSendAds, logConsentBlocked } from '../utils';
  * @param event - Evento formateado para Meta Pixel
  * @param eventId - Event ID para deduplicación con CAPI
  * @param userData - Datos de usuario hasheados para Advanced Matching (opcional)
- *
- * @example
- * ```typescript
- * const metaEvent = toMetaEvent(dlEvent, eventId);
- * const userData = await hashUserData({ email: 'user@example.com' });
- * sendMeta(metaEvent, eventId, userData);
- * ```
  */
 export function sendMeta(
   event: MetaEvent,
   eventId: string,
   userData?: Record<string, string>
 ): void {
-  // Verificar consentimiento
-  if (!canSendAds()) {
-    logConsentBlocked('Meta Pixel', event.name);
-    return;
-  }
-
-  // Verificar que fbq esté disponible
-  if (typeof window === 'undefined' || typeof window.fbq !== 'function') {
-    console.warn('[Meta Pixel] fbq() not available, skipping event:', event.name);
-    return;
-  }
-
-  try {
-    // Preparar opciones con eventID para deduplicación
-    const options: Record<string, unknown> = {
-      eventID: eventId,
-    };
-
-    // Si hay datos de usuario, añadir para Advanced Matching
+  deliverOrQueue(event.name, () => {
+    const fbq = typeof window !== 'undefined' ? window.fbq : undefined;
+    if (typeof fbq !== 'function') return;
+    const options: Record<string, unknown> = { eventID: eventId };
     if (userData && Object.keys(userData).length > 0) {
-      // fbq espera user_data en el tercer parámetro
-      // pero también puede ir en el segundo parámetro como parte de custom_data
-      // Para Advanced Matching, lo mejor es usar fbq('track', event, data, { eventID, em, ph, ... })
+      // Para Advanced Matching: fbq('track', event, data, { eventID, em, ph, ... })
       Object.assign(options, userData);
     }
-
-    // Enviar evento
-    window.fbq('track', event.name, event.data, options);
-  } catch (error) {
-    console.error('[Meta Pixel] Failed to send event:', event.name, error);
-  }
+    fbq('track', event.name, event.data, options);
+  });
 }
 
 /**
@@ -71,19 +167,9 @@ export function sendMetaCustom(
   data: Record<string, unknown>,
   eventId: string
 ): void {
-  if (!canSendAds()) {
-    logConsentBlocked('Meta Pixel', eventName);
-    return;
-  }
-
-  if (typeof window === 'undefined' || typeof window.fbq !== 'function') {
-    console.warn('[Meta Pixel] fbq() not available');
-    return;
-  }
-
-  try {
-    window.fbq('trackCustom', eventName, data, { eventID: eventId });
-  } catch (error) {
-    console.error('[Meta Pixel] Failed to send custom event:', eventName, error);
-  }
+  deliverOrQueue(eventName, () => {
+    const fbq = typeof window !== 'undefined' ? window.fbq : undefined;
+    if (typeof fbq !== 'function') return;
+    fbq('trackCustom', eventName, data, { eventID: eventId });
+  });
 }


### PR DESCRIPTION
## Problem
Meta Pixel Helper shows only PageView on `imagiq.com/carrito/step1` — `InitiateCheckout` absent.

## Two-part root cause
1. **Step1 timing**: `trackBeginCheckout` (→ Meta `InitiateCheckout`) was wired only to the **"Continuar" click** (3 sites), never on entering the cart view.
2. **Core Meta emitter race**: even firing on mount, `emit.meta.ts` **dropped** events when `fbq` wasn't loaded yet / consent unresolved (no queue/retry). The Meta pixel (`fbevents.js`) is injected async, only after marketing consent, so early mount events lose the race. Verified empirically: GA4 `begin_checkout` + TikTok CAPI fired on `/carrito/step1` load, but Meta produced no `tr?ev=InitiateCheckout`.

## Fix (2 commits)
- **`Step1.tsx`**: module-scoped one-shot guard + `fireInitiateCheckoutOnce()` from a mount effect once cart+total ready; the 3 click sites route through the same guarded helper (fires exactly once per checkout session; click paths remain as fallback for auth users skipping step1). Module-scoped (not `useRef`) to survive remounts.
- **`emit.meta.ts`**: resilient `sendMeta`/`sendMetaCustom` — immediate send when `fbq`+consent ready (unchanged fast path); otherwise **enqueue + bounded retry (~10s) + immediate flush on `consentChange`**. Fixes InitiateCheckout **and any other early mount event** globally.
  - **Privacy preserved**: a queued event is delivered only when `canSendAds()` is true at flush time (revalidated every attempt). Denied/never-granted consent → event expires in memory, never sent (`logConsentBlocked` on expiry).

## Audit (rest of funnel is already correct)
Step3 SelectDeliveryMethod ✅ · Step4 AddPaymentInfo+SelectPaymentMethod ✅ · Step5/6 ✅ · Step7 ✅ · **Purchase** fully wired & dedup-gated on `success-checkout/[orderId]/page.tsx:170` ✅. No `fbq()` in components — all via `processAnalyticsEvent`.

## Verification
- `bun run build`: ✅ exit 0, 0 TS errors, 49 static pages.
- GA4 `begin_checkout` confirmed firing on `/carrito/step1` load (was click-only before).
- Post-deploy: add product → `/carrito/step1` → exactly one `tr?ev=InitiateCheckout` with content_ids (SKUs), value (cart total), num_items, COP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)