### PR TITLE
fix(analytics): synthesize CAPI fbc from fbclid when _fbc cookie absent

### DIFF
--- a/src/lib/analytics/utils/anonymize.ts
+++ b/src/lib/analytics/utils/anonymize.ts
@@ -58,15 +58,48 @@ export interface FacebookCookies {
   fbc: string | null;
 }
 
+/** Vigencia de la cookie _fbc: 90 días (igual que Meta). */
+const FBC_MAX_AGE_SECONDS = 90 * 24 * 60 * 60;
+
+/** fbclid plausible: tokens URL-safe que usa Meta (evita basura/inyección). */
+function isValidFbclid(value: string): boolean {
+  return /^[\w.\-]{1,512}$/.test(value);
+}
+
 /**
- * Extrae cookies de Facebook del navegador
+ * Escribe la cookie `_fbc` en el formato exacto de Meta (`fb.1.{ts}.{fbclid}`)
+ * para que el Pixel y CAPI converjan en el MISMO valor (dedup) y las
+ * conversiones posteriores sigan atribuyendo tras navegar fuera de la URL del
+ * anuncio. Persistencia ≈ 90 días, primera‑parte.
+ */
+function writeFbcCookie(value: string): void {
+  try {
+    const host = window.location.hostname;
+    const onImagiq = /(^|\.)imagiq\.com$/.test(host);
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    const domain = onImagiq ? '; domain=.imagiq.com' : '';
+    document.cookie = `_fbc=${value}; path=/; max-age=${FBC_MAX_AGE_SECONDS}; SameSite=Lax${secure}${domain}`;
+  } catch {
+    // no-op: si la escritura falla igual devolvemos el valor sintetizado
+  }
+}
+
+/**
+ * Extrae cookies de Facebook del navegador.
+ *
+ * `fbc`: si NO existe la cookie `_fbc` pero la URL trae `?fbclid=` (clic de
+ * anuncio), se sintetiza `fb.1.{ts}.{fbclid}` y se persiste como cookie `_fbc`
+ * (formato Meta). El Pixel de este sitio carga async y tras consentimiento, así
+ * que sin este fallback los clics de anuncio perdían `fbc` (atribución rota).
+ * Nunca se sobrescribe una cookie `_fbc` existente (el Pixel gestiona el
+ * refresh de un clic nuevo).
  *
  * @returns Objeto con fbp y fbc (o null si no existen)
  *
  * @example
  * ```typescript
  * const { fbp, fbc } = getFacebookCookies();
- * // { fbp: 'fb.1.xxx', fbc: 'fb.2.yyy' }
+ * // { fbp: 'fb.1.xxx', fbc: 'fb.1.{ts}.{fbclid}' }
  * ```
  */
 export function getFacebookCookies(): FacebookCookies {
@@ -82,8 +115,22 @@ export function getFacebookCookies(): FacebookCookies {
     return acc;
   }, {});
 
-  return {
-    fbp: cookies['_fbp'] ?? null,
-    fbc: cookies['_fbc'] ?? null,
-  };
+  const fbp = cookies['_fbp'] ?? null;
+  let fbc = cookies['_fbc'] ?? null;
+
+  if (!fbc && typeof window !== 'undefined') {
+    try {
+      const raw = new URLSearchParams(window.location.search).get('fbclid');
+      const fbclid = raw ? raw.trim() : '';
+      if (fbclid && isValidFbclid(fbclid)) {
+        const synthesized = `fb.1.${Date.now()}.${fbclid}`;
+        writeFbcCookie(synthesized);
+        fbc = synthesized;
+      }
+    } catch {
+      // no-op: ante cualquier error de parseo, fbc queda null
+    }
+  }
+
+  return { fbp, fbc };
 }


### PR DESCRIPTION
## Context
Without `user_data.fbc`, Meta can't attribute conversions to the originating ad (low Event Match Quality).

**fbc/fbp were already implemented end-to-end** — frontend reads `_fbc`/`_fbp` from `document.cookie` (`getFacebookCookies` in `anonymize.ts`) and sends them in the CAPI POST (`emit.meta-capi.ts:124,138-139`); backend DTO/`meta-capi.service.ts`/controller accept & forward them un-hashed; api-gateway forwards the body. **Not a missing-param bug.**

**Real gap:** `fbc` was only sent when the `_fbc` cookie already existed. Meta's `fbevents.js` here loads **async and only after marketing consent**, so ad clicks (`?fbclid=`) where the cookie isn't set yet lost `fbc`. No `fbclid → fbc` synthesis fallback existed.

## Change (frontend-only)
`src/lib/analytics/utils/anonymize.ts` → `getFacebookCookies()`:
- If `_fbc` cookie present → use it (never clobbered — Pixel owns refresh).
- Else if URL has a valid `?fbclid=` → synthesize `fb.1.{Date.now()}.{fbclid}` and **persist it as the `_fbc` cookie** in Meta's exact format (~90d, first-party, `domain=.imagiq.com` on prod, `SameSite=Lax`, `Secure` on https). Pixel + CAPI converge on the same `fbc` (dedup); later conversions keep attributing after navigating off the ad URL.
- Else → `fbc` omitted (organic — no false attribution).
- SSR-guarded; `fbclid` validated (`/^[\w.\-]{1,512}$/`). `fbp` unchanged. Consent-consistent (only the already consent-gated `buildFullUserData` path consumes this).

**No backend/api-gateway changes** — they already accept any `fbc` string.

## Verification
- `bun run build`: ✅ exit 0, 0 TS errors, 49 static pages.
- Post-deploy (Playwright, www.imagiq.com, post-consent):
  - `/?fbclid=TESTclick123` (no prior `_fbc`) → `_fbc` cookie `fb.1.<ts>.TESTclick123` written; CAPI POST `user_data.fbc` equals it.
  - Pre-existing `_fbc` → that value used, **not** clobbered.
  - Organic (no fbclid, no `_fbc`) → `fbc` omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)