### PR TITLE
fix(checkout): direcciones completas, UX de formulario y exclusión de facturación

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "lodash": "^4.17.21",
         "lodash.debounce": "^4.0.8",
         "lucide-react": "^0.535.0",
-        "next": "^16.0.7",
+        "next": "16.0.10",
         "next-themes": "^0.4.6",
         "pdfjs-dist": "^5.4.449",
         "posthog-js": "^1.318.2",
@@ -674,7 +674,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.0.7",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.10.tgz",
+      "integrity": "sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -686,7 +688,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.0.7",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.10.tgz",
+      "integrity": "sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg==",
       "cpu": [
         "arm64"
       ],
@@ -700,12 +704,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.7.tgz",
-      "integrity": "sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.10.tgz",
+      "integrity": "sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -715,12 +720,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.7.tgz",
-      "integrity": "sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.10.tgz",
+      "integrity": "sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -730,12 +736,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.7.tgz",
-      "integrity": "sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.10.tgz",
+      "integrity": "sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -745,12 +752,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.7.tgz",
-      "integrity": "sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.10.tgz",
+      "integrity": "sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -760,12 +768,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.7.tgz",
-      "integrity": "sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.10.tgz",
+      "integrity": "sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -775,12 +784,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.7.tgz",
-      "integrity": "sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.10.tgz",
+      "integrity": "sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -790,12 +800,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.0.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.7.tgz",
-      "integrity": "sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.10.tgz",
+      "integrity": "sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -6219,10 +6230,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "16.0.7",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.0.10.tgz",
+      "integrity": "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.0.7",
+        "@next/env": "16.0.10",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -6235,14 +6248,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.0.7",
-        "@next/swc-darwin-x64": "16.0.7",
-        "@next/swc-linux-arm64-gnu": "16.0.7",
-        "@next/swc-linux-arm64-musl": "16.0.7",
-        "@next/swc-linux-x64-gnu": "16.0.7",
-        "@next/swc-linux-x64-musl": "16.0.7",
-        "@next/swc-win32-arm64-msvc": "16.0.7",
-        "@next/swc-win32-x64-msvc": "16.0.7",
+        "@next/swc-darwin-arm64": "16.0.10",
+        "@next/swc-darwin-x64": "16.0.10",
+        "@next/swc-linux-arm64-gnu": "16.0.10",
+        "@next/swc-linux-arm64-musl": "16.0.10",
+        "@next/swc-linux-x64-gnu": "16.0.10",
+        "@next/swc-linux-x64-musl": "16.0.10",
+        "@next/swc-win32-arm64-msvc": "16.0.10",
+        "@next/swc-win32-x64-msvc": "16.0.10",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {

--- a/src/app/carrito/Step2.tsx
+++ b/src/app/carrito/Step2.tsx
@@ -73,7 +73,9 @@ export default function Step2({
     apellido: "",
     cedula: "",
     celular: "",
-    tipo_documento: "",
+    // Por defecto "CC" (cédula de ciudadanía), el caso más común, para que el
+    // botón no quede bloqueado si el usuario olvida abrir el selector.
+    tipo_documento: "CC",
   });
 
   // Estado para validación y UX
@@ -887,7 +889,7 @@ export default function Step2({
         apellido: savedUser.apellido || "",
         cedula: savedUser.numero_documento || "",
         celular: savedUser.telefono || "",
-        tipo_documento: savedUser.tipo_documento || "",
+        tipo_documento: savedUser.tipo_documento || "CC",
       });
 
       // Marcar como registrado como invitado (ya verificado)

--- a/src/app/carrito/Step6.tsx
+++ b/src/app/carrito/Step6.tsx
@@ -47,7 +47,9 @@ export default function Step6({ onBack, onContinue }: Step6Props) {
   const { products, isLoading: isCartLoading } = useCart();
 
   const [billingType, setBillingType] = useState<BillingType>("natural");
-  const [useShippingData, setUseShippingData] = useState(false);
+  // Por defecto marcado: usa los mismos datos/dirección de envío para facturación
+  // (el caso más común). El usuario puede desmarcarlo si factura con otros datos.
+  const [useShippingData, setUseShippingData] = useState(true);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isProcessing, setIsProcessing] = useState(false);
 
@@ -646,13 +648,29 @@ export default function Step6({ onBack, onContinue }: Step6Props) {
         billingData.direccion && (
           <div className="p-4 bg-gray-50 rounded-lg border border-gray-200">
             <p className="text-sm font-medium text-gray-700">
-              {billingData.direccion.linea_uno}
+              {billingData.direccion.linea_uno ||
+                billingData.direccion.lineaUno ||
+                billingData.direccion.direccionFormateada}
             </p>
-            {billingData.direccion.ciudad && (
-              <p className="text-sm text-gray-600 mt-1">
-                {billingData.direccion.ciudad}
-              </p>
-            )}
+            <div className="flex flex-col text-sm text-gray-600 mt-1">
+              {billingData.direccion.complemento && (
+                <span>{billingData.direccion.complemento}</span>
+              )}
+              {billingData.direccion.barrio && (
+                <span>Barrio: {billingData.direccion.barrio}</span>
+              )}
+              {billingData.direccion.tipoDireccion && (
+                <span className="capitalize">
+                  {billingData.direccion.tipoDireccion}
+                </span>
+              )}
+              {billingData.direccion.departamento && (
+                <span>{billingData.direccion.departamento}</span>
+              )}
+              {billingData.direccion.ciudad && (
+                <span>{billingData.direccion.ciudad}</span>
+              )}
+            </div>
           </div>
         )
       );
@@ -1059,7 +1077,7 @@ export default function Step6({ onBack, onContinue }: Step6Props) {
                   isOpen={isAddAddressModalOpen}
                   onClose={handleCloseAddAddressModal}
                   size="lg"
-                  showCloseButton={false}
+                  showCloseButton={true}
                 >
                   <AddNewAddressForm
                     onAddressAdded={handleAddressAdded}

--- a/src/app/carrito/Step7.tsx
+++ b/src/app/carrito/Step7.tsx
@@ -109,6 +109,12 @@ interface BillingData {
     usuario_id: string;
     linea_uno: string;
     ciudad: string;
+    lineaUno?: string;
+    direccionFormateada?: string;
+    barrio?: string;
+    complemento?: string;
+    tipoDireccion?: string;
+    departamento?: string;
   };
   // Campos de persona jurídica
   razonSocial?: string;
@@ -129,6 +135,14 @@ export default function Step7({ onBack }: Step7Props) {
   const [paymentData, setPaymentData] = useState<PaymentData | null>(null);
   const [shippingData, setShippingData] = useState<ShippingData | null>(null);
   const [billingData, setBillingData] = useState<BillingData | null>(null);
+  // Datos del comprador (la persona que hace la compra, de imagiq_user).
+  // Se muestra como tarjeta aparte cuando la facturación es de otra persona.
+  const [compradorData, setCompradorData] = useState<{
+    nombre?: string;
+    apellido?: string;
+    email?: string;
+    telefono?: string;
+  } | null>(null);
   const [recipientData, setRecipientData] = useState<{
     receivedByClient: boolean;
     firstName?: string;
@@ -365,6 +379,23 @@ export default function Step7({ onBack }: Step7Props) {
         setBillingData(parsed);
       } catch (error) {
         console.error("Error parsing billing data:", error);
+      }
+    }
+
+    // Cargar datos del comprador (imagiq_user) para mostrarlos cuando la
+    // facturación corresponde a otra persona.
+    const compradorStr = localStorage.getItem("imagiq_user");
+    if (compradorStr) {
+      try {
+        const u = JSON.parse(compradorStr);
+        setCompradorData({
+          nombre: u.nombre || "",
+          apellido: u.apellido || "",
+          email: u.email || "",
+          telefono: u.telefono || u.celular || "",
+        });
+      } catch (error) {
+        console.error("Error parsing comprador (imagiq_user):", error);
       }
     }
 
@@ -1600,6 +1631,20 @@ export default function Step7({ onBack }: Step7Props) {
       //       console.log("🏠 [Step7] Usuario ID (del contexto):", authContext.user?.id || loggedUser?.id);
       //       console.log("🏠 [Step7] =============================================");
 
+      // Destinatario de envío (step3). Si el cliente desmarcó "Será recibido por
+      // el cliente" y puso a otra persona, lo mandamos para que el backend lo
+      // guarde; si recibe el comprador, solo enviamos el flag.
+      const recipientPayload =
+        recipientData?.receivedByClient === false
+          ? {
+              receivedByClient: false,
+              firstName: recipientData.firstName?.trim() || "",
+              lastName: recipientData.lastName?.trim() || "",
+              email: recipientData.email?.trim() || "",
+              phone: recipientData.phone?.trim() || "",
+            }
+          : { receivedByClient: true };
+
       switch (paymentData?.method) {
         case "tarjeta": {
           //           console.log("💳 [Step7] ========== PAGO CON TARJETA ==========");
@@ -1656,6 +1701,7 @@ export default function Step7({ onBack }: Step7Props) {
             informacion_facturacion,
             beneficios: buildBeneficios(),
             couponCode: appliedCouponCode || undefined,
+            recipientData: recipientPayload,
           });
 
           if ("error" in res) {
@@ -1770,6 +1816,7 @@ export default function Step7({ onBack }: Step7Props) {
             beneficios: buildBeneficios(),
             bankName: paymentData.bankName || "",
             couponCode: appliedCouponCode || undefined,
+            recipientData: recipientPayload,
           });
           if ("error" in res) {
             setError(res.message);
@@ -1823,6 +1870,7 @@ export default function Step7({ onBack }: Step7Props) {
             informacion_facturacion,
             beneficios: buildBeneficios(),
             couponCode: appliedCouponCode || undefined,
+            recipientData: recipientPayload,
           });
           if ("error" in res) {
             setError(res.message);
@@ -2346,6 +2394,20 @@ export default function Step7({ onBack }: Step7Props) {
                                   {shippingData.address}
                                 </span>
                                 <div className="flex flex-col text-xs text-gray-600 mt-1">
+                                  {checkoutAddress?.complemento && (
+                                    <span>{checkoutAddress.complemento}</span>
+                                  )}
+                                  {checkoutAddress?.barrio && (
+                                    <span>Barrio: {checkoutAddress.barrio}</span>
+                                  )}
+                                  {checkoutAddress?.tipoDireccion && (
+                                    <span className="capitalize">
+                                      {checkoutAddress.tipoDireccion}
+                                    </span>
+                                  )}
+                                  {checkoutAddress?.departamento && (
+                                    <span>{checkoutAddress.departamento}</span>
+                                  )}
                                   {shippingData.city && (
                                     <span>{shippingData.city}</span>
                                   )}
@@ -2486,13 +2548,29 @@ export default function Step7({ onBack }: Step7Props) {
                             <MapPin className="w-4 h-4 text-gray-400 flex-shrink-0 mt-0.5" />
                             <div>
                               <p className="text-sm font-medium text-gray-900">
-                                {billingData.direccion.linea_uno}
+                                {billingData.direccion.linea_uno ||
+                                  billingData.direccion.lineaUno ||
+                                  billingData.direccion.direccionFormateada}
                               </p>
-                              {billingData.direccion.ciudad && (
-                                <p className="text-xs text-gray-600 mt-1">
-                                  {billingData.direccion.ciudad}
-                                </p>
-                              )}
+                              <div className="flex flex-col text-xs text-gray-600 mt-1">
+                                {billingData.direccion.complemento && (
+                                  <span>{billingData.direccion.complemento}</span>
+                                )}
+                                {billingData.direccion.barrio && (
+                                  <span>Barrio: {billingData.direccion.barrio}</span>
+                                )}
+                                {billingData.direccion.tipoDireccion && (
+                                  <span className="capitalize">
+                                    {billingData.direccion.tipoDireccion}
+                                  </span>
+                                )}
+                                {billingData.direccion.departamento && (
+                                  <span>{billingData.direccion.departamento}</span>
+                                )}
+                                {billingData.direccion.ciudad && (
+                                  <span>{billingData.direccion.ciudad}</span>
+                                )}
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -2500,6 +2578,65 @@ export default function Step7({ onBack }: Step7Props) {
                     </div>
                   </div>
                 )}
+
+                {/* Información del comprador: solo cuando la facturación es de otra persona */}
+                {compradorData &&
+                  billingData &&
+                  ((compradorData.email || "").trim().toLowerCase() !==
+                    (billingData.email || "").trim().toLowerCase() ||
+                    `${compradorData.nombre || ""} ${compradorData.apellido || ""}`
+                      .trim()
+                      .toLowerCase() !==
+                      (billingData.nombre || "").trim().toLowerCase()) && (
+                    <div className="bg-white rounded-lg p-4 border border-gray-300">
+                      <div className="flex items-center gap-3 mb-4">
+                        <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
+                          <UserIcon className="w-5 h-5 text-gray-600" />
+                        </div>
+                        <div>
+                          <h2 className="text-lg font-bold text-gray-900">
+                            Información del comprador
+                          </h2>
+                          <p className="text-sm text-gray-600">
+                            Quien realiza la compra
+                          </p>
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <p className="text-xs text-gray-500 mb-1">Nombre</p>
+                          <p className="text-sm font-medium text-gray-900">
+                            {compradorData.nombre || "-"}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-gray-500 mb-1">Apellido</p>
+                          <p className="text-sm font-medium text-gray-900">
+                            {compradorData.apellido || "-"}
+                          </p>
+                        </div>
+                        <div className="overflow-hidden">
+                          <p className="text-xs text-gray-500 mb-1">
+                            Correo electrónico
+                          </p>
+                          <p
+                            className="text-sm font-medium text-gray-900 truncate"
+                            title={compradorData.email || ""}
+                          >
+                            {compradorData.email || "-"}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-gray-500 mb-1">
+                            Número de celular
+                          </p>
+                          <p className="text-sm font-medium text-gray-900">
+                            {compradorData.telefono || "-"}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  )}
               </>
             )}
           </div>

--- a/src/app/carrito/components/AddNewAddressForm.tsx
+++ b/src/app/carrito/components/AddNewAddressForm.tsx
@@ -793,10 +793,11 @@ export default function AddNewAddressForm({
             ciudad: shippingResponse.ciudad || '',
             pais: shippingResponse.pais || 'Colombia',
             esPredeterminada: true,
-            // Campos adicionales para mostrar detalles en Step3
+            // Campos adicionales para mostrar detalles en Step3/Step7
             localidad: shippingResponse.localidad || '',
             barrio: shippingResponse.barrio || '',
             complemento: shippingResponse.complemento || '',
+            departamento: shippingResponse.departamento || formData.departamento || '',
             instruccionesEntrega: shippingResponse.instruccionesEntrega || '',
             tipoDireccion: shippingResponse.tipoDireccion || '',
             nombreDireccion: shippingResponse.nombreDireccion || '',
@@ -893,9 +894,14 @@ export default function AddNewAddressForm({
   };
 
   const handleInputChange = (field: string, value: string) => {
-    // Si intentan modificar la ciudad y fue auto-completada, no permitirlo
-    if (field === "ciudad" && isCityAutoCompleted) {
-      return;
+    // El autocompletado de la ubicación (geolocalización / Google Places) marca
+    // la ciudad como auto-completada UNA sola vez. En cuanto el usuario edita
+    // CUALQUIER campo a mano, liberamos ese "lock" para permitir edición libre
+    // de todo el formulario (incluida la ciudad). La geolocalización/Google
+    // escriben con setFormData directo, no pasan por aquí, así que el lock solo
+    // se libera ante una edición manual real del usuario.
+    if (isCityAutoCompleted) {
+      setIsCityAutoCompleted(false);
     }
     setFormData((prev) => ({ ...prev, [field]: value }));
     // Clear error when user starts typing
@@ -1204,7 +1210,11 @@ export default function AddNewAddressForm({
   const formContent = (
     <form onSubmit={handleSubmit} className="space-y-4">
       {/* Título, indicador de pasos y botón continuar */}
-      <div className="flex items-center justify-between mb-6 gap-4">
+      <div
+        className={`flex items-center justify-between mb-6 gap-4 ${
+          billingOnly ? "pr-10" : ""
+        }`}
+      >
         {/* Título + Indicador de pasos */}
         <div className="flex items-center gap-4">
           {/* Título (si se proporciona) */}

--- a/src/app/carrito/components/AddressSelector.tsx
+++ b/src/app/carrito/components/AddressSelector.tsx
@@ -108,11 +108,14 @@ export const AddressSelector: React.FC<AddressSelectorProps> = ({
     setAddressToDelete(null);
   };
 
-  // Si no hay dirección seleccionada, seleccionar por defecto la marcada
+  // Si no hay dirección seleccionada, seleccionar por defecto la marcada.
+  // IMPORTANTE: excluir las direcciones de FACTURACION — no deben usarse como
+  // dirección de ENVÍO (si no, la última factura agregada se cuela como envío).
   useEffect(() => {
     if (!address && addresses.length > 0) {
+      const enviables = addresses.filter((a) => a.tipo !== "FACTURACION");
       const defaultAddr =
-        addresses.find((a) => a.esPredeterminada) || addresses[0];
+        enviables.find((a) => a.esPredeterminada) || enviables[0];
       if (defaultAddr) onAddressChange(defaultAddr);
     }
   }, [address, addresses, onAddressChange]);
@@ -148,13 +151,13 @@ export const AddressSelector: React.FC<AddressSelectorProps> = ({
   };
 
   return (
-    <Modal isOpen={addressEdit} onClose={handleCloseModal} size="lg" showCloseButton={false}>
+    <Modal isOpen={addressEdit} onClose={handleCloseModal} size="lg" showCloseButton={true}>
       <div className="space-y-6">
         {/* Vista de selección de direcciones */}
         {!showAddForm && (
           <>
             {/* Header */}
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pb-4 border-b border-gray-200">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pb-4 border-b border-gray-200 sm:pr-10">
               <h4 className="text-xl font-semibold text-gray-900">
                 Selecciona tu dirección de envío
               </h4>

--- a/src/app/carrito/components/StoreSelector.tsx
+++ b/src/app/carrito/components/StoreSelector.tsx
@@ -102,10 +102,10 @@ export const StoreSelector: React.FC<StoreSelectorProps> = ({
     : [];
 
   return (
-    <Modal isOpen={storeEdit} onClose={handleCloseModal} size="lg" showCloseButton={false}>
+    <Modal isOpen={storeEdit} onClose={handleCloseModal} size="lg" showCloseButton={true}>
       <div className="space-y-6">
         {/* Header */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pb-4 border-b border-gray-200">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pb-4 border-b border-gray-200 sm:pr-10">
           <h4 className="text-xl font-semibold text-gray-900">
             Selecciona tu tienda
           </h4>

--- a/src/app/carrito/types/index.ts
+++ b/src/app/carrito/types/index.ts
@@ -1,3 +1,13 @@
+export interface RecipientPayload {
+  // = checkbox "Será recibido por el cliente" del step3.
+  receivedByClient: boolean;
+  // Solo presentes cuando receivedByClient === false (otra persona recibe).
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+}
+
 export interface BasicPaymentData {
   totalAmount: string;
   shippingAmount: string;
@@ -9,6 +19,7 @@ export interface BasicPaymentData {
   informacion_facturacion: InformacionFacturacion;
   beneficios?: BeneficiosDTO[];
   couponCode?: string;
+  recipientData?: RecipientPayload;
 }
 export interface InformacionFacturacion {
   type: string;

--- a/src/components/navbar/AddressDropdown.tsx
+++ b/src/components/navbar/AddressDropdown.tsx
@@ -700,6 +700,18 @@ const AddressDropdown: React.FC<AddressDropdownProps> = React.memo(({
                             <p className="text-sm text-gray-700 mt-1.5 leading-relaxed">
                               {address.lineaUno || address.direccionFormateada}
                             </p>
+                            {(address.complemento || address.barrio) && (
+                              <p className="text-xs text-gray-500 mt-1">
+                                {[
+                                  address.complemento,
+                                  address.barrio
+                                    ? `Barrio: ${address.barrio}`
+                                    : null,
+                                ]
+                                  .filter(Boolean)
+                                  .join(" · ")}
+                              </p>
+                            )}
                             {address.ciudad && (
                               <p className="text-xs text-gray-500 mt-1">
                                 {address.ciudad}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -70,9 +70,10 @@ const Modal: React.FC<ModalProps> = ({
         {showCloseButton && (
           <button
             onClick={onClose}
-            className="absolute top-4 right-4 p-2 hover:bg-gray-100 rounded-full transition-colors z-10"
+            aria-label="Cerrar"
+            className="absolute top-3 right-3 p-2 bg-white border border-gray-200 shadow-sm hover:bg-gray-100 rounded-full transition-colors z-20 cursor-pointer"
           >
-            <X className="w-5 h-5 text-gray-500" />
+            <X className="w-5 h-5 text-gray-700" />
           </button>
         )}
 

--- a/src/features/checkout/CheckoutAddressContext.tsx
+++ b/src/features/checkout/CheckoutAddressContext.tsx
@@ -83,9 +83,12 @@ export function CheckoutAddressProvider({ children }: { children: ReactNode }) {
       setSelectedAddress((prev) => {
         if (prev && all.some((a) => a.id === prev.id)) return prev;
         if (defaultAddr) return defaultAddr;
-        const predeterminada = all.find((a) => a.esPredeterminada);
+        // Excluir direcciones de FACTURACION: nunca deben elegirse como envío
+        // (si no, la última factura agregada —primera del listado— se cuela).
+        const enviables = all.filter((a) => a.tipo !== "FACTURACION");
+        const predeterminada = enviables.find((a) => a.esPredeterminada);
         if (predeterminada) return predeterminada;
-        return all.length > 0 ? all[0] : null;
+        return enviables.length > 0 ? enviables[0] : null;
       });
     } catch (error) {
       console.error("[CheckoutAddress] Error fetching addresses:", error);

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -235,6 +235,7 @@ export interface Direccion {
   localidad?: string;
   barrio?: string;
   complemento?: string;
+  departamento?: string;
   instruccionesEntrega?: string;
   tipoDireccion?: string;
   nombreDireccion?: string;


### PR DESCRIPTION
## Resumen
Ajustes del checkout (validado contra **develop**).

- **Step2 invitado**: tipo de documento **"CC" por defecto** (el botón ya no queda bloqueado).
- **Formulario de dirección**: editar **cualquier** campo libera el lock del autocompletado → permite cambiar ciudad/departamento sin que se buguee.
- **Excluir direcciones `FACTURACION`** de la selección de **envío** (antes la última factura agregada se colaba como dirección de envío).
- **Step6**: "usar los mismos datos de envío" **marcado por defecto**; dirección de facturación **completa**; modal con **X visible** + cursor + botones corridos para no chocar.
- **Step7**: dirección de envío y facturación **completas** (complemento/barrio/tipo/departamento); se guarda `departamento`.
- **Header "Mis direcciones"**: muestra barrio + complemento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)