### PR TITLE
feat(capi): persist _fbp/_fbc/UA at checkout for server-side Purchase

### DIFF
--- a/src/app/carrito/types/index.ts
+++ b/src/app/carrito/types/index.ts
@@ -9,6 +9,11 @@ export interface BasicPaymentData {
   informacion_facturacion: InformacionFacturacion;
   beneficios?: BeneficiosDTO[];
   couponCode?: string;
+  // Cookies de Facebook (_fbp/_fbc) y user-agent para Meta CAPI server-side.
+  // Se persisten en la orden y se reusan al disparar el `Purchase` server-side.
+  _fbp?: string | null;
+  _fbc?: string | null;
+  client_user_agent?: string;
 }
 export interface InformacionFacturacion {
   type: string;

--- a/src/app/carrito/utils/index.ts
+++ b/src/app/carrito/utils/index.ts
@@ -1,6 +1,7 @@
 "use client";
 import { AddiPaymentData, CardPaymentData, PsePaymentData, CheckZeroInterestRequest, CheckZeroInterestResponse } from "../types";
 import { apiPost, apiGet } from "@/lib/api-client";
+import { getFacebookCookies } from "@/lib/analytics/utils/anonymize";
 import posthog from "posthog-js";
 
 /** Get PostHog session tracking IDs (safe - returns empty strings if unavailable) */
@@ -16,11 +17,34 @@ function getPostHogIds() {
   return { posthogSessionId: "", posthogDistinctId: "" };
 }
 
+/**
+ * Cookies de Facebook (_fbp/_fbc, fbc se sintetiza desde ?fbclid si falta) y
+ * user-agent. Se persisten con la orden para que el backend dispare el
+ * `Purchase` server-side a Meta CAPI (Advanced Matching + dedup con el píxel).
+ */
+function getFacebookPayload() {
+  try {
+    const { fbp, fbc } = getFacebookCookies();
+    return {
+      _fbp: fbp,
+      _fbc: fbc,
+      client_user_agent:
+        typeof navigator !== "undefined" ? navigator.userAgent : "",
+    };
+  } catch {
+    return { _fbp: null, _fbc: null, client_user_agent: "" };
+  }
+}
+
 export async function payWithAddi(
   props: AddiPaymentData
 ): Promise<{ redirectUrl: string } | { error: string; message: string }> {
   try {
-    const data = await apiPost<{ redirectUrl: string }>('/api/payments/addi/apply', props);
+    const data = await apiPost<{ redirectUrl: string }>('/api/payments/addi/apply', {
+      ...props,
+      ...getPostHogIds(),
+      ...getFacebookPayload(),
+    });
     return data;
   } catch (error) {
     console.error("Error initiating Addi payment:", error);
@@ -39,6 +63,7 @@ export async function payWithCard(
       ...props,
       dues: props.dues.trim() === "" ? "1" : props.dues,
       ...getPostHogIds(),
+      ...getFacebookPayload(),
     });
     return data;
   } catch (error) {
@@ -59,6 +84,7 @@ export async function payWithSavedCard(
       ...props,
       dues: props.dues.trim() === "" ? "1" : props.dues,
       ...getPostHogIds(),
+      ...getFacebookPayload(),
     });
     return data;
   } catch (error) {
@@ -75,6 +101,7 @@ export async function payWithPse(props: PsePaymentData): Promise<{ redirectUrl: 
     const data = await apiPost<{ redirectUrl: string }>('/api/payments/epayco/pse', {
       ...props,
       ...getPostHogIds(),
+      ...getFacebookPayload(),
     });
     return data;
   } catch (error) {


### PR DESCRIPTION
## Por qué

El `Purchase` de Meta sólo se dispara client-side en `success-checkout/[orderId]`, pero los pagos (ePayco/PSE/Addi) redirigen fuera del sitio y la orden se confirma por **webhook server-side**, así que muchos usuarios nunca vuelven a esa página → el `Purchase` nunca se emite (~50% de conversiones web perdidas en Meta Ads).

El backend va a disparar el `Purchase` **server-side** a Meta CAPI cuando la orden web pasa a `APPROVED` (PR de backend aparte). Para que ese evento tenga buena calidad de match —y para que pase la validación FULL de CAPI, que **exige `client_user_agent`**— el checkout debe persistir las cookies de Facebook y el user-agent junto con la orden.

## Qué cambia

- `BasicPaymentData`: nuevos campos opcionales `_fbp` / `_fbc` / `client_user_agent` (heredados por Addi/Card/Pse).
- `payWith{Addi,Card,SavedCard,Pse}`: adjuntan `getFacebookCookies()` (reutiliza el helper existente; `fbc` se sintetiza desde `?fbclid` si falta) + `navigator.userAgent`.
- `payWithAddi`: además adjunta `getPostHogIds()` — antes no lo hacía, así que las órdenes Addi quedaban sin `posthog_session_id`.

El fire **client-side** del píxel se mantiene (dual tracking); Meta deduplica por `event_id = purchase_${orderId}`.

## Verificación

- `tsc --noEmit` limpio.
- En el checkout, confirmar en el payload de red de `/api/payments/...` que viajan `_fbp`, `_fbc` y `client_user_agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)