### PR TITLE
release: promote develop → main (CAPI Purchase _fbp/_fbc/UA persistence)

### DIFF
--- a/src/app/carrito/types/index.ts
+++ b/src/app/carrito/types/index.ts
@@ -9,6 +9,11 @@ export interface BasicPaymentData {
   informacion_facturacion: InformacionFacturacion;
   beneficios?: BeneficiosDTO[];
   couponCode?: string;
+  // Cookies de Facebook (_fbp/_fbc) y user-agent para Meta CAPI server-side.
+  // Se persisten en la orden y se reusan al disparar el `Purchase` server-side.
+  _fbp?: string | null;
+  _fbc?: string | null;
+  client_user_agent?: string;
 }
 export interface InformacionFacturacion {
   type: string;

--- a/src/app/carrito/utils/index.ts
+++ b/src/app/carrito/utils/index.ts
@@ -1,6 +1,7 @@
 "use client";
 import { AddiPaymentData, CardPaymentData, PsePaymentData, CheckZeroInterestRequest, CheckZeroInterestResponse } from "../types";
 import { apiPost, apiGet } from "@/lib/api-client";
+import { getFacebookCookies } from "@/lib/analytics/utils/anonymize";
 import posthog from "posthog-js";
 
 /** Get PostHog session tracking IDs (safe - returns empty strings if unavailable) */
@@ -16,11 +17,34 @@ function getPostHogIds() {
   return { posthogSessionId: "", posthogDistinctId: "" };
 }
 
+/**
+ * Cookies de Facebook (_fbp/_fbc, fbc se sintetiza desde ?fbclid si falta) y
+ * user-agent. Se persisten con la orden para que el backend dispare el
+ * `Purchase` server-side a Meta CAPI (Advanced Matching + dedup con el píxel).
+ */
+function getFacebookPayload() {
+  try {
+    const { fbp, fbc } = getFacebookCookies();
+    return {
+      _fbp: fbp,
+      _fbc: fbc,
+      client_user_agent:
+        typeof navigator !== "undefined" ? navigator.userAgent : "",
+    };
+  } catch {
+    return { _fbp: null, _fbc: null, client_user_agent: "" };
+  }
+}
+
 export async function payWithAddi(
   props: AddiPaymentData
 ): Promise<{ redirectUrl: string } | { error: string; message: string }> {
   try {
-    const data = await apiPost<{ redirectUrl: string }>('/api/payments/addi/apply', props);
+    const data = await apiPost<{ redirectUrl: string }>('/api/payments/addi/apply', {
+      ...props,
+      ...getPostHogIds(),
+      ...getFacebookPayload(),
+    });
     return data;
   } catch (error) {
     console.error("Error initiating Addi payment:", error);
@@ -39,6 +63,7 @@ export async function payWithCard(
       ...props,
       dues: props.dues.trim() === "" ? "1" : props.dues,
       ...getPostHogIds(),
+      ...getFacebookPayload(),
     });
     return data;
   } catch (error) {
@@ -59,6 +84,7 @@ export async function payWithSavedCard(
       ...props,
       dues: props.dues.trim() === "" ? "1" : props.dues,
       ...getPostHogIds(),
+      ...getFacebookPayload(),
     });
     return data;
   } catch (error) {
@@ -75,6 +101,7 @@ export async function payWithPse(props: PsePaymentData): Promise<{ redirectUrl: 
     const data = await apiPost<{ redirectUrl: string }>('/api/payments/epayco/pse', {
       ...props,
       ...getPostHogIds(),
+      ...getFacebookPayload(),
     });
     return data;
   } catch (error) {


### PR DESCRIPTION
Promoción develop → main para llevar a **producción** la persistencia de `_fbp`/`_fbc`/`client_user_agent` en el checkout (PR #996).

Esto completa la feature de **Meta CAPI `Purchase` server-side**: el backend (ya en prod) la dispara cuando la orden web pasa a APPROVED, pero necesita que el frontend guarde el `client_user_agent` en la orden (la validación FULL de CAPI lo exige) — esto recién llega a prod con esta promoción.

**Alcance** (develop adelante de main): solo el trabajo de CAPI.
- feat(capi): send _fbp/_fbc/client_user_agent on checkout so backend fires Purchase (#996)

Sin conflictos (merge-tree limpio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)