### PR TITLE
feat(seo): product-specific SSR metadata + product:* OG + JSON-LD + dynamic OG image

### DIFF
--- a/scripts/seo-coverage.ts
+++ b/scripts/seo-coverage.ts
@@ -1,0 +1,149 @@
+/**
+ * SEO coverage verifier (AC#8) — replaces a DB backfill.
+ *
+ * Because product metadata is generated server-side at request time from the
+ * live catalog, 100% of products get product-specific metadata automatically.
+ * This script PROVES it: it enumerates every product (codigoMarket) and, for
+ * each canonical PDP URL, asserts the rendered HTML carries product-specific
+ * Open Graph (og:type=product, a non-generic og:title, product:price:amount)
+ * and that the og:image returns a 200 image. It reports coverage % and lists
+ * every product that fell back to generic metadata or failed, so missing
+ * catalog data is visible.
+ *
+ * Idempotent / repeatable / no writes. Run against any environment:
+ *
+ *   SEO_COVERAGE_BASE_URL=https://www.imagiq.com bun scripts/seo-coverage.ts
+ *   bun scripts/seo-coverage.ts --limit 200          # sample
+ *
+ * Exit code: 0 if 100% covered, 1 otherwise (usable as a CI gate).
+ */
+
+const BASE_URL = (
+  process.env.SEO_COVERAGE_BASE_URL || "https://www.imagiq.com"
+).replace(/\/$/, "");
+const GENERIC_TITLE = "Samsung Store - iMagiQ Colombia";
+const CONCURRENCY = 8;
+
+const limitArg = process.argv.indexOf("--limit");
+const LIMIT =
+  limitArg > -1 ? parseInt(process.argv[limitArg + 1] || "0", 10) : 0;
+
+type Status = "OK" | "FALLBACK_GENERIC" | "MISSING_PRODUCT_TAGS" | "IMAGE_FAIL" | "FETCH_ERROR";
+interface Result {
+  codigoMarket: string;
+  status: Status;
+  detail?: string;
+}
+
+function metaContent(html: string, key: string): string | null {
+  // matches <meta property="key" content="..."> or name="key", any attr order
+  const re = new RegExp(
+    `<meta[^>]+(?:property|name)=["']${key.replace(/[:]/g, "\\:")}["'][^>]*>`,
+    "i",
+  );
+  const tag = html.match(re)?.[0];
+  if (!tag) return null;
+  return tag.match(/content=["']([^"']*)["']/i)?.[1] ?? null;
+}
+
+async function checkProduct(codigoMarket: string): Promise<Result> {
+  const url = `${BASE_URL}/productos/view/${encodeURIComponent(codigoMarket)}`;
+  try {
+    const res = await fetch(url, { headers: { "user-agent": "imagiq-seo-coverage" } });
+    if (!res.ok) return { codigoMarket, status: "FETCH_ERROR", detail: `HTTP ${res.status}` };
+    const html = await res.text();
+
+    const ogTitle = metaContent(html, "og:title");
+    const ogType = metaContent(html, "og:type");
+    const price = metaContent(html, "product:price:amount");
+    const ogImage = metaContent(html, "og:image");
+
+    if (!ogTitle || ogTitle === GENERIC_TITLE) {
+      return { codigoMarket, status: "FALLBACK_GENERIC", detail: `og:title="${ogTitle ?? ""}"` };
+    }
+    if (ogType !== "product" || !price || Number(price) <= 0) {
+      return {
+        codigoMarket,
+        status: "MISSING_PRODUCT_TAGS",
+        detail: `og:type=${ogType} price=${price}`,
+      };
+    }
+    if (ogImage) {
+      try {
+        const img = await fetch(ogImage, { method: "GET" });
+        const ct = img.headers.get("content-type") || "";
+        if (!img.ok || !ct.startsWith("image/")) {
+          return { codigoMarket, status: "IMAGE_FAIL", detail: `${img.status} ${ct}` };
+        }
+      } catch (e) {
+        return { codigoMarket, status: "IMAGE_FAIL", detail: String(e) };
+      }
+    } else {
+      return { codigoMarket, status: "IMAGE_FAIL", detail: "no og:image" };
+    }
+    return { codigoMarket, status: "OK" };
+  } catch (e) {
+    return { codigoMarket, status: "FETCH_ERROR", detail: String(e) };
+  }
+}
+
+async function fetchAllCodigoMarkets(): Promise<string[]> {
+  const res = await fetch(`${BASE_URL}/api/products`);
+  if (!res.ok) throw new Error(`catalog fetch failed: HTTP ${res.status}`);
+  const json: any = await res.json();
+  const arr: any[] = Array.isArray(json) ? json : json?.products || json?.data || [];
+  const set = new Set<string>();
+  for (const p of arr) {
+    const cm = String(p?.codigoMarket || p?.codigo_market || "").trim();
+    if (cm) set.add(cm);
+  }
+  return [...set];
+}
+
+async function runPool<T, R>(items: T[], n: number, fn: (t: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let i = 0;
+  async function worker() {
+    while (i < items.length) {
+      const idx = i++;
+      out[idx] = await fn(items[idx]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(n, items.length) }, worker));
+  return out;
+}
+
+async function main() {
+  console.log(`[seo-coverage] target: ${BASE_URL}`);
+  let codes = await fetchAllCodigoMarkets();
+  console.log(`[seo-coverage] catalog products (codigoMarket): ${codes.length}`);
+  if (LIMIT > 0) {
+    codes = codes.slice(0, LIMIT);
+    console.log(`[seo-coverage] sampling first ${codes.length}`);
+  }
+
+  const results = await runPool(codes, CONCURRENCY, checkProduct);
+  const by: Record<Status, Result[]> = {
+    OK: [], FALLBACK_GENERIC: [], MISSING_PRODUCT_TAGS: [], IMAGE_FAIL: [], FETCH_ERROR: [],
+  };
+  for (const r of results) by[r.status].push(r);
+
+  const ok = by.OK.length;
+  const total = results.length;
+  const pct = total ? ((ok / total) * 100).toFixed(2) : "0";
+  console.log(`\n===== SEO COVERAGE REPORT =====`);
+  console.log(`OK (product-specific OG + price + image): ${ok}/${total} (${pct}%)`);
+  for (const s of ["FALLBACK_GENERIC", "MISSING_PRODUCT_TAGS", "IMAGE_FAIL", "FETCH_ERROR"] as Status[]) {
+    if (by[s].length) {
+      console.log(`\n${s}: ${by[s].length}`);
+      by[s].slice(0, 50).forEach((r) => console.log(`  - ${r.codigoMarket}  ${r.detail ?? ""}`));
+      if (by[s].length > 50) console.log(`  … and ${by[s].length - 50} more`);
+    }
+  }
+  process.exit(ok === total && total > 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("[seo-coverage] fatal:", e);
+  process.exit(1);
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -145,7 +145,7 @@ export default function RootLayout({
   }
   return (
     <html
-      lang="es"
+      lang="es-CO"
       suppressHydrationWarning
       className={`${samsungSharpSans.variable}`}
       style={
@@ -185,6 +185,23 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(
               buildSiteNavigationJsonLd(process.env.NEXT_PUBLIC_SITE_URL || "https://imagiq.com")
+            ),
+          }}
+        />
+        {/* JSON-LD: Organization */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(
+              buildOrganizationJsonLd({
+                site_name: "Samsung Store - iMagiQ Colombia",
+                site_url: process.env.NEXT_PUBLIC_SITE_URL || "https://imagiq.com",
+                title_template: "",
+                default_title: "",
+                default_description: "",
+                default_og_image: "",
+                google_verification: "",
+              })
             ),
           }}
         />

--- a/src/app/og/product/[codigoMarket]/route.tsx
+++ b/src/app/og/product/[codigoMarket]/route.tsx
@@ -1,0 +1,170 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+// Brand
+const SAMSUNG_BLUE = "#1428A0";
+const INK = "#0a0a0a";
+
+interface ProductMeta {
+  codigoMarket: string;
+  name: string;
+  price: number;
+  priceNormal: number;
+  image: string | null;
+  inStock: boolean;
+}
+
+function formatCop(value: number): string {
+  if (!value || value <= 0) return "";
+  const grouped = Math.round(value)
+    .toString()
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return `$ ${grouped}`;
+}
+
+/** Force a satori-friendly JPG render of a Cloudinary image (avoids webp/avif). */
+function toSatoriImage(url: string | null): string | null {
+  if (!url) return null;
+  if (url.includes("res.cloudinary.com") && url.includes("/image/upload/")) {
+    return url.replace(
+      /\/image\/upload\/(?:[^/]+\/)?/,
+      "/image/upload/f_jpg,q_80,w_760,c_pad,b_white/",
+    );
+  }
+  return url;
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ codigoMarket: string }> },
+) {
+  const { codigoMarket } = await params;
+  const origin = new URL(req.url).origin;
+
+  let meta: ProductMeta | null = null;
+  try {
+    const res = await fetch(
+      `${origin}/api/products/${encodeURIComponent(codigoMarket)}/meta`,
+      { headers: { accept: "application/json" } },
+    );
+    if (res.ok) {
+      const data = (await res.json()) as ProductMeta | null;
+      if (data && data.codigoMarket) meta = data;
+    }
+  } catch {
+    meta = null;
+  }
+
+  const name = meta?.name || "Samsung Store";
+  const photo = toSatoriImage(meta?.image ?? null);
+  const price = formatCop(meta?.price ?? 0);
+  const hadDiscount =
+    !!meta && meta.priceNormal > 0 && meta.price > 0 && meta.priceNormal > meta.price;
+
+  const cacheHeaders = {
+    "Cache-Control":
+      "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+  };
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "1200px",
+          height: "630px",
+          display: "flex",
+          backgroundColor: "#ffffff",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {/* Left: product photo on white */}
+        <div
+          style={{
+            width: "560px",
+            height: "630px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: "#f4f6fb",
+          }}
+        >
+          {photo ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={photo}
+              alt={name}
+              width={480}
+              height={480}
+              style={{ objectFit: "contain" }}
+            />
+          ) : (
+            <div style={{ display: "flex", fontSize: 48, color: SAMSUNG_BLUE }}>
+              Samsung Store
+            </div>
+          )}
+        </div>
+
+        {/* Right: brand + name + price */}
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            padding: "64px 56px",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              fontSize: 28,
+              fontWeight: 700,
+              color: SAMSUNG_BLUE,
+              letterSpacing: "1px",
+            }}
+          >
+            SAMSUNG STORE
+          </div>
+          <div
+            style={{
+              display: "flex",
+              marginTop: 24,
+              fontSize: 52,
+              fontWeight: 800,
+              color: INK,
+              lineHeight: 1.1,
+              maxWidth: "560px",
+            }}
+          >
+            {name.length > 80 ? `${name.slice(0, 80)}…` : name}
+          </div>
+          {price ? (
+            <div style={{ display: "flex", alignItems: "flex-end", marginTop: 28, gap: 16 }}>
+              <div style={{ display: "flex", fontSize: 44, fontWeight: 800, color: SAMSUNG_BLUE }}>
+                {price}
+              </div>
+              {hadDiscount ? (
+                <div
+                  style={{
+                    display: "flex",
+                    fontSize: 26,
+                    color: "#9aa0a6",
+                    textDecoration: "line-through",
+                    paddingBottom: 6,
+                  }}
+                >
+                  {formatCop(meta!.priceNormal)}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+          <div style={{ display: "flex", marginTop: 36, fontSize: 24, color: "#5f6368" }}>
+            Distribuidor oficial Samsung · Envío a toda Colombia
+          </div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630, headers: cacheHeaders },
+  );
+}

--- a/src/app/productos/[categoria]/layout.tsx
+++ b/src/app/productos/[categoria]/layout.tsx
@@ -12,6 +12,7 @@
  */
 
 import type { Metadata } from "next";
+import { buildItemListJsonLd } from "@/lib/seo-utils";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://imagiq.com";
@@ -106,6 +107,52 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
   };
 }
 
-export default function CategoriaLayout({ children }: LayoutProps) {
-  return children;
+/** Best-effort ItemList JSON-LD for the category listing (AC#4). Defensive:
+ * any failure (unknown category, fetch error, unexpected shape) just renders
+ * children with no ItemList — never breaks the page. */
+async function fetchCategoryItemList(
+  categoria: string,
+): Promise<Array<{ name: string; url: string }>> {
+  try {
+    const data = await findCategoriaBySlug(categoria);
+    const key = data?.nombre || categoria;
+    const res = await fetch(
+      `${API_URL}/api/products/filtered?categoria=${encodeURIComponent(key)}`,
+      { next: { revalidate: 600 } },
+    );
+    if (!res.ok) return [];
+    const json = await res.json();
+    const arr: any[] = Array.isArray(json) ? json : json?.products || json?.data || [];
+    const seen = new Set<string>();
+    const items: Array<{ name: string; url: string }> = [];
+    for (const p of arr) {
+      const cm = String(p?.codigoMarket || p?.codigo_market || "").trim();
+      const name = String(p?.nombreMarket || p?.nombre || p?.name || "").trim();
+      if (!cm || !name || seen.has(cm)) continue;
+      seen.add(cm);
+      items.push({ name, url: `${SITE_URL}/productos/view/${encodeURIComponent(cm)}` });
+      if (items.length >= 30) break;
+    }
+    return items;
+  } catch {
+    return [];
+  }
+}
+
+export default async function CategoriaLayout({ children, params }: LayoutProps) {
+  const { categoria } = await params;
+  const items = await fetchCategoryItemList(categoria);
+  return (
+    <>
+      {items.length > 0 ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(buildItemListJsonLd(items)),
+          }}
+        />
+      ) : null}
+      {children}
+    </>
+  );
 }

--- a/src/app/productos/multimedia/[id]/layout.tsx
+++ b/src/app/productos/multimedia/[id]/layout.tsx
@@ -7,17 +7,19 @@ interface Props {
   children: React.ReactNode;
 }
 
-// Server-side metadata. The route param `id` is the product's codigoMarket
-// (or a SKU). `buildProductMetadata` resolves canonical product data + manual
-// SEO overrides, emits og:type=product + product:* for the Meta catalog, and
-// points og:image to the dynamic branded 1200×630 OG image. Returns {} only
-// when the product can't be resolved (keeps the generic root metadata).
+// The multimedia route is the URL shared in Meta Ads / WhatsApp. It used to be
+// a client-only page with no metadata, so crawlers got the generic root tags.
+// This server layout renders product-specific metadata + product:* + JSON-LD
+// (canonical points to the single /productos/view/{codigoMarket} URL).
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   return (await buildProductMetadata(id)) ?? {};
 }
 
-export default async function ProductViewLayout({ params, children }: Props) {
+export default async function ProductMultimediaLayout({
+  params,
+  children,
+}: Props) {
   const { id } = await params;
   return (
     <>

--- a/src/app/productos/viewpremium/[id]/layout.tsx
+++ b/src/app/productos/viewpremium/[id]/layout.tsx
@@ -7,17 +7,18 @@ interface Props {
   children: React.ReactNode;
 }
 
-// Server-side metadata. The route param `id` is the product's codigoMarket
-// (or a SKU). `buildProductMetadata` resolves canonical product data + manual
-// SEO overrides, emits og:type=product + product:* for the Meta catalog, and
-// points og:image to the dynamic branded 1200×630 OG image. Returns {} only
-// when the product can't be resolved (keeps the generic root metadata).
+// Premium PDP variant. Was client-only with no metadata → generic preview.
+// Server layout adds product-specific metadata + product:* + JSON-LD, sharing
+// the same central helper as /view and /multimedia.
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   return (await buildProductMetadata(id)) ?? {};
 }
 
-export default async function ProductViewLayout({ params, children }: Props) {
+export default async function ProductViewPremiumLayout({
+  params,
+  children,
+}: Props) {
   const { id } = await params;
   return (
     <>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -67,5 +67,27 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     }));
 
-  return [...staticPages, ...cmsPages, ...categoryPages];
+  // Product pages — one canonical URL per product group (codigoMarket). Best
+  // effort: defensively parse the catalog response, dedupe, and cap to stay
+  // well under the 50k-URL sitemap limit. Never breaks the sitemap on error.
+  const catalog = await fetchJson<any>(`${API_URL}/api/products`, []);
+  const catalogArr: any[] = Array.isArray(catalog)
+    ? catalog
+    : catalog?.products || catalog?.data || [];
+  const seenCm = new Set<string>();
+  const productPages: MetadataRoute.Sitemap = [];
+  for (const p of catalogArr) {
+    const cm = String(p?.codigoMarket || p?.codigo_market || '').trim();
+    if (!cm || seenCm.has(cm)) continue;
+    seenCm.add(cm);
+    productPages.push({
+      url: `${baseUrl}/productos/view/${encodeURIComponent(cm)}`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.7,
+    });
+    if (productPages.length >= 20000) break;
+  }
+
+  return [...staticPages, ...cmsPages, ...categoryPages, ...productPages];
 }

--- a/src/components/seo/ProductStructuredData.tsx
+++ b/src/components/seo/ProductStructuredData.tsx
@@ -1,0 +1,58 @@
+import {
+  fetchProductMeta,
+  buildProductJsonLd,
+  buildBreadcrumbJsonLd,
+  productCanonicalUrl,
+} from "@/lib/seo-utils";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://imagiq.com";
+
+/**
+ * Server component that renders Product + BreadcrumbList JSON-LD for a PDP.
+ * Shared by the /productos/{view,multimedia,viewpremium} layouts. The
+ * `fetchProductMeta` call is memoized by Next within the same request, so this
+ * does not add an extra round-trip on top of `generateMetadata`.
+ */
+export default async function ProductStructuredData({
+  pageKey,
+}: {
+  pageKey: string;
+}) {
+  const meta = await fetchProductMeta(pageKey);
+  if (!meta) return null;
+
+  const url = productCanonicalUrl(meta.codigoMarket);
+
+  const product = buildProductJsonLd({
+    name: meta.name,
+    description: meta.description,
+    sku: meta.sku,
+    gtin13: meta.ean,
+    images: meta.image ? [meta.image] : [],
+    price: meta.price,
+    currency: meta.currency,
+    inStock: meta.inStock,
+    brand: meta.brand,
+    url,
+  });
+
+  const breadcrumb = buildBreadcrumbJsonLd([
+    { name: "Inicio", url: SITE_URL },
+    { name: "Productos", url: `${SITE_URL}/productos` },
+    { name: meta.name, url },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(product) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+    </>
+  );
+}

--- a/src/lib/seo-utils.ts
+++ b/src/lib/seo-utils.ts
@@ -41,14 +41,24 @@ export async function getSeoSettings(): Promise<SeoSettings> {
   return DEFAULTS;
 }
 
-/** Build WebSite JSON-LD — controls the site name shown in Google SERPs (especially mobile) */
+/** Build WebSite JSON-LD — controls the site name shown in Google SERPs (especially
+ * mobile) and enables the Sitelinks Search Box via `potentialAction`. */
 export function buildWebSiteJsonLd(settings: SeoSettings) {
+  const base = settings.site_url || SITE_URL;
   return {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: "Samsung Store",
     alternateName: ["Samsung Store iMagiQ", "Samsung Store Colombia"],
-    url: settings.site_url,
+    url: base,
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${base}/productos?q={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
   };
 }
 
@@ -73,6 +83,7 @@ export function buildProductJsonLd(product: {
   name: string;
   description?: string;
   sku: string;
+  gtin13?: string | null;
   images: string[];
   price: number;
   currency?: string;
@@ -86,6 +97,7 @@ export function buildProductJsonLd(product: {
     name: product.name,
     description: product.description,
     sku: product.sku,
+    ...(product.gtin13 ? { gtin13: product.gtin13 } : {}),
     image: product.images,
     brand: {
       "@type": "Brand",
@@ -99,9 +111,10 @@ export function buildProductJsonLd(product: {
       availability: product.inStock !== false
         ? "https://schema.org/InStock"
         : "https://schema.org/OutOfStock",
+      itemCondition: "https://schema.org/NewCondition",
       seller: {
         "@type": "Organization",
-        name: "ImagiQ",
+        name: "Samsung Store iMagiQ",
       },
     },
   };
@@ -144,5 +157,177 @@ export function buildBreadcrumbJsonLd(
       name: item.name,
       item: item.url,
     })),
+  };
+}
+
+/** Build ItemList JSON-LD for category/listing pages */
+export function buildItemListJsonLd(
+  items: Array<{ name: string; url: string }>,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      url: item.url,
+    })),
+  };
+}
+
+// ===========================================================================
+// PRODUCT (PDP) METADATA — single source of truth reused by /productos/view,
+// /productos/multimedia and /productos/viewpremium layouts (server-side).
+// ===========================================================================
+
+export interface ProductMeta {
+  codigoMarket: string;
+  sku: string;
+  ean: string | null;
+  name: string;
+  description: string;
+  image: string | null;
+  price: number;
+  priceNormal: number;
+  currency: string;
+  inStock: boolean;
+  brand: string;
+  condition: string;
+  categoria: string | null;
+}
+
+export interface ProductSeoOverride {
+  codigoMarket: string;
+  meta_title?: string | null;
+  meta_description?: string | null;
+  meta_keywords?: string | null;
+  og_image?: string | null;
+  seo_og_title?: string | null;
+  seo_og_description?: string | null;
+  seo_canonical?: string | null;
+  seo_no_index?: boolean;
+  seo_no_follow?: boolean;
+}
+
+/** Canonical product data for SSR metadata (backend reuses the merchant-feed
+ * resolvers, so OG `product:*`, JSON-LD and the Meta catalog feed all agree). */
+export async function fetchProductMeta(key: string): Promise<ProductMeta | null> {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/products/${encodeURIComponent(key)}/meta`,
+      { next: { revalidate: 300 } }, // 5 min: price/stock stay reasonably fresh
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data || !data.codigoMarket) return null;
+    return data as ProductMeta;
+  } catch {
+    return null;
+  }
+}
+
+/** Per-product SEO overrides (product_seo side table, keyed by codigoMarket).
+ * Returns null when the product has no manual override (the common case). */
+export async function fetchProductSeoOverride(
+  codigoMarket: string,
+): Promise<ProductSeoOverride | null> {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/products/seo/overrides/${encodeURIComponent(codigoMarket)}`,
+      { next: { revalidate: 300 } },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data || !data.codigoMarket) return null;
+    return data as ProductSeoOverride;
+  } catch {
+    return null;
+  }
+}
+
+/** URL of the dynamic branded OG image (next/og route). Lives OUTSIDE `/api/*`
+ * because next.config rewrites `/api/*` to the backend, which would shadow it. */
+export function productOgImageUrl(codigoMarket: string): string {
+  return `${SITE_URL}/og/product/${encodeURIComponent(codigoMarket)}`;
+}
+
+/** Canonical product URL — one per product group, regardless of which PDP
+ * variant route (view/multimedia/viewpremium) the user landed on. */
+export function productCanonicalUrl(codigoMarket: string): string {
+  return `${SITE_URL}/productos/view/${encodeURIComponent(codigoMarket)}`;
+}
+
+/**
+ * Build the full Next.js Metadata for a product page. `key` is the route param
+ * (codigoMarket or SKU). Precedence: manual `product_seo` override > catalog
+ * default. Emits the complete Open Graph + `product:*` namespace via `other`
+ * (Next's typed `openGraph` can't express og:type=product / product:* and would
+ * also emit a conflicting og:type=website), so PDP pages feed the Meta catalog.
+ * Returns `null` when the product can't be resolved (caller keeps the generic
+ * root metadata).
+ */
+export async function buildProductMetadata(
+  key: string,
+): Promise<import("next").Metadata | null> {
+  const [meta, override] = await Promise.all([
+    fetchProductMeta(key),
+    fetchProductSeoOverride(key),
+  ]);
+  if (!meta) return null;
+
+  const codigoMarket = meta.codigoMarket;
+  const canonical = override?.seo_canonical || productCanonicalUrl(codigoMarket);
+
+  const title = override?.meta_title || `${meta.name} | Samsung Store`;
+  const description = (
+    override?.meta_description || meta.description
+  ).slice(0, 200);
+  const ogTitle = override?.seo_og_title || override?.meta_title || meta.name;
+  const ogDescription = override?.seo_og_description || description;
+  const ogImage =
+    override?.og_image || productOgImageUrl(codigoMarket);
+  const availability = meta.inStock ? "in stock" : "out of stock";
+
+  return {
+    title,
+    description,
+    keywords: override?.meta_keywords || undefined,
+    alternates: { canonical },
+    robots: {
+      index: !(override?.seo_no_index ?? false),
+      follow: !(override?.seo_no_follow ?? false),
+    },
+    // Twitter is conflict-free via the typed field.
+    twitter: {
+      card: "summary_large_image",
+      title: ogTitle,
+      description: ogDescription,
+      images: [ogImage],
+    },
+    // Full OG + product namespace emitted manually for deterministic og:type
+    // and the Meta-catalog `product:*` tags. All URLs absolute.
+    other: {
+      "og:type": "product",
+      "og:title": ogTitle,
+      "og:description": ogDescription,
+      "og:url": canonical,
+      "og:site_name": "Samsung Store",
+      "og:locale": "es_CO",
+      "og:image": ogImage,
+      "og:image:secure_url": ogImage,
+      "og:image:width": "1200",
+      "og:image:height": "630",
+      "og:image:alt": meta.name,
+      "product:price:amount": String(meta.price),
+      "product:price:currency": meta.currency,
+      "product:availability": availability,
+      "product:retailer_item_id": meta.sku,
+      "product:brand": meta.brand,
+      "product:condition": meta.condition,
+      // Some scrapers read the legacy og:price:* pair too.
+      "og:price:amount": String(meta.price),
+      "og:price:currency": meta.currency,
+    },
   };
 }


### PR DESCRIPTION
## Por qué
Compartir una PDP (ej. `https://www.imagiq.com/productos/multimedia/S31GF`) en Meta Ads / WhatsApp mostraba metadata **genérica** ("Samsung Store - iMagiQ Colombia"). Causa raíz: las rutas `multimedia` y `viewpremium` eran **client-only sin `generateMetadata`** (caían al root), `view` emitía `og:type=website` sin `product:*` ni JSON-LD, y su fetch de producto apuntaba a un endpoint sin handler.

> Requiere el PR de backend (Davases22/imagiq-backend#618: `GET /api/products/:codigoMarket/meta`).

## Qué cambia
- **`seo-utils.buildProductMetadata(key)`** — fuente única para las 3 rutas PDP. Lee `/api/products/:key/meta` + override de `product_seo` (precedencia **override > catálogo**), emite OG completo + **`product:*`** (`price`, `currency=COP`, `availability`, `retailer_item_id`=SKU, `brand`, `condition`) vía `other` (determinístico, alimenta el catálogo de Meta), `og:image` 1200×630. + `buildItemListJsonLd`, **SearchAction** en WebSite, `gtin13`(EAN)+`itemCondition` en Product JSON-LD.
- **PDP**: layouts server nuevos en `multimedia` y `viewpremium`; `view` refactor al helper. JSON-LD `Product`+`BreadcrumbList` (`ProductStructuredData`). **Canonical único** `/productos/view/{codigoMarket}` en las 3 variantes.
- **OG image branded dinámica** en `/og/product/[codigoMarket]` (next/og, 1200×630: foto + nombre + precio + Samsung Store). El override manual del dashboard manda; fallback a la foto real.
- **Categoría**: `ItemList` JSON-LD (best-effort). **Home**: `WebSite`+`SearchAction` + `Organization`. `<html lang="es-CO">`. **sitemap**: URLs de producto.
- **`scripts/seo-coverage.ts`**: verifica cobertura **100%** (OG product-specific + `product:price:amount` + imagen 200) y lista fallbacks. Reemplaza el backfill en DB (sin congelar precio/título).

## Verificación
- `tsc --noEmit` limpio; `next build` OK (rutas PDP y `/og/product/[codigoMarket]` ahora server-rendered).
- Tras deploy: Facebook Sharing Debugger sobre una `/multimedia/...`, Google Rich Results Test (Product+Breadcrumb), `bun scripts/seo-coverage.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)