### PR TITLE
fix(seo): clean white background on dynamic OG image

### DIFF
--- a/src/app/og/product/[codigoMarket]/route.tsx
+++ b/src/app/og/product/[codigoMarket]/route.tsx
@@ -78,7 +78,8 @@ export async function GET(
           fontFamily: "sans-serif",
         }}
       >
-        {/* Left: product photo on white */}
+        {/* Left: product photo on a clean white panel (matches the right side,
+            no visible "background" — Samsung-style). */}
         <div
           style={{
             width: "560px",
@@ -86,7 +87,7 @@ export async function GET(
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            backgroundColor: "#f4f6fb",
+            backgroundColor: "#ffffff",
           }}
         >
           {photo ? (


### PR DESCRIPTION
La foto del producto en la imagen OG estaba sobre un panel gris-azulado (#f4f6fb) → se veía como 'fondo' al compartir. Ahora blanco uniforme (#ffffff), estilo Samsung. 🤖 Generated with [Claude Code](https://claude.com/claude-code)