### PR TITLE
fix(payments): enviar IP real del cliente (x-imagiq-client-ip)

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -7,6 +7,8 @@
  * - Bearer Token (Authorization): Autenticación del usuario (desde localStorage)
  */
 
+import { getCachedClientIp, primeClientIp } from "@/lib/client-ip";
+
 // Browser: use relative URLs so requests go through Next.js rewrites.
 // Server (SSR): use the full backend URL since relative URLs don't work.
 // We use a non-NEXT_PUBLIC_ env var for server-side to avoid Turbopack inlining.
@@ -57,6 +59,18 @@ export async function apiClient(
     ...(authToken && { Authorization: `Bearer ${authToken}` }),
     ...options.headers,
   });
+
+  // IP real del cliente para flujos de pago / orden. Las peticiones van por el
+  // rewrite de Vercel, así que el backend no puede ver la IP del navegador en
+  // x-forwarded-for (ve la de Vercel/AWS). Enviamos la IP pública obtenida vía
+  // ipify en un header dedicado que el gateway prioriza. Ver lib/client-ip.ts.
+  if (typeof window !== "undefined") {
+    void primeClientIp(); // resuelve y cachea una sola vez por sesión
+    if (/^\/api\/(payments|orders)\b/.test(endpoint)) {
+      const clientIp = getCachedClientIp();
+      if (clientIp) headers.set("x-imagiq-client-ip", clientIp);
+    }
+  }
 
   try {
     const response = await fetch(url, {

--- a/src/lib/client-ip.ts
+++ b/src/lib/client-ip.ts
@@ -1,0 +1,80 @@
+/**
+ * Captura de la IP pública REAL del cliente.
+ *
+ * Problema: el frontend sirve `/api/*` vía rewrite de Next.js, así que las
+ * peticiones llegan al backend proxeadas por la infraestructura de Vercel
+ * (AWS us-east-1). El gateway solo ve la IP de egreso de Vercel en
+ * `x-forwarded-for`, no la del navegador del cliente. Por eso las órdenes
+ * quedaban con `client_ip` = IP de Vercel (Ashburn, Virginia) y la
+ * geolocalización de las alertas / ePayco / Meta CAPI era inservible.
+ *
+ * Solución: el navegador consulta su propia IP pública (ipify, ya permitido en
+ * el CSP) y la adjunta como header `x-imagiq-client-ip` en las peticiones de
+ * pago. Ese header sí sobrevive el rewrite y el gateway lo prioriza.
+ *
+ * La IP se cachea en memoria + sessionStorage para no consultar ipify en cada
+ * request. Es best-effort: si ipify falla, no se envía el header y el backend
+ * cae a su comportamiento anterior.
+ */
+
+const STORAGE_KEY = "imagiq_client_ip";
+const IPIFY_URL = "https://api.ipify.org?format=json";
+
+let cachedIp: string | null = null;
+let inFlight: Promise<string | null> | null = null;
+
+/**
+ * Devuelve la IP cacheada de forma síncrona (memoria o sessionStorage), o null
+ * si aún no se ha resuelto. No dispara ninguna petición.
+ */
+export function getCachedClientIp(): string | null {
+  if (cachedIp) return cachedIp;
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      cachedIp = stored;
+      return stored;
+    }
+  } catch {
+    // sessionStorage no disponible (modo privado, etc.) — se ignora.
+  }
+  return null;
+}
+
+/**
+ * Resuelve y cachea la IP pública del cliente. Idempotente: una sola petición
+ * a ipify por sesión; las llamadas concurrentes comparten la misma promesa.
+ * Conviene invocarla temprano (p. ej. al entrar al checkout) para que la IP
+ * esté lista antes de pagar.
+ */
+export function primeClientIp(): Promise<string | null> {
+  if (cachedIp) return Promise.resolve(cachedIp);
+  if (typeof window === "undefined") return Promise.resolve(null);
+
+  const stored = getCachedClientIp();
+  if (stored) return Promise.resolve(stored);
+
+  if (inFlight) return inFlight;
+
+  inFlight = fetch(IPIFY_URL, { cache: "no-store" })
+    .then((res) => (res.ok ? res.json() : null))
+    .then((data: { ip?: string } | null) => {
+      const ip = typeof data?.ip === "string" ? data.ip.trim() : null;
+      if (ip) {
+        cachedIp = ip;
+        try {
+          sessionStorage.setItem(STORAGE_KEY, ip);
+        } catch {
+          // se ignora
+        }
+      }
+      return ip;
+    })
+    .catch(() => null)
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return inFlight;
+}


### PR DESCRIPTION
## Problema

Las peticiones de pago/orden salen por el *rewrite* `/api/*` de Next.js, así que llegan al backend **proxeadas por Vercel (AWS us-east-1)**. El gateway solo ve la IP de egreso de Vercel, nunca la del cliente. Resultado: la `Ubicación IP` de las alertas **PAGO RECHAZADO** siempre sale "Ashburn, Virginia · AWS EC2", y lo mismo afecta el payload a ePayco y `client_ip_address` de Meta CAPI.

## Solución

- Nuevo `src/lib/client-ip.ts`: obtiene la IP pública del navegador vía **ipify** (ya permitido en el CSP), cacheada en memoria + `sessionStorage` (una sola consulta por sesión, *best-effort*).
- `apiClient` la *primea* en la primera llamada al API y adjunta el header **`x-imagiq-client-ip`** únicamente en endpoints `/api/payments` y `/api/orders`. El header sobrevive el rewrite y el gateway lo prioriza.
- Si ipify falla, el header simplemente no se manda y el backend cae a su comportamiento anterior.

`getClientIP()` del emitter de Meta CAPI seguía siendo un stub (`0.0.0.0`); este fix corrige la IP de CAPI por la vía del backend (que ahora recibe la IP real).

## Requiere
PR de backend que lee el header `x-imagiq-client-ip` con prioridad: Davases22/imagiq-backend#620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)