### PR TITLE
fix(seo): valid Facebook og:locale es_LA (was es_CO → invalid OG object)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -88,7 +88,10 @@ export async function generateMetadata(): Promise<Metadata> {
     },
     openGraph: {
       type: "website",
-      locale: "es_CO",
+      // Facebook usa su propio enum de locales: español de Latinoamérica es
+      // es_LA (es_CO NO es válido e invalida todo el objeto OG). El <html lang>
+      // sí usa es-CO (BCP-47 para Google/hreflang).
+      locale: "es_LA",
       url: s.site_url,
       siteName: s.site_name,
       title: s.default_title,

--- a/src/lib/seo-utils.ts
+++ b/src/lib/seo-utils.ts
@@ -314,7 +314,9 @@ export async function buildProductMetadata(
       title: ogTitle,
       description: ogDescription,
       siteName: "Samsung Store",
-      locale: "es_CO",
+      // es_LA = locale de Facebook para LatAm (es_CO no es válido e invalida el
+      // objeto OG, lo que bloqueaba fb:app_id). El <html lang> usa es-CO.
+      locale: "es_LA",
       images: [
         { url: ogImage, width: 1200, height: 630, alt: meta.name },
       ],


### PR DESCRIPTION
Causa raíz del warning persistente: `og:locale=es_CO` no es un locale válido de Facebook → FB invalidaba todo el objeto OG → no registraba fb:app_id. Se cambia a `es_LA` (español LatAm). `<html lang=es-CO>` se mantiene (Google). 🤖 Generated with [Claude Code](https://claude.com/claude-code)