### PR TITLE
release: slash-free product slug (AV/DA social previews)

### DIFF
--- a/src/app/productos/components/ProductCard.tsx
+++ b/src/app/productos/components/ProductCard.tsx
@@ -515,8 +515,9 @@ export default function ProductCard({
       closeChat();
     }
 
-    // Navega primero a la página multimedia con contenido Flixmedia
-    router.push(`/productos/multimedia/${id}`);
+    // Navega primero a la página multimedia con contenido Flixmedia.
+    // Slug sin slash: codigoMarket de AV/DA trae '/' y rompe el route de Next.
+    router.push(`/productos/multimedia/${String(id).split("/")[0]}`);
     posthogUtils.capture("product_more_info_click", {
       product_id: id,
       product_name: name,

--- a/src/app/productos/electrodomesticos/components/CardExplore.tsx
+++ b/src/app/productos/electrodomesticos/components/CardExplore.tsx
@@ -48,8 +48,8 @@ export default function CardExplore({
   const handleMoreInfo = () => {
     console.log(`🔗 Navegando a producto con ID: ${id}`);
     console.log(`📝 Nombre del producto: ${name}`);
-    // Navega primero a la página multimedia
-    router.push(`/productos/multimedia/${id}`);
+    // Navega primero a la página multimedia (slug sin slash: AV/DA traen '/').
+    router.push(`/productos/multimedia/${String(id).split("/")[0]}`);
     posthogUtils.capture("product_more_info_click", {
       product_id: id,
       product_name: name,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -78,10 +78,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const productPages: MetadataRoute.Sitemap = [];
   for (const p of catalogArr) {
     const cm = String(p?.codigoMarket || p?.codigo_market || '').trim();
-    if (!cm || seenCm.has(cm)) continue;
-    seenCm.add(cm);
+    // Slug sin slash (codigoMarket de AV/DA trae '/'): el base resuelve igual y
+    // evita %2F en la URL. Dedup por base.
+    const slug = cm.split('/')[0].trim();
+    if (!slug || seenCm.has(slug)) continue;
+    seenCm.add(slug);
     productPages.push({
-      url: `${baseUrl}/productos/view/${encodeURIComponent(cm)}`,
+      url: `${baseUrl}/productos/view/${encodeURIComponent(slug)}`,
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 0.7,

--- a/src/lib/seo-utils.ts
+++ b/src/lib/seo-utils.ts
@@ -246,16 +246,25 @@ export async function fetchProductSeoOverride(
   }
 }
 
+/** Slug de URL de producto SIN slash. Muchos codigoMarket de AV/DA traen '/'
+ * (ej. "HW-B400F/ZL"); un '/' en el path se vuelve %2F y rompe el match del
+ * segmento [id] de Next → metadata genérica. El base (parte antes del '/')
+ * resuelve igual en el backend (getProductMeta y filtered aceptan codigo_market_base)
+ * y se usa de forma consistente en canónico, og:image, feed y sitemap. */
+export function productSlug(codigoMarket: string): string {
+  return (codigoMarket || "").split("/")[0].trim();
+}
+
 /** URL of the dynamic branded OG image (next/og route). Lives OUTSIDE `/api/*`
  * because next.config rewrites `/api/*` to the backend, which would shadow it. */
 export function productOgImageUrl(codigoMarket: string): string {
-  return `${SITE_URL}/og/product/${encodeURIComponent(codigoMarket)}`;
+  return `${SITE_URL}/og/product/${encodeURIComponent(productSlug(codigoMarket))}`;
 }
 
-/** Canonical product URL — one per product group, regardless of which PDP
- * variant route (view/multimedia/viewpremium) the user landed on. */
+/** Canonical product URL — one per product group (slug sin slash), regardless of
+ * which PDP variant route (view/multimedia/viewpremium) the user landed on. */
 export function productCanonicalUrl(codigoMarket: string): string {
-  return `${SITE_URL}/productos/view/${encodeURIComponent(codigoMarket)}`;
+  return `${SITE_URL}/productos/view/${encodeURIComponent(productSlug(codigoMarket))}`;
 }
 
 /**


### PR DESCRIPTION
Promueve #1012 (slug sin slash para AV/DA). 🤖 Generated with [Claude Code](https://claude.com/claude-code)