### PR TITLE
feat(search-history): recent-searches dropdown + search logging

### DIFF
--- a/src/components/navbar/components/SearchBar.tsx
+++ b/src/components/navbar/components/SearchBar.tsx
@@ -1,5 +1,14 @@
-import { Search } from "lucide-react";
-import type { FC, FormEvent } from "react";
+"use client";
+
+import { Search, X, Clock } from "lucide-react";
+import { useEffect, useRef, useState, type FC, type FormEvent } from "react";
+import {
+  getRecentSearches,
+  removeRecentSearch,
+  clearRecentSearches,
+  recordSearch,
+  type RecentSearch,
+} from "@/lib/searchHistory";
 
 type Props = {
   value: string;
@@ -7,24 +16,117 @@ type Props = {
   onSubmit: (e: FormEvent) => void;
 };
 
-export const SearchBar: FC<Props> = ({ value, onChange, onSubmit }) => (
-  <form
-    onSubmit={onSubmit}
-    className="relative flex items-center rounded-full px-5 h-14 lg:px-4 lg:h-10 transition-all duration-300 w-full lg:w-[200px] xl:w-[220px] 2xl:w-[260px] backdrop-blur-md border border-gray-200 bg-white shadow-md"
-    style={{
-      overflow: "hidden",
-      boxShadow: "0 2px 8px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.06)"
-    }}
-  >
-    <Search className="w-5 h-5 mr-3 text-gray-500" />
-    <input
-      type="text"
-      className="w-full bg-transparent border-none focus:outline-none text-[15px] text-gray-900 placeholder-gray-400 font-medium"
-      placeholder="Búsqueda"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      aria-label="Buscar productos"
-      autoComplete="off"
-    />
-  </form>
-);
+export const SearchBar: FC<Props> = ({ value, onChange, onSubmit }) => {
+  const [focused, setFocused] = useState(false);
+  const [recent, setRecent] = useState<RecentSearch[]>([]);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Lee localStorage fresco cada vez que se abre el dropdown.
+  const refreshRecent = () => setRecent(getRecentSearches());
+
+  // Cerrar al hacer click fuera.
+  useEffect(() => {
+    if (!focused) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setFocused(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [focused]);
+
+  // Mostrar recientes solo cuando el input está vacío y hay historial.
+  const showDropdown = focused && value.trim().length === 0 && recent.length > 0;
+
+  const goToSearch = (query: string) => {
+    const q = query.trim();
+    if (!q) return;
+    recordSearch(q, { source: "recent" });
+    setFocused(false);
+    window.location.href = `/productos?q=${encodeURIComponent(q)}`;
+  };
+
+  return (
+    <div
+      ref={wrapperRef}
+      className="relative w-full lg:w-[200px] xl:w-[220px] 2xl:w-[260px]"
+    >
+      <form
+        onSubmit={onSubmit}
+        className="relative flex items-center rounded-full px-5 h-14 lg:px-4 lg:h-10 transition-all duration-300 w-full backdrop-blur-md border border-gray-200 bg-white shadow-md"
+        style={{
+          overflow: "hidden",
+          boxShadow:
+            "0 2px 8px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.06)",
+        }}
+      >
+        <Search className="w-5 h-5 mr-3 text-gray-500" />
+        <input
+          type="text"
+          className="w-full bg-transparent border-none focus:outline-none text-[15px] text-gray-900 placeholder-gray-400 font-medium"
+          placeholder="Búsqueda"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={() => {
+            refreshRecent();
+            setFocused(true);
+          }}
+          aria-label="Buscar productos"
+          autoComplete="off"
+        />
+      </form>
+
+      {showDropdown && (
+        <div className="absolute z-50 left-0 right-0 mt-2 rounded-2xl border border-gray-200 bg-white shadow-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 pt-3 pb-1">
+            <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+              Búsquedas recientes
+            </span>
+            <button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                clearRecentSearches();
+                refreshRecent();
+              }}
+              className="text-xs font-medium text-[#0066CC] hover:underline"
+            >
+              Borrar todo
+            </button>
+          </div>
+          <ul className="py-1 max-h-72 overflow-y-auto">
+            {recent.map((r) => (
+              <li
+                key={`${r.query}-${r.ts}`}
+                className="group flex items-center justify-between px-4 py-2 hover:bg-gray-50 cursor-pointer"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => goToSearch(r.query)}
+              >
+                <span className="flex items-center gap-3 min-w-0">
+                  <Clock className="w-4 h-4 text-gray-400 shrink-0" />
+                  <span className="truncate text-[14px] text-gray-800">
+                    {r.query}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Eliminar ${r.query}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeRecentSearch(r.query);
+                    refreshRecent();
+                  }}
+                  className="ml-2 p-1 rounded-full text-gray-400 hover:text-gray-700 hover:bg-gray-200 opacity-0 group-hover:opacity-100 transition-opacity"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/auth/context.tsx
+++ b/src/features/auth/context.tsx
@@ -20,6 +20,7 @@ import { apiClient } from "@/lib/api";
 import { User } from "@/types/user";
 import { addressesService } from "@/services/addresses.service";
 import { setPosthogUserId, posthogUtils } from "@/lib/posthogClient";
+import { mergeSearchHistoryOnLogin } from "@/lib/searchHistory";
 
 interface AuthContextType {
   user: User | null;
@@ -183,6 +184,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       telefono: userData.telefono,
       role: userRole,
     });
+
+    // Merge del historial de búsqueda anónimo → usuario (reasigna las búsquedas
+    // pre-login al usuario; espejo del identify() de PostHog). Best-effort.
+    mergeSearchHistoryOnLogin(userData.id);
 
     // ✅ NUEVO: Cargar dirección predeterminada del usuario
     try {

--- a/src/hooks/navbarLogic.ts
+++ b/src/hooks/navbarLogic.ts
@@ -5,6 +5,7 @@ import { useCartContext } from "@/features/cart/CartContext";
 import { useNavbarVisibility } from "@/features/layout/NavbarVisibilityContext";
 import { useDebounce } from "@/hooks/useDebounce";
 import { posthogUtils } from "@/lib/posthogClient";
+import { recordSearch } from "@/lib/searchHistory";
 import { navbarRoutes } from "@/routes/navbarRoutes";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -268,6 +269,12 @@ export function useNavbarLogic() {
         query: searchQuery.trim(),
         source: "navbar",
         results_count: searchResults.length,
+      });
+      // Historial: recientes en localStorage (UX) + log al backend (data de
+      // demanda). Best-effort, no bloquea la navegación.
+      recordSearch(searchQuery.trim(), {
+        resultCount: searchResults.length,
+        source: "navbar",
       });
       window.location.href = `/productos?q=${encodeURIComponent(
         searchQuery.trim()

--- a/src/lib/searchHistory.ts
+++ b/src/lib/searchHistory.ts
@@ -1,0 +1,139 @@
+/**
+ * Historial de búsqueda del buscador del sitio.
+ *
+ * - UX: "búsquedas recientes" en localStorage (instantáneo, anónimo y logueado),
+ *   normalizado, capado y deduplicado por recencia — patrón de Algolia/Segment.
+ * - Data: cada búsqueda se loguea al backend (best-effort) para la analítica de
+ *   demanda y el "SEO privado" futuro; anónimas con el posthog distinct_id,
+ *   logueadas con el user_id. Al iniciar sesión se hace merge anónimo→usuario.
+ */
+import posthog from "posthog-js";
+import { apiPost } from "@/lib/api-client";
+
+const RECENT_KEY = "imagiq_search_history";
+const MAX_RECENT = 10;
+
+export interface RecentSearch {
+  query: string; // texto mostrado (raw)
+  ts: number; // timestamp
+}
+
+function normalize(raw: string): string {
+  return (raw || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// ───────────────────────── localStorage (UX) ─────────────────────────
+
+export function getRecentSearches(): RecentSearch[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    const arr = raw ? (JSON.parse(raw) as RecentSearch[]) : [];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function setRecentSearches(items: RecentSearch[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(items.slice(0, MAX_RECENT)));
+  } catch {
+    /* storage lleno / bloqueado: no-op */
+  }
+}
+
+/** Agrega (o sube por recencia) una búsqueda al historial local, dedup por
+ * texto normalizado, capado a MAX_RECENT. */
+export function addRecentSearch(query: string): void {
+  const q = (query || "").trim();
+  const norm = normalize(q);
+  if (!norm) return;
+  const existing = getRecentSearches().filter((r) => normalize(r.query) !== norm);
+  setRecentSearches([{ query: q, ts: Date.now() }, ...existing]);
+}
+
+export function removeRecentSearch(query: string): void {
+  const norm = normalize(query);
+  setRecentSearches(getRecentSearches().filter((r) => normalize(r.query) !== norm));
+}
+
+export function clearRecentSearches(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(RECENT_KEY);
+  } catch {
+    /* no-op */
+  }
+}
+
+// ───────────────────────── backend (data) ─────────────────────────
+
+function getUserId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem("imagiq_user");
+    if (!raw) return null;
+    const u = JSON.parse(raw) as { id?: string };
+    return u?.id || null;
+  } catch {
+    return null;
+  }
+}
+
+function getAnonId(): string | null {
+  try {
+    if (typeof window !== "undefined" && posthog.__loaded) {
+      return posthog.get_distinct_id?.() || null;
+    }
+  } catch {
+    /* posthog no listo */
+  }
+  return null;
+}
+
+/** Loguea la búsqueda al backend (fire-and-forget, nunca lanza). */
+export function logSearchToServer(opts: {
+  query: string;
+  resultCount?: number;
+  clickedProductId?: string;
+  categoryContext?: string;
+  source?: string;
+}): void {
+  const query = (opts.query || "").trim();
+  if (!query) return;
+  const userId = getUserId();
+  void apiPost("/api/search-history", {
+    query,
+    userId,
+    anonymousId: userId ? null : getAnonId(),
+    resultCount: opts.resultCount,
+    clickedProductId: opts.clickedProductId,
+    categoryContext: opts.categoryContext,
+    source: opts.source ?? "navbar",
+  }).catch(() => {
+    /* best-effort: no romper el buscador */
+  });
+}
+
+/** Atajo: registra una búsqueda (UX local + data backend) en un solo lugar. */
+export function recordSearch(query: string, opts?: { resultCount?: number; source?: string }): void {
+  addRecentSearch(query);
+  logSearchToServer({ query, resultCount: opts?.resultCount, source: opts?.source });
+}
+
+/** Merge anónimo→usuario al iniciar sesión: reasigna las búsquedas anónimas
+ * (mismo posthog distinct_id) a la cuenta. Llamar tras el login. */
+export function mergeSearchHistoryOnLogin(userId: string): void {
+  const anonymousId = getAnonId();
+  if (!userId || !anonymousId) return;
+  void apiPost("/api/search-history/merge", { userId, anonymousId }).catch(() => {
+    /* best-effort */
+  });
+}


### PR DESCRIPTION
Frontend de la feature de historial de búsqueda (requiere backend #624).

- **UX**: dropdown de búsquedas recientes en el `SearchBar` (localStorage, click para buscar, borrar individual / borrar todo). Capado 10, normalizado, dedup por recencia.
- **Data**: cada búsqueda se loguea a `/api/search-history` (anon con posthog distinct_id, logueada con user_id). Best-effort.
- **Merge**: al login se reasignan las búsquedas anónimas al usuario.

`tsc` + `next build` limpios. Backend ya verificado en prod (log→list round-trip OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)