### PR TITLE
fix(analytics): dedup Meta Purchase + reliable COP value + consistent external_id

### DIFF
--- a/src/app/success-checkout/[orderId]/page.tsx
+++ b/src/app/success-checkout/[orderId]/page.tsx
@@ -152,11 +152,22 @@ export default function SuccessCheckoutPage({
           const orderData = orderResponse.data;
           const items = orderData.order_items || [];
 
-          // Calcular el valor total usando precios reales
-          const totalValue = orderData.total_amount || items.reduce(
-            (sum, item) => sum + (Number(item.unit_price || item.precio) || 0) * (item.quantity || item.cantidad || 1),
-            0
-          );
+          // Valor total REAL de la orden, en unidades COP y SIEMPRE numérico.
+          // `total_amount` puede llegar como string (numeric de pg, p.ej.
+          // "1699900.00"); Number() lo normaliza. Solo si falta/es 0 caemos a la
+          // suma de líneas. Un valor no numérico rompía el píxel y el CAPI
+          // (guard `typeof === 'number'`) → Purchase sin precio.
+          const parsedTotal = Number(orderData.total_amount);
+          const totalValue =
+            Number.isFinite(parsedTotal) && parsedTotal > 0
+              ? parsedTotal
+              : items.reduce(
+                  (sum, item) =>
+                    sum +
+                    (Number(item.unit_price || item.precio) || 0) *
+                      (item.quantity || item.cantidad || 1),
+                  0
+                );
 
           const mappedItems = items.map((item) => ({
             item_id: item.sku || "unknown",

--- a/src/lib/analytics/controller.ts
+++ b/src/lib/analytics/controller.ts
@@ -22,6 +22,10 @@ import { generateEventIdForEvent, handleAbandonTracking } from './helpers/event-
  * Interfaz unificada para datos de usuario en analytics
  */
 export interface AnalyticsUserData {
+  /** ID interno del usuario (usuarios.id). Se usa como `external_id` en Meta,
+   *  idéntico al que envía el server-side (payments-ms usa order.usuario_id),
+   *  para que cliente y servidor compartan el mismo identificador. */
+  id?: string;
   email?: string;
   phone?: string;
   firstName?: string;

--- a/src/lib/analytics/emitters/emit.meta-capi.ts
+++ b/src/lib/analytics/emitters/emit.meta-capi.ts
@@ -137,7 +137,13 @@ async function buildFullUserData(
     client_user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
     fbp: fbp ?? undefined,
     fbc: fbc ?? undefined,
-    external_id: userData?.email ? await hashSingleValue(userData.email) : undefined,
+    // external_id: preferimos el usuario_id en crudo (idéntico al server-side)
+    // y caemos al email hasheado solo si no hay id. Consistencia cliente/servidor.
+    external_id: userData?.id
+      ? userData.id
+      : userData?.email
+        ? await hashSingleValue(userData.email)
+        : undefined,
   };
 }
 

--- a/src/lib/analytics/helpers/event-processing.ts
+++ b/src/lib/analytics/helpers/event-processing.ts
@@ -37,6 +37,14 @@ export async function generateEventIdForEvent(event: DlAny): Promise<string> {
     }
   }
 
+  // Purchase: event_id DETERMINISTA por orden (no depende de ts/value), idéntico
+  // al que dispara el servidor en Meta CAPI (`purchase_${orderId}` en payments-ms)
+  // y a `$insert_id` de PostHog. Sin esto, el píxel del browser usaba un hash con
+  // Date.now() y nunca deduplicaba contra el evento server-side → Purchase doble.
+  if (eventName === 'purchase' && transactionId) {
+    return `purchase_${transactionId}`;
+  }
+
   return generateEventId(eventName, ts, items, transactionId, value);
 }
 

--- a/src/lib/analytics/hooks/useAnalyticsWithUser.ts
+++ b/src/lib/analytics/hooks/useAnalyticsWithUser.ts
@@ -41,6 +41,7 @@ export function useAnalyticsWithUser() {
     if (!isAuthenticated || !user) return undefined;
 
     return {
+      id: user.id,
       email: user.email,
       phone: user.telefono,
       firstName: user.nombre,


### PR DESCRIPTION
## Problem
Meta **Purchase** reports *"envía precios no válidos"* (~67%) and *"todos el mismo precio"*. Root cause on the client:

- The browser pixel + client CAPI computed `event_id = SHA256(purchase|Date.now()|skus|orderId|value)`, while the server-side CAPI uses `purchase_${orderId}`. **They never deduplicated** → Meta double-counted Purchase, and a 0/empty browser value was counted *separately* from the correct server value.
- `success-checkout` used `orderData.total_amount || items.reduce(...)`. `total_amount` arrives as a pg `numeric` **string**; a non-number broke the value path. Empirically (PostHog) order `purchase_f2b6aabb…` sent **client `value=0` while the server sent the real `1,099,800`**.

## Changes
- **Dedup (the core fix):** `generateEventIdForEvent()` now returns `purchase_${transactionId}` for the `purchase` event — deterministic, identical to the server CAPI and PostHog `$insert_id`. Browser pixel + client CAPI + server CAPI collapse into **one** Purchase.
- **Value:** `success-checkout` coerces `total_amount` with `Number()` (COP units, e.g. `1699900`) and only falls back to the line-sum when it's missing/0/`NaN` — so the pixel, the client CAPI (`typeof value === 'number'` guard) and PostHog all get a finite amount.
- **EMQ:** `external_id` now uses the raw `usuario_id` (`AnalyticsUserData.id ← user.id`), matching the server-side `external_id` (`order.usuario_id`) for consistent identity.

## Verification
- `tsc --noEmit`: no new errors in touched files (pre-existing `@/img/*` asset-typing errors on `develop` are unrelated).
- Redirect payments (ePayco/Addi) already land on `/success-checkout/[orderId]` and the approval webhook fires the server CAPI — they now dedup correctly.

## Companion / follow-up
- Backend PR (`imagiq-backend` → `main`, #625): server-side `value` units guard + Advanced Matching (`fn/ln/ct/country`) + controller forwarding of hashed AM fields. Adds the value-units regression test.
- **Manual action:** enable **Automatic Advanced Matching** in Meta Events Manager.
- Funnel-event EMQ (ViewContent/AddToCart/InitiateCheckout advanced matching) is a separate fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)