### PR TITLE
Promote develop→main: Meta Purchase value/dedup/EMQ fix (#1016)

### DIFF
--- a/src/app/success-checkout/[orderId]/page.tsx
+++ b/src/app/success-checkout/[orderId]/page.tsx
@@ -152,11 +152,22 @@ export default function SuccessCheckoutPage({
           const orderData = orderResponse.data;
           const items = orderData.order_items || [];
 
-          // Calcular el valor total usando precios reales
-          const totalValue = orderData.total_amount || items.reduce(
-            (sum, item) => sum + (Number(item.unit_price || item.precio) || 0) * (item.quantity || item.cantidad || 1),
-            0
-          );
+          // Valor total REAL de la orden, en unidades COP y SIEMPRE numérico.
+          // `total_amount` puede llegar como string (numeric de pg, p.ej.
+          // "1699900.00"); Number() lo normaliza. Solo si falta/es 0 caemos a la
+          // suma de líneas. Un valor no numérico rompía el píxel y el CAPI
+          // (guard `typeof === 'number'`) → Purchase sin precio.
+          const parsedTotal = Number(orderData.total_amount);
+          const totalValue =
+            Number.isFinite(parsedTotal) && parsedTotal > 0
+              ? parsedTotal
+              : items.reduce(
+                  (sum, item) =>
+                    sum +
+                    (Number(item.unit_price || item.precio) || 0) *
+                      (item.quantity || item.cantidad || 1),
+                  0
+                );
 
           const mappedItems = items.map((item) => ({
             item_id: item.sku || "unknown",

--- a/src/lib/analytics/controller.ts
+++ b/src/lib/analytics/controller.ts
@@ -22,6 +22,10 @@ import { generateEventIdForEvent, handleAbandonTracking } from './helpers/event-
  * Interfaz unificada para datos de usuario en analytics
  */
 export interface AnalyticsUserData {
+  /** ID interno del usuario (usuarios.id). Se usa como `external_id` en Meta,
+   *  idéntico al que envía el server-side (payments-ms usa order.usuario_id),
+   *  para que cliente y servidor compartan el mismo identificador. */
+  id?: string;
   email?: string;
   phone?: string;
   firstName?: string;

--- a/src/lib/analytics/emitters/emit.meta-capi.ts
+++ b/src/lib/analytics/emitters/emit.meta-capi.ts
@@ -137,7 +137,13 @@ async function buildFullUserData(
     client_user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
     fbp: fbp ?? undefined,
     fbc: fbc ?? undefined,
-    external_id: userData?.email ? await hashSingleValue(userData.email) : undefined,
+    // external_id: preferimos el usuario_id en crudo (idéntico al server-side)
+    // y caemos al email hasheado solo si no hay id. Consistencia cliente/servidor.
+    external_id: userData?.id
+      ? userData.id
+      : userData?.email
+        ? await hashSingleValue(userData.email)
+        : undefined,
   };
 }
 

--- a/src/lib/analytics/helpers/event-processing.ts
+++ b/src/lib/analytics/helpers/event-processing.ts
@@ -37,6 +37,14 @@ export async function generateEventIdForEvent(event: DlAny): Promise<string> {
     }
   }
 
+  // Purchase: event_id DETERMINISTA por orden (no depende de ts/value), idéntico
+  // al que dispara el servidor en Meta CAPI (`purchase_${orderId}` en payments-ms)
+  // y a `$insert_id` de PostHog. Sin esto, el píxel del browser usaba un hash con
+  // Date.now() y nunca deduplicaba contra el evento server-side → Purchase doble.
+  if (eventName === 'purchase' && transactionId) {
+    return `purchase_${transactionId}`;
+  }
+
   return generateEventId(eventName, ts, items, transactionId, value);
 }
 

--- a/src/lib/analytics/hooks/useAnalyticsWithUser.ts
+++ b/src/lib/analytics/hooks/useAnalyticsWithUser.ts
@@ -41,6 +41,7 @@ export function useAnalyticsWithUser() {
     if (!isAuthenticated || !user) return undefined;
 
     return {
+      id: user.id,
       email: user.email,
       phone: user.telefono,
       firstName: user.nombre,


### PR DESCRIPTION
Promotes the Meta Purchase fix to production (Vercel).

Ships only #1016: aligns the browser Purchase `event_id` to `purchase_${orderId}` (dedup with server-side CAPI), makes the success-page `value` a reliable COP number, and unifies `external_id` with the server.

Pairs with backend #625 (already merged to `imagiq-backend` main → Railway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)