### PR TITLE
fix(analytics): funnel-event advanced matching (ViewContent/AddToCart/InitiateCheckout/Search) for EMQ

### DIFF
--- a/src/app/productos/view/[id]/page.tsx
+++ b/src/app/productos/view/[id]/page.tsx
@@ -16,7 +16,7 @@ import ProductDetailSkeleton from "@/app/productos/dispositivos-moviles/detalles
 import AddToCartButton from "../../viewpremium/components/AddToCartButton";
 import StockNotificationModal from "@/components/StockNotificationModal";
 import { useStockNotification } from "@/hooks/useStockNotification";
-import { useAnalytics } from "@/lib/analytics/hooks/useAnalytics";
+import { useAnalyticsWithUser } from "@/lib/analytics";
 import { useTradeInPrefetch } from "@/hooks/useTradeInPrefetch";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import QuickNavBar from "../../viewpremium/[id]/components/QuickNavBar";
@@ -208,7 +208,7 @@ export default function ProductViewPage({ params }) {
   const [shouldRedirectToPremium, setShouldRedirectToPremium] = React.useState(false);
   const [premiumCheckDone, setPremiumCheckDone] = React.useState(false);
   const stockNotification = useStockNotification();
-  const { trackViewItem } = useAnalytics();
+  const { trackViewItem } = useAnalyticsWithUser();
 
   // Hook para manejo inteligente de selección de productos - compartido entre componentes
   const productSelection = useProductSelection(

--- a/src/app/productos/viewpremium/[id]/page.tsx
+++ b/src/app/productos/viewpremium/[id]/page.tsx
@@ -14,7 +14,7 @@ import fallbackImage from "@/img/dispositivosmoviles/cel1.png";
 import StockNotificationModal from "@/components/StockNotificationModal";
 import { useStockNotification } from "@/hooks/useStockNotification";
 import { useTradeInPrefetch } from "@/hooks/useTradeInPrefetch";
-import { useAnalytics } from "@/lib/analytics/hooks/useAnalytics";
+import { useAnalyticsWithUser } from "@/lib/analytics";
 
 // Componentes
 import ProductCarousel from "../components/ProductCarousel";
@@ -118,7 +118,7 @@ export default function ProductViewPage({ params }) {
 
   // ViewContent se dispara más abajo, cuando productSelection ya resolvió el
   // precio/SKU de la variante (el API premium NO expone product.price).
-  const { trackViewItem } = useAnalytics();
+  const { trackViewItem } = useAnalyticsWithUser();
   const viewContentFiredRef = React.useRef<string | null>(null);
 
   const [showContent, setShowContent] = React.useState(false);

--- a/src/hooks/navbarLogic.ts
+++ b/src/hooks/navbarLogic.ts
@@ -17,7 +17,7 @@ import {
   useState,
 } from "react";
 import { useFavorites } from "@/features/products/useProducts";
-import { useAnalytics } from "@/lib/analytics/hooks/useAnalytics";
+import { useAnalyticsWithUser } from "@/lib/analytics";
 
 // Tipo para resultados de búsqueda
 export interface SearchResult {
@@ -50,7 +50,7 @@ export function useNavbarLogic() {
   const isMultimedia = pathname?.startsWith("/productos/multimedia") ?? false; // ¿Está en multimedia?
   const debouncedSearch = useDebounce(searchQuery, 300); // Query de búsqueda con debounce
   const { cart: cartItems, itemCount } = useCartContext();
-  const { trackSearch, trackCategoryClick } = useAnalytics();
+  const { trackSearch, trackCategoryClick } = useAnalyticsWithUser();
   // Derivar cartCount con useMemo para evitar stale closures
   // Usa itemCount como fuente de verdad para garantizar sincronización con el estado global del carrito
   const cartCount = useMemo(() => {

--- a/src/lib/analytics/controller.ts
+++ b/src/lib/analytics/controller.ts
@@ -12,9 +12,10 @@
 import type { DlAny } from './types';
 import { toGa4Event, toMetaEvent, toTiktokEvent } from './mappers';
 import type { MetaEvent, TikTokEvent } from './mappers';
-import { sendGa4, sendMeta, sendTiktok, sendMetaCapi, sendTikTokCapi } from './emitters';
+import { sendGa4, sendMeta, sendTiktok, sendMetaCapi, sendTikTokCapi, setMetaAdvancedMatching } from './emitters';
 import type { GA4UserData } from './emitters/emit.ga4';
 import type { MetaCapiCustomData, TikTokEventsProperties } from './types/capi';
+import { normalizeUserDataForPixel } from './utils';
 import { resolveCartAbandon, resolveCheckoutAbandon } from './abandon';
 import { generateEventIdForEvent, handleAbandonTracking } from './helpers/event-processing';
 
@@ -97,6 +98,20 @@ export async function processAnalyticsEvent(
 
     // 4. CLIENT-SIDE: Enviar a pixels (solo si hay consentimiento)
     await sendGa4(ga4Event, ga4UserData);
+    // Advanced Matching manual del píxel para usuario conocido: sube el EMQ de
+    // todos los eventos del píxel (ViewContent/AddToCart/...). Plaintext
+    // normalizado (el píxel hashea). El AAM automático está desactivado por
+    // autoConfig=false, así que este es el mecanismo de coincidencia avanzada.
+    if (user) {
+      const pixelAM = normalizeUserDataForPixel({
+        id: user.id,
+        email: user.email,
+        phone: user.phone,
+        firstName: user.firstName,
+        lastName: user.lastName,
+      });
+      if (Object.keys(pixelAM).length > 0) setMetaAdvancedMatching(pixelAM);
+    }
     sendMeta(metaEvent, eventId);
     sendTiktok(tiktokEvent, eventId);
 

--- a/src/lib/analytics/emitters/emit.meta.ts
+++ b/src/lib/analytics/emitters/emit.meta.ts
@@ -136,22 +136,50 @@ function deliverOrQueue(label: string, send: () => void): void {
  *
  * @param event - Evento formateado para Meta Pixel
  * @param eventId - Event ID para deduplicación con CAPI
- * @param userData - Datos de usuario hasheados para Advanced Matching (opcional)
+ *
+ * Nota: el Advanced Matching NO se pasa en las opciones del `track` (Meta lo
+ * ignora ahí). Se configura aparte vía {@link setMetaAdvancedMatching}, que llama
+ * `fbq('init', pixelId, {...})`.
  */
-export function sendMeta(
-  event: MetaEvent,
-  eventId: string,
-  userData?: Record<string, string>
-): void {
+export function sendMeta(event: MetaEvent, eventId: string): void {
   deliverOrQueue(event.name, () => {
     const fbq = typeof window !== 'undefined' ? window.fbq : undefined;
     if (typeof fbq !== 'function') return;
-    const options: Record<string, unknown> = { eventID: eventId };
-    if (userData && Object.keys(userData).length > 0) {
-      // Para Advanced Matching: fbq('track', event, data, { eventID, em, ph, ... })
-      Object.assign(options, userData);
+    fbq('track', event.name, event.data, { eventID: eventId });
+  });
+}
+
+/**
+ * Configura el Advanced Matching MANUAL del píxel para un usuario conocido.
+ *
+ * Mecanismo correcto de Meta: `fbq('init', pixelId, { em, ph, fn, ln, external_id })`.
+ * El píxel hashea (SHA-256) internamente, así que `userData` debe venir en
+ * PLAINTEXT NORMALIZADO (ver normalizeUserDataForPixel). El pixelId vive en el
+ * backend; el bootstrap expone `window.__imagiqSetMetaAM(d)` que hace el init.
+ *
+ * - Consent-gated: usa deliverOrQueue ⇒ solo se aplica con fbq listo + consentimiento.
+ * - Idempotente por usuario: solo re-aplica cuando cambian los datos.
+ * - Degradación elegante: si el bootstrap viejo no expuso el helper, es no-op.
+ */
+let lastAppliedAMKey = '';
+
+export function setMetaAdvancedMatching(userData: Record<string, string>): void {
+  if (typeof window === 'undefined') return;
+  if (!userData || Object.keys(userData).length === 0) return;
+
+  const key = JSON.stringify(userData);
+  if (key === lastAppliedAMKey) return; // ya aplicado para este usuario
+
+  deliverOrQueue('advanced-matching', () => {
+    const setAM = (
+      window as unknown as {
+        __imagiqSetMetaAM?: (d: Record<string, string>) => void;
+      }
+    ).__imagiqSetMetaAM;
+    if (typeof setAM === 'function') {
+      setAM(userData);
+      lastAppliedAMKey = key; // marcar solo tras aplicar realmente
     }
-    fbq('track', event.name, event.data, options);
   });
 }
 

--- a/src/lib/analytics/emitters/index.ts
+++ b/src/lib/analytics/emitters/index.ts
@@ -3,7 +3,7 @@
  */
 
 export { sendGa4 } from './emit.ga4';
-export { sendMeta, sendMetaCustom } from './emit.meta';
+export { sendMeta, sendMetaCustom, setMetaAdvancedMatching } from './emit.meta';
 export { sendTiktok } from './emit.tiktok';
 export { sendMetaCapi } from './emit.meta-capi';
 export { sendTikTokCapi } from './emit.tiktok-capi';

--- a/src/lib/analytics/mappers/map.meta.ts
+++ b/src/lib/analytics/mappers/map.meta.ts
@@ -60,6 +60,8 @@ export function toMetaEvent(
           content_type: 'product',
           content_name: event.ecommerce.items[0]?.item_name,
           contents: mapContents(event.ecommerce.items),
+          // value del producto visto (unidades COP) para optimización por valor
+          value: event.ecommerce.items[0]?.price,
           currency: 'COP',
         },
       };

--- a/src/lib/analytics/utils/hash.ts
+++ b/src/lib/analytics/utils/hash.ts
@@ -27,22 +27,24 @@ export function normalizeEmail(email: string): string {
 }
 
 /**
- * Normaliza un teléfono según estándares de Meta/TikTok
- * 1. Remove all non-numeric characters EXCEPT leading +
- * 2. Must include country code (e.g., +57 for Colombia)
+ * Normaliza un teléfono al formato de hashing de Meta/TikTok:
+ * solo dígitos, con indicativo de país, SIN '+' (Meta hashea sin el símbolo).
+ * Asume Colombia (57) para móviles locales de 10 dígitos. Idéntico al
+ * normalizePhone del server-side (payments-ms) para que el hash cliente↔servidor
+ * coincida y Meta empareje el teléfono.
  *
  * @param phone - Teléfono sin normalizar
- * @returns Teléfono normalizado (solo dígitos con + opcional)
+ * @returns Teléfono normalizado (dígitos con indicativo, sin '+')
  *
  * @example
- * normalizePhone('+57 (300) 123-4567') // => '+573001234567'
- * normalizePhone('300 123 4567')       // => '3001234567' (falta country code!)
+ * normalizePhone('+57 (300) 123-4567') // => '573001234567'
+ * normalizePhone('300 123 4567')       // => '573001234567' (agrega indicativo)
  */
 export function normalizePhone(phone: string): string {
-  // Preservar el + inicial si existe
-  const hasPlus = phone.trim().startsWith('+');
-  const digits = phone.replace(/[^\d]/g, '');
-  return hasPlus ? `+${digits}` : digits;
+  let digits = phone.replace(/[^\d]/g, '');
+  // Colombia: agregar indicativo 57 a móviles locales de 10 dígitos.
+  if (digits.length === 10) digits = `57${digits}`;
+  return digits;
 }
 
 /**
@@ -116,9 +118,9 @@ export async function hashPhone(phone: string): Promise<string> {
   if (!phone || phone.trim() === '') return '';
   const normalized = normalizePhone(phone);
 
-  // Validar que tenga country code (debe empezar con +)
-  if (!normalized.startsWith('+')) {
-    console.warn('[Analytics] Phone number missing country code, hash may be invalid:', phone);
+  // Validar que incluya indicativo de país (Colombia E.164 = 12 dígitos).
+  if (normalized.length < 11) {
+    console.warn('[Analytics] Phone number may be missing country code, hash may be invalid:', phone);
   }
 
   return sha256Hex(normalized);
@@ -236,4 +238,35 @@ export async function hashUserData(user: {
   }
 
   return hashed;
+}
+
+/**
+ * Normaliza (SIN hashear) los datos de usuario para Advanced Matching manual del
+ * **píxel** vía `fbq('init', pixelId, {...})`.
+ *
+ * IMPORTANTE: el píxel hashea (SHA-256) internamente lo que le pasamos, así que
+ * aquí enviamos PLAINTEXT NORMALIZADO (em/ph/fn/ln). Pasar valores ya hasheados
+ * provocaría un doble-hash y el match fallaría. `external_id` va en crudo (el
+ * píxel no lo hashea) — el mismo `usuario_id` que usa el server-side, para
+ * consistencia. La pata CAPI sigue enviando SHA-256 (ver hashUserData).
+ *
+ * @returns Objeto con solo los campos presentes; vacío si no hay datos.
+ */
+export function normalizeUserDataForPixel(user: {
+  id?: string;
+  email?: string;
+  phone?: string;
+  firstName?: string;
+  lastName?: string;
+}): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (user.email && user.email.trim()) out.em = normalizeEmail(user.email);
+  if (user.phone && user.phone.trim()) {
+    const ph = normalizePhone(user.phone);
+    if (ph) out.ph = ph;
+  }
+  if (user.firstName && user.firstName.trim()) out.fn = user.firstName.trim().toLowerCase();
+  if (user.lastName && user.lastName.trim()) out.ln = user.lastName.trim().toLowerCase();
+  if (user.id) out.external_id = user.id; // crudo, idéntico al server-side
+  return out;
 }

--- a/src/lib/analytics/utils/index.ts
+++ b/src/lib/analytics/utils/index.ts
@@ -10,5 +10,6 @@ export {
   hashEmail,
   hashPhone,
   hashUserData,
+  normalizeUserDataForPixel,
 } from './hash';
 export { canSendAnalytics, canSendAds, logConsentBlocked } from './consent';


### PR DESCRIPTION
## Why
Fast-follow to the Purchase EMQ fix (#1016/#1017). Funnel events (ViewContent 3.3, InitiateCheckout 4.4, AddToCart 4.9, Search 4.9) report low **Event Match Quality** — they send no advanced-matching params. These are "Múltiple" (pixel + CAPI), so both legs are addressed.

## Changes
**CAPI leg (user_data)**
- ViewContent (`productos/view/[id]`, `viewpremium/[id]`) and Search (`navbarLogic`) used the no-user hook → even logged-in users sent zero PII. Switched to `useAnalyticsWithUser`, so their `user_data` now carries hashed `em/ph/fn/ln/external_id` (the backend controller already forwards all of these, post-#625). AddToCart/InitiateCheckout already used the user-aware hook.

**Pixel leg (manual advanced matching)**
- `autoConfig=false` disables Automatic Advanced Matching, so the pixel sent nothing. New `setMetaAdvancedMatching()` sets manual AM via the bootstrap helper `window.__imagiqSetMetaAM` → `fbq('init', pixelId, {...})` with **plaintext-normalized** PII (the pixel hashes; pre-hashing would double-hash). Consent-gated (`deliverOrQueue`), idempotent per user, no-op if the helper is absent.
- Removed the misleading per-`track` `userData` path (Meta ignores advanced matching in `track` options).

**Correctness / consistency**
- `normalizePhone` → digits + country code `57`, **no `+`** (matches the server normalizer, so client↔server phone hashes agree).
- `external_id` unified to raw `usuario_id` (consistent with server, like Purchase).
- ViewContent now sends `value` (product price).

## Dedup (verified, no change)
Unlike Purchase, funnel pixel & client-CAPI **already share the same `eventId`** (computed once in `processAnalyticsEvent` and passed to both legs). The Purchase double-count was the *separate* payments-ms server emission with a different id — that pattern doesn't exist for funnel events. So there's no desalignment to fix.

## No card data; consent-gated
Only em/ph/fn/ln/external_id/fbp/fbc/ip/ua. The pixel only loads after marketing consent; CAPI uses anonymous mode without it.

## Verification
- `bun run build` (next build) ✅ passes. `tsc --noEmit` clean (touched files).
- Pairs with backend PR `imagiq-backend#626` (bootstrap exposes `__imagiqSetMetaAM`).
- Follow-up (noted, not in scope): guest-checkout email/phone (form values) for InitiateCheckout/AddPaymentInfo when not logged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)