### PR TITLE
fix(telemetry): guest-checkout identity stitching + remove test events (PR1: WS1+WS2)

### DIFF
--- a/src/app/carrito/utils/getUserId.ts
+++ b/src/app/carrito/utils/getUserId.ts
@@ -3,6 +3,8 @@
  * Busca en múltiples fuentes para asegurar que siempre se encuentre el userId
  */
 
+import { setPosthogUserId } from "@/lib/posthogClient";
+
 /**
  * Obtiene el userId del usuario actual (invitado o registrado)
  * Busca en este orden de prioridad:
@@ -128,6 +130,23 @@ export function saveUserId(userId: string, userEmail?: string, clearPrevious: bo
       if (userEmail) address.email = userEmail;
       localStorage.setItem('checkout-address', JSON.stringify(address));
       // console.log('✅ [saveUserId] UserId guardado en checkout-address:', userId);
+    }
+
+    // PASO 4: Identificar en PostHog con el MISMO id que usa el server-side
+    // (order.usuario_id). posthog.identify une el distinct_id anónimo actual a
+    // esta persona ⇒ los eventos anónimos previos (ViewContent, etc.) quedan
+    // bajo la misma persona que la compra (capturada server-side con
+    // distinctId=usuario_id). Sin esto, el checkout de INVITADO quedaba anónimo
+    // y el stitching fallaba → "primer evento = compra" → tiempo-a-compra 0h.
+    // (Los logueados ya se identifican vía auth context; aquí cerramos el gap.)
+    // NO hacemos reset(): orfanaría los eventos anónimos. Reset solo en logout.
+    try {
+      setPosthogUserId(userId, {
+        customer_id: userId,
+        ...(userEmail ? { $email: userEmail } : {}),
+      });
+    } catch (e) {
+      console.warn('⚠️ [saveUserId] No se pudo identificar en PostHog:', e);
     }
 
     // console.log('✅ [saveUserId] UserId guardado exitosamente:', userId);

--- a/src/lib/posthogClient.ts
+++ b/src/lib/posthogClient.ts
@@ -154,15 +154,6 @@ export const initPostHog = () => {
   try {
     posthog.init(POSTHOG_KEY, posthogConfig);
     console.log("PostHog initialized successfully");
-    
-    // 🧪 Evento de prueba al inicializar - puedes eliminarlo después de verificar
-    posthog.capture("posthog_test_event", {
-      test: true,
-      timestamp: new Date().toISOString(),
-      source: "posthog_initialization",
-      message: "PostHog se ha inicializado correctamente en Imagiq"
-    });
-    console.log("🧪 PostHog test event captured: posthog_test_event");
   } catch (error) {
     console.error("Error initializing PostHog:", error);
   }


### PR DESCRIPTION
PR1 of the telemetry-quality work — **identity (WS1)** + **hygiene (WS2)**. High-impact, low-risk; phased per plan (funnel/guest-AM/product_viewed come in PR2).

## WS1 — identity stitching (the main bug)
Verified in PostHog: for buyers, "first interaction → purchase" collapses to **0h** because the anonymous visitor never merges into their identified person until checkout.

**Root cause:** `saveUserId()` (`carrito/utils/getUserId.ts`) — the **guest** checkout path in Step2 — only wrote localStorage and **never called `posthog.identify()`**. So the guest's browser stayed anonymous, while the **server-side** `purchase` is captured with `distinctId = order.usuario_id`. The anonymous browsing history (ViewContent, etc.) never merged into that person → "first event = purchase" → 0h. Most buyers are guests, hence near-universal 0h. Logged-in users were fine (auth context already identifies).

**Fix:** `saveUserId` now calls `setPosthogUserId(userId, { customer_id, $email })` → `posthog.identify` with the **same `usuario_id`** the server uses, merging the current anonymous distinct_id into the person. No `reset()` here (would orphan anonymous events; reset stays on logout). Centralized so every userId-persisting path identifies.

## WS2 — remove test events from prod
`posthogClient.ts` fired `posthog.capture('posthog_test_event')` on **every** PostHog init with no env gate → **13,142 events in 60d** (`$lib=web`) polluting counts/dashboards. Removed. (`cli_smoke_test` is not present in the codebase.)

## Verification
- `bun run build` ✅ · `tsc --noEmit` clean (touched files).
- After deploy (PostHog, project 274592):
  - WS2: `SELECT count() FROM events WHERE event='posthog_test_event' AND timestamp > '<deploy>'` → **0**.
  - WS1: for buyer persons, time between their first event and the `purchase` stops being 0h, and pre-checkout anonymous events appear under the same person.

PR2 (next): funnel monotonicity (dedupe), guest advanced matching, `product_viewed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)