### PR TITLE
fix(telemetry): monotonic checkout funnel + guest advanced matching + product_viewed (PR2)

### DIFF
--- a/src/app/carrito/Step2.tsx
+++ b/src/app/carrito/Step2.tsx
@@ -21,7 +21,8 @@ import {
   getTradeInValidationMessage,
 } from "./utils/validateTradeIn";
 import { toast } from "sonner";
-import { associateEmailWithSession, identifyEmailEarly, posthogUtils } from "@/lib/posthogClient";
+import { associateEmailWithSession, identifyEmailEarly } from "@/lib/posthogClient";
+import { trackCheckoutStep } from "./utils/checkoutTracking";
 import { fbqTrackCustom } from "@/lib/meta-pixel";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -765,9 +766,14 @@ export default function Step2({
       step: 2,
       currency: "COP",
     });
-    posthogUtils.capture("checkout_step2_completed", {
+    // Funnel deduplicado por intento (ver checkoutTracking). Step2 es CONDICIONAL:
+    // los usuarios logueados con dirección guardada se saltan este paso, así que
+    // step2 < step3 es esperado (no un bug). El dedupe evita el sobreconteo.
+    trackCheckoutStep(2, "checkout_step2_completed", {
       user_type: userType,
-      step: 2,
+      conditional: "guest_or_new_address",
+      value: Number(calculations?.total) || undefined,
+      content_ids: cartProducts.map((p) => p.sku),
     });
   };
 

--- a/src/app/carrito/Step3.tsx
+++ b/src/app/carrito/Step3.tsx
@@ -13,7 +13,7 @@ import Step4OrderSummary from "./components/Step4OrderSummary";
 import TradeInCompletedSummary from "@/app/productos/dispositivos-moviles/detalles-producto/estreno-y-entrego/TradeInCompletedSummary";
 import type { Address } from "@/types/address";
 import { fbqTrackCustom } from "@/lib/meta-pixel";
-import { posthogUtils } from "@/lib/posthogClient";
+import { trackCheckoutStep } from "./utils/checkoutTracking";
 import { tradeInEndpoints } from "@/lib/api";
 import { validateTradeInProducts, getTradeInValidationMessage } from "./utils/validateTradeIn";
 import { useTradeInVerification } from "@/hooks/useTradeInVerification";
@@ -1035,10 +1035,10 @@ export default function Step3({
         value: calculations.subtotal,
         currency: 'COP',
       });
-      posthogUtils.capture('checkout_step3_delivery_selected', {
+      trackCheckoutStep(3, 'checkout_step3_delivery_selected', {
         delivery_method: deliveryMethod || 'domicilio',
-        value: calculations.subtotal,
-        step: 3,
+        value: Number(calculations?.total) || undefined,
+        content_ids: products.map((p) => p.sku),
       });
 
       if (typeof onContinue === "function") {
@@ -1138,10 +1138,13 @@ export default function Step3({
       value: calculations.subtotal,
       currency: 'COP',
     });
-    posthogUtils.capture('checkout_step3_delivery_selected', {
+    // Mismo evento que el path de auto-advance (~L1038): trackCheckoutStep
+    // deduplica por intento, así que solo uno de los dos paths emite (arregla el
+    // doble-disparo 32ev/18 personas).
+    trackCheckoutStep(3, 'checkout_step3_delivery_selected', {
       delivery_method: deliveryMethod || 'domicilio',
-      value: calculations.subtotal,
-      step: 3,
+      value: Number(calculations?.total) || undefined,
+      content_ids: products.map((p) => p.sku),
     });
 
     if (typeof onContinue === "function") {

--- a/src/app/carrito/Step4.tsx
+++ b/src/app/carrito/Step4.tsx
@@ -16,8 +16,9 @@ import {
 import { toast } from "sonner";
 import useSecureStorage from "@/hooks/useSecureStorage";
 import { User } from "@/types/user";
-import { fbqTrackCustom, fbqAddPaymentInfo } from "@/lib/meta-pixel";
-import { posthogUtils } from "@/lib/posthogClient";
+import { fbqTrackCustom } from "@/lib/meta-pixel";
+import { trackCheckoutStep } from "./utils/checkoutTracking";
+import { useAnalyticsWithUser } from "@/lib/analytics";
 
 export default function Step4({
   onBack,
@@ -59,6 +60,7 @@ export default function Step4({
     "imagiq_user",
     null
   );
+  const { trackAddPaymentInfo } = useAnalyticsWithUser();
   const [isValidatingCard, setIsValidatingCard] = React.useState(false);
   const [isCardFormValid, setIsCardFormValid] = React.useState(false);
   const formRef = React.useRef<AddCardFormHandle>(null);
@@ -340,12 +342,27 @@ export default function Step4({
       // console.log("💳 [Step4] isValid is true, calling onContinue()");
       const cartValue = calculations?.total || calculations?.subtotal || 0;
 
-      // AddPaymentInfo REAL — aquí sí el usuario está en el paso de pago
-      fbqAddPaymentInfo({
-        value: cartValue,
-        currency: "COP",
-        content_ids: products?.map((p) => p.sku || p.id) || [],
-      });
+      // AddPaymentInfo por el pipeline unificado (pixel + CAPI + GA4/TikTok) con
+      // coincidencia avanzada del usuario — incluido el INVITADO (email/teléfono
+      // ya guardados en imagiq_user tras el OTP de Step2). Reemplaza el
+      // fbqAddPaymentInfo crudo (sin AM, sin eventID/CAPI, sin dedupe); su mapper
+      // de Meta emite el mismo AddPaymentInfo, así que NO se deja el crudo (doble).
+      void trackAddPaymentInfo(
+        products.map((p) => ({
+          item_id: p.sku || p.id,
+          item_name: p.name,
+          price: p.price,
+          quantity: p.quantity,
+        })),
+        cartValue,
+        {
+          id: loggedUser?.id,
+          email: loggedUser?.email,
+          phone: loggedUser?.telefono,
+          firstName: loggedUser?.nombre,
+          lastName: loggedUser?.apellido,
+        }
+      );
 
       fbqTrackCustom("SelectPaymentMethod", {
         payment_method: paymentMethod,
@@ -367,11 +384,11 @@ export default function Step4({
         });
       }
 
-      posthogUtils.capture("checkout_step4_payment_method_selected", {
+      trackCheckoutStep(4, "checkout_step4_payment_method_selected", {
         payment_method: paymentMethod,
         is_saved_card: !!selectedCardId && !useNewCard,
-        step: 4,
         value: cartValue,
+        content_ids: products?.map((p) => p.sku || p.id) || [],
       });
 
       onContinue();

--- a/src/app/carrito/Step5.tsx
+++ b/src/app/carrito/Step5.tsx
@@ -10,7 +10,7 @@ import { CheckZeroInterestResponse } from "./types";
 import { DBCard } from "@/features/profile/types";
 import CardBrandLogo from "@/components/ui/CardBrandLogo";
 import { fbqTrackCustom } from "@/lib/meta-pixel";
-import { posthogUtils } from "@/lib/posthogClient";
+import { trackCheckoutStep } from "./utils/checkoutTracking";
 
 interface Step5Props {
   onBack?: () => void;
@@ -317,10 +317,14 @@ export default function Step5({ onBack, onContinue }: Step5Props) {
       });
     }
 
-    posthogUtils.capture("checkout_step5_installments_selected", {
+    // Step5 es CONDICIONAL (solo tarjeta): pse/addi no montan este paso, así que
+    // step5 < step4 es esperado. Deduplicado por intento.
+    trackCheckoutStep(5, "checkout_step5_installments_selected", {
       installments: selectedInstallments || 1,
       zero_interest: hasZeroInterest,
-      step: 5,
+      conditional: "card_only",
+      value: Number(calculations?.total) || undefined,
+      content_ids: products.map((p) => p.sku),
     });
 
     if (onContinue) {

--- a/src/app/carrito/Step6.tsx
+++ b/src/app/carrito/Step6.tsx
@@ -14,6 +14,7 @@ import { MapPin, Plus, Check, Trash2 } from "lucide-react";
 import { safeGetLocalStorage } from "@/lib/localStorage";
 import { useCart } from "@/hooks/useCart";
 import { associateEmailWithSession, identifyEmailEarly, posthogUtils } from "@/lib/posthogClient";
+import { trackCheckoutStep } from "./utils/checkoutTracking";
 import { fbqTrackCustom } from "@/lib/meta-pixel";
 import { validateTradeInProducts, getTradeInValidationMessage } from "./utils/validateTradeIn";
 import { toast } from "sonner";
@@ -607,10 +608,11 @@ export default function Step6({ onBack, onContinue }: Step6Props) {
         currency: "COP",
       });
 
-      posthogUtils.capture("checkout_step6_billing_selected", {
+      trackCheckoutStep(6, "checkout_step6_billing_selected", {
         billing_type: billingType,
         is_b2b: billingType === "juridica",
-        step: 6,
+        value: products.reduce((a, p) => a + p.price * p.quantity, 0) || undefined,
+        content_ids: products.map((p) => p.sku),
         $set: { billing_type_preference: billingType },
       });
 

--- a/src/app/carrito/Step7.tsx
+++ b/src/app/carrito/Step7.tsx
@@ -36,6 +36,7 @@ import { User } from "@/types/user";
 import RegisterGuestPasswordModal from "./components/RegisterGuestPasswordModal";
 import { fbqTrackCustom } from "@/lib/meta-pixel";
 import { posthogUtils } from "@/lib/posthogClient";
+import { trackCheckoutStep } from "./utils/checkoutTracking";
 
 declare global {
   interface Window {
@@ -1298,10 +1299,10 @@ export default function Step7({ onBack }: Step7Props) {
       step: 7,
       payment_method: paymentData?.method || "unknown",
     });
-    posthogUtils.capture("checkout_step7_pay_clicked", {
+    trackCheckoutStep(7, "checkout_step7_pay_clicked", {
       value: reviewTotal,
       payment_method: paymentData?.method || "unknown",
-      step: 7,
+      content_ids: products.map((p) => p.sku),
     });
 
     setIsProcessing(true);

--- a/src/app/carrito/utils/checkoutTracking.ts
+++ b/src/app/carrito/utils/checkoutTracking.ts
@@ -1,0 +1,108 @@
+/**
+ * Telemetría del funnel de checkout — disparo deduplicado y monótono.
+ *
+ * Problema que resuelve: los eventos `checkout_stepN_*` se disparaban en varios
+ * paths / re-renders / remounts (Suspense) sin dedupe ⇒ funnel NO monótono
+ * (p.ej. step3 = 32 eventos / 18 personas). Aquí cada paso se emite EXACTAMENTE
+ * una vez por INTENTO de checkout.
+ *
+ * Mecanismo: un `checkout_attempt_id` estable por intento (sessionStorage) que
+ * sobrevive a navegar entre steps; el dedupe se guarda por (intento, paso). Un
+ * intento nuevo (otra compra / nueva sesión) obtiene un id fresco vía
+ * `resetCheckoutAttempt()` (llamar al completar la compra). Reusa
+ * `posthogUtils.capture` (que ya adjunta userId).
+ */
+
+import { posthogUtils } from "@/lib/posthogClient";
+
+const ATTEMPT_KEY = "checkout_attempt_id";
+const ATTEMPT_TS_KEY = "checkout_attempt_ts";
+// Ventana deslizante: si pasan >30 min sin actividad de checkout, el próximo
+// paso abre un INTENTO nuevo. Así un re-intento posterior (misma pestaña, sin
+// cerrarla) no queda suprimido por el dedupe del intento anterior abandonado;
+// navegar entre steps en minutos mantiene el mismo intento.
+const IDLE_MS = 30 * 60 * 1000;
+const stepKey = (attemptId: string, step: number) => `ph_step_${attemptId}_${step}`;
+
+/** Genera un id opaco (no cripto-sensible) para el intento de checkout. */
+function newAttemptId(): string {
+  try {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
+  } catch {
+    /* fallthrough */
+  }
+  return `att_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * id estable del intento de checkout actual (lo crea si no existe). Persiste en
+ * sessionStorage: estable mientras dure el flujo (todos los steps), fresco en
+ * una sesión nueva. Se usa como `cart_id`/clave de dedupe del funnel.
+ */
+export function getCheckoutAttemptId(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const now = Date.now();
+    let id = sessionStorage.getItem(ATTEMPT_KEY);
+    const tsRaw = sessionStorage.getItem(ATTEMPT_TS_KEY);
+    const ts = tsRaw ? Number(tsRaw) : 0;
+    // Intento nuevo si no hay id o estuvo inactivo más de IDLE_MS.
+    if (!id || !ts || now - ts > IDLE_MS) {
+      id = newAttemptId();
+      sessionStorage.setItem(ATTEMPT_KEY, id);
+    }
+    sessionStorage.setItem(ATTEMPT_TS_KEY, String(now)); // ventana deslizante
+    return id;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Cierra el intento actual: limpia el id y todas las marcas de dedupe de pasos,
+ * para que un próximo checkout (misma sesión/tab) cuente como intento nuevo.
+ * Llamar al completar la compra (success-checkout).
+ */
+export function resetCheckoutAttempt(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const id = sessionStorage.getItem(ATTEMPT_KEY);
+    if (id) {
+      for (let s = 1; s <= 8; s++) sessionStorage.removeItem(stepKey(id, s));
+    }
+    sessionStorage.removeItem(ATTEMPT_KEY);
+    sessionStorage.removeItem(ATTEMPT_TS_KEY);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Dispara un evento de paso del funnel UNA sola vez por intento. Adjunta
+ * `checkout_attempt_id` (= cart_id del funnel) y `step`. El caller pasa el resto
+ * de contexto (value, content_ids/SKUs, y props específicas del paso).
+ *
+ * @returns true si se emitió, false si se deduplicó (ya disparado este intento).
+ */
+export function trackCheckoutStep(
+  step: number,
+  eventName: string,
+  props?: Record<string, unknown>
+): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const attemptId = getCheckoutAttemptId();
+    const key = stepKey(attemptId, step);
+    if (sessionStorage.getItem(key)) return false; // ya disparado este intento
+    sessionStorage.setItem(key, "1");
+    posthogUtils.capture(eventName, {
+      ...(props || {}),
+      step,
+      cart_id: attemptId,
+      checkout_attempt_id: attemptId,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/app/productos/view/[id]/page.tsx
+++ b/src/app/productos/view/[id]/page.tsx
@@ -17,6 +17,7 @@ import AddToCartButton from "../../viewpremium/components/AddToCartButton";
 import StockNotificationModal from "@/components/StockNotificationModal";
 import { useStockNotification } from "@/hooks/useStockNotification";
 import { useAnalyticsWithUser } from "@/lib/analytics";
+import { posthogUtils } from "@/lib/posthogClient";
 import { useTradeInPrefetch } from "@/hooks/useTradeInPrefetch";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import QuickNavBar from "../../viewpremium/[id]/components/QuickNavBar";
@@ -300,21 +301,39 @@ export default function ProductViewPage({ params }) {
     setVariantsReady(false);
   }, [id]);
 
+  // dedupe del ViewContent/product_viewed: una vez por producto (el effect podía
+  // re-disparar al togglear loading o al cambiar la referencia `product` entre el
+  // producto optimista de localStorage y el del API).
+  const productViewedFiredRef = React.useRef<string | null>(null);
+
   // 🔥 Track View Item apenas el producto carga
   React.useEffect(() => {
-    if (product && !loading) {
+    if (product && !loading && productViewedFiredRef.current !== product.id) {
+      productViewedFiredRef.current = product.id;
       const productPrice =
         typeof product.price === "number"
           ? product.price
           : Number.parseFloat(String(product.price)) || 0;
+      // SKU real de la variante si ya está resuelta; si no, el codigoMarketBase.
+      const sku = productSelectionState?.selectedSku || product.id;
+      const category = product.apiProduct?.categoria || "Sin categoría";
 
       trackViewItem({
-        item_id: product.id,
+        item_id: sku,
         item_name: product.name,
         item_brand: "Samsung",
-        item_category: product.apiProduct?.categoria || "Sin categoría",
+        item_category: category,
         price: productPrice,
         currency: "COP",
+      });
+      // product_viewed nativo de PostHog (SKU/precio) — mismo dedupe que ViewContent.
+      posthogUtils.capture("product_viewed", {
+        product_id: product.id,
+        sku,
+        price: productPrice,
+        currency: "COP",
+        brand: "Samsung",
+        category,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/productos/viewpremium/[id]/page.tsx
+++ b/src/app/productos/viewpremium/[id]/page.tsx
@@ -15,6 +15,7 @@ import StockNotificationModal from "@/components/StockNotificationModal";
 import { useStockNotification } from "@/hooks/useStockNotification";
 import { useTradeInPrefetch } from "@/hooks/useTradeInPrefetch";
 import { useAnalyticsWithUser } from "@/lib/analytics";
+import { posthogUtils } from "@/lib/posthogClient";
 
 // Componentes
 import ProductCarousel from "../components/ProductCarousel";
@@ -194,13 +195,25 @@ export default function ProductViewPage({ params }) {
     const price = Number(productSelection.selectedPrice) || 0;
     if (!price) return; // esperar a que resuelva el precio de la variante
     viewContentFiredRef.current = product.id;
+    const sku = productSelection.selectedSku || product.id;
+    const category = product.apiProduct?.categoria || "Sin categoría";
     trackViewItem({
-      item_id: productSelection.selectedSku || product.id,
+      item_id: sku,
       item_name: product.name,
       item_brand: "Samsung",
-      item_category: product.apiProduct?.categoria || "Sin categoría",
+      item_category: category,
       price,
       currency: "COP",
+    });
+    // product_viewed nativo de PostHog (SKU/precio reales) — mismo gating/dedupe
+    // que ViewContent; no duplica el disparo del píxel.
+    posthogUtils.capture("product_viewed", {
+      product_id: product.id,
+      sku,
+      price,
+      currency: "COP",
+      brand: "Samsung",
+      category,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [product?.id, productSelection.selectedPrice, productSelection.selectedSku, trackViewItem]);

--- a/src/app/success-checkout/[orderId]/page.tsx
+++ b/src/app/success-checkout/[orderId]/page.tsx
@@ -21,6 +21,7 @@ import { useCart } from "@/hooks/useCart";
 import { apiClient } from "@/lib/api";
 import { useAnalyticsWithUser } from "@/lib/analytics";
 import { posthogUtils } from "@/lib/posthogClient";
+import { resetCheckoutAttempt } from "@/app/carrito/utils/checkoutTracking";
 import { apiPost } from "@/lib/api-client";
 import { addBusinessDays, getNextBusinessDay } from "@/lib/dateUtils";
 import useSecureStorage from "@/hooks/useSecureStorage";
@@ -130,6 +131,13 @@ export default function SuccessCheckoutPage({
     };
     verifyOrderStatus();
   }, [pathParams.orderId, router]);
+
+  // Cerrar el intento de checkout al llegar a la página de éxito (independiente
+  // de si el fetch de la orden falla): el próximo checkout será un intento nuevo.
+  useEffect(() => {
+    resetCheckoutAttempt();
+  }, []);
+
   const { trackPurchase } = useAnalyticsWithUser();
   const whatsappSentRef = useRef(false);
   const analyticsSentRef = useRef(false);

--- a/src/lib/analytics/hooks/useAnalyticsWithUser.ts
+++ b/src/lib/analytics/hooks/useAnalyticsWithUser.ts
@@ -55,6 +55,35 @@ export function useAnalyticsWithUser() {
   }, [isAuthenticated, user]);
 
   /**
+   * Resuelve los datos de usuario para Advanced Matching. El usuario autenticado
+   * tiene prioridad; si no hay sesión (checkout de INVITADO) usa el override que
+   * el componente de checkout pasa con el email/teléfono del formulario, para que
+   * el invitado también alimente el AM del pixel (plaintext) y del CAPI (hash).
+   */
+  const resolveUser = useCallback(
+    (override?: {
+      id?: string;
+      email?: string;
+      phone?: string;
+      firstName?: string;
+      lastName?: string;
+    }): AnalyticsUserData | undefined => {
+      if (userData) return userData;
+      if (override && (override.email || override.phone)) {
+        return {
+          id: override.id,
+          email: override.email,
+          phone: override.phone,
+          firstName: override.firstName,
+          lastName: override.lastName,
+        };
+      }
+      return undefined;
+    },
+    [userData]
+  );
+
+  /**
    * Track cuando un usuario ve un producto
    */
   const trackViewItem = useCallback(
@@ -147,7 +176,14 @@ export function useAnalyticsWithUser() {
         price: number;
         quantity: number;
       }>,
-      totalValue: number
+      totalValue: number,
+      userOverride?: {
+        id?: string;
+        email?: string;
+        phone?: string;
+        firstName?: string;
+        lastName?: string;
+      }
     ) => {
       const event: DlCheckoutProgress = {
         event: 'begin_checkout',
@@ -163,9 +199,9 @@ export function useAnalyticsWithUser() {
         },
       };
 
-      await processAnalyticsEvent(event, userData);
+      await processAnalyticsEvent(event, resolveUser(userOverride));
     },
-    [userData]
+    [resolveUser]
   );
 
   /**
@@ -179,7 +215,14 @@ export function useAnalyticsWithUser() {
         price: number;
         quantity: number;
       }>,
-      totalValue: number
+      totalValue: number,
+      userOverride?: {
+        id?: string;
+        email?: string;
+        phone?: string;
+        firstName?: string;
+        lastName?: string;
+      }
     ) => {
       const event: DlCheckoutProgress = {
         event: 'add_payment_info',
@@ -195,9 +238,9 @@ export function useAnalyticsWithUser() {
         },
       };
 
-      await processAnalyticsEvent(event, userData);
+      await processAnalyticsEvent(event, resolveUser(userOverride));
     },
-    [userData]
+    [resolveUser]
   );
 
   /**


### PR DESCRIPTION
PR2 of the telemetry-quality work (PR1 #1020/#1021 already live). Frontend → `develop`, then promotion. Independent adversarial review done (no blockers).

## WS3 — funnel monotonicity / dedupe
`checkout_stepN` events double-fired (PostHog: **step3 = 32 events / 18 persons**; two un-deduped paths in Step3 + remount/re-click across steps), so drop-off was unreadable.
- New `carrito/utils/checkoutTracking.ts` → `trackCheckoutStep(step, name, props)` emits each step **at most once per checkout attempt** (sessionStorage `checkout_attempt_id` + per-step key, with a **30-min sliding-idle window** so a later same-tab re-attempt still counts), and attaches standardized context (`cart_id`, `value`=cart total, `content_ids`=SKUs).
- Applied to Step2–Step7; **Step3's two paths collapse to one**. `resetCheckoutAttempt()` runs on the success page (mount, regardless of order-fetch result).
- Conditional steps tagged (`conditional: guest_or_new_address` for step2, `card_only` for step5) so step2<step3 / step5<step4 read as **expected structure, not bugs**.

## WS4b — guest advanced matching
`useAnalyticsWithUser` gains `resolveUser` + optional `userOverride` on `trackBeginCheckout`/`trackAddPaymentInfo` (auth user wins; else build from form email/phone). **Step4 replaces the raw `fbqAddPaymentInfo`** with the unified `trackAddPaymentInfo(items, value, {guest email/phone from imagiq_user})` → pixel + CAPI + GA4/TikTok **with advanced matching for guests**, and **no double-fire** (raw call removed; the Meta mapper emits AddPaymentInfo). PII → hashed to CAPI / plaintext-normalized to the pixel (pixel hashes); never logged in clear.

## WS5 — product_viewed
PDP `view/[id]` + `viewpremium/[id]` now also emit a native PostHog **`product_viewed`** (`product_id, sku, price, currency, brand, category`) in the same effect as ViewContent, **deduped** (standard PDP gains the ref it lacked). ViewContent `item_id` prefers the real variant SKU.

## WS4 (verify-only, no code)
Redirect purchases (ePayco/Addi) already capture server-side PostHog + Meta CAPI, idempotent + `$insert_id=purchase_${orderId}`.

## Verification
- `bun run build` ✅ · `tsc --noEmit` clean.
- After deploy (PostHog 274592):
  - Funnel: `SELECT event, count(), count(distinct person_id) FROM events WHERE event LIKE 'checkout_step%' GROUP BY event` → **events ≈ persons** (no double-fire); step2/step5 lower is expected (conditional).
  - `product_viewed`: `SELECT count(), count(distinct properties.sku) FROM events WHERE event='product_viewed'`.
  - Guest AM: AddPaymentInfo EMQ for guest sessions rises in Meta Events Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)