### PR TITLE
fix(pdp): galería en blanco por variantes ocultas sin imágenes (LS03H)

### DIFF
--- a/src/hooks/useProductSelection.ts
+++ b/src/hooks/useProductSelection.ts
@@ -147,6 +147,27 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
       });
     }
 
+    // Excluir variantes ocultas en el entorno actual (visibleProduction/visibleStaging
+    // === false). Ej: SKUs de bundle "+ Marco Café" que no se venden en la web, no tienen
+    // imágenes y NO deben seleccionarse por defecto. Sin esto, si solo esas variantes
+    // ocultas tienen stock, findBestVariantToDisplay las elige y la galería queda sin imagen.
+    // Replica el filtro de visibilidad de mapApiProductsToFrontend, pero por variante.
+    // Se preserva el índice original (v.index) para no romper los accesos posicionales
+    // a apiProduct.* (ej: imageDetailsUrls[selectedVariant.index]).
+    const environment = process.env.NEXT_PUBLIC_ENVIRONMENT || 'production';
+    const visibilityArray = environment === 'staging'
+      ? apiProduct.visibleStaging
+      : apiProduct.visibleProduction;
+
+    if (Array.isArray(visibilityArray) && visibilityArray.length > 0) {
+      const visibleVariants = variants.filter(v => visibilityArray[v.index] === true);
+      // Fallback defensivo: si el filtro dejara todo fuera, conservar todas las variantes
+      // (evita un producto sin variantes seleccionables).
+      if (visibleVariants.length > 0) {
+        return visibleVariants;
+      }
+    }
+
     return variants;
   }, [apiProduct]);
 

--- a/src/lib/productMapper.ts
+++ b/src/lib/productMapper.ts
@@ -127,10 +127,14 @@ export function mapApiProductToFrontend(apiProduct: ProductApiData): ProductCard
  * Obtiene la imagen apropiada para el producto
  */
 function getProductImage(apiProduct: ProductApiData): string | StaticImageData {
-  // Priorizar imagePreviewUrl si existe y tiene elementos
+  // Priorizar imagePreviewUrl: tomar la PRIMERA URL no vacía, no la posición [0].
+  // Algunas variantes ocultas (ej: bundles "+ Marco Café") llegan con imagePreviewUrl=""
+  // en el índice 0, lo que dejaba la card sin imagen pese a tener otras variantes con foto.
   if (apiProduct.imagePreviewUrl && apiProduct.imagePreviewUrl.length > 0) {
-    const firstPreviewUrl = apiProduct.imagePreviewUrl[0];
-    if (firstPreviewUrl && firstPreviewUrl.trim() !== '') {
+    const firstPreviewUrl = apiProduct.imagePreviewUrl.find(
+      (url) => url && typeof url === 'string' && url.trim() !== ''
+    );
+    if (firstPreviewUrl) {
       return firstPreviewUrl;
     }
   }


### PR DESCRIPTION
## Problema
La PDP `/productos/view/<codigo>` mostraba la galería **en blanco** para productos como **LS03H** (Samsung The Frame). Reporte real de cliente vía WhatsApp.

## Causa raíz
LS03H tiene 5 variantes. El stock por índice es `[20, 0, 0, 13, 0]`:

| Variante | Stock | Imagen | `visibleProduction` |
|----------|-------|--------|---------------------|
| 55" **+ Marco Café** (`F-QN55…`) | 20 | ❌ vacía | **false** |
| 55" (`QN55…`) | 0 | ✅ | true |
| 65" (`QN65…`) | 0 | ✅ | true |
| 65" **+ Marco Café** (`F-QN65…`) | 13 | ❌ vacía | **false** |
| 75" (`QN75…`) | 0 | ✅ | true |

`findBestVariantToDisplay` prioriza `stockDisponible > 0`. Las únicas variantes con stock son las dos **"+ Marco Café"**, que están marcadas como **no visibles en web** y **sin imágenes** → la galería (`selectedVariant.imagePreviewUrl` / `imageDetailsUrls[index]`) queda vacía.

## Fix
- **`useProductSelection.ts`**: al construir `allVariants`, excluir las variantes con `visibleProduction`/`visibleStaging === false` en el entorno actual, **preservando el índice original** (no rompe accesos posicionales como `imageDetailsUrls[selectedVariant.index]`). Replica el filtro de visibilidad que ya existía a nivel de producto en `mapApiProductsToFrontend`, pero por variante. Fallback defensivo: si el filtro dejara 0 variantes, se conservan todas.
- **`productMapper.ts` `getProductImage`**: tomar la primera `imagePreviewUrl` **no vacía** en vez de `[0]` (que venía `""`). Arregla también la miniatura en grillas del catálogo.

## Verificación
- `tsc --noEmit`: 0 errores.
- Preview local apuntando al backend de **producción**: la galería de LS03H ahora carga imagen principal + miniaturas, y el selector de tamaño muestra solo 55"/65"/75" (sin las "+ Marco Café" fantasma).

## Nota (no es de este PR)
Tras el fix la página muestra imágenes pero queda **"Stock Total: 0 / Notificarme"**, porque los SKUs visibles del TV están agotados y el único stock está en las "+ Marco Café" ocultas. Eso es un tema de inventario/catálogo (Novasoft), separado de este arreglo de display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)