### PR TITLE
Promote: fix PDP galería en blanco por variantes ocultas (LS03H)

### DIFF
--- a/src/hooks/useProductSelection.ts
+++ b/src/hooks/useProductSelection.ts
@@ -147,6 +147,27 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
       });
     }
 
+    // Excluir variantes ocultas en el entorno actual (visibleProduction/visibleStaging
+    // === false). Ej: SKUs de bundle "+ Marco Café" que no se venden en la web, no tienen
+    // imágenes y NO deben seleccionarse por defecto. Sin esto, si solo esas variantes
+    // ocultas tienen stock, findBestVariantToDisplay las elige y la galería queda sin imagen.
+    // Replica el filtro de visibilidad de mapApiProductsToFrontend, pero por variante.
+    // Se preserva el índice original (v.index) para no romper los accesos posicionales
+    // a apiProduct.* (ej: imageDetailsUrls[selectedVariant.index]).
+    const environment = process.env.NEXT_PUBLIC_ENVIRONMENT || 'production';
+    const visibilityArray = environment === 'staging'
+      ? apiProduct.visibleStaging
+      : apiProduct.visibleProduction;
+
+    if (Array.isArray(visibilityArray) && visibilityArray.length > 0) {
+      const visibleVariants = variants.filter(v => visibilityArray[v.index] === true);
+      // Fallback defensivo: si el filtro dejara todo fuera, conservar todas las variantes
+      // (evita un producto sin variantes seleccionables).
+      if (visibleVariants.length > 0) {
+        return visibleVariants;
+      }
+    }
+
     return variants;
   }, [apiProduct]);
 

--- a/src/lib/productMapper.ts
+++ b/src/lib/productMapper.ts
@@ -127,10 +127,14 @@ export function mapApiProductToFrontend(apiProduct: ProductApiData): ProductCard
  * Obtiene la imagen apropiada para el producto
  */
 function getProductImage(apiProduct: ProductApiData): string | StaticImageData {
-  // Priorizar imagePreviewUrl si existe y tiene elementos
+  // Priorizar imagePreviewUrl: tomar la PRIMERA URL no vacía, no la posición [0].
+  // Algunas variantes ocultas (ej: bundles "+ Marco Café") llegan con imagePreviewUrl=""
+  // en el índice 0, lo que dejaba la card sin imagen pese a tener otras variantes con foto.
   if (apiProduct.imagePreviewUrl && apiProduct.imagePreviewUrl.length > 0) {
-    const firstPreviewUrl = apiProduct.imagePreviewUrl[0];
-    if (firstPreviewUrl && firstPreviewUrl.trim() !== '') {
+    const firstPreviewUrl = apiProduct.imagePreviewUrl.find(
+      (url) => url && typeof url === 'string' && url.trim() !== ''
+    );
+    if (firstPreviewUrl) {
       return firstPreviewUrl;
     }
   }


### PR DESCRIPTION
Promoción a producción del fix de la galería en blanco en la PDP.

Incluye **#1026** — `fix(pdp)`: la PDP elegía por defecto variantes ocultas (`visibleProduction=false`) y sin imágenes cuando eran las únicas con stock (caso **LS03H** The Frame), dejando la galería vacía. Ahora se excluyen esas variantes y `getProductImage` toma la primera URL no vacía.

Verificado: `tsc` 0 errores, Vercel preview pass, preview local contra backend de producción mostrando imágenes correctamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)