### PR TITLE
fix(trade-in): cortar bucle infinito de reintentos del prefetch (tormenta de ~180 req/carga)

### DIFF
--- a/src/hooks/useTradeInPrefetch.ts
+++ b/src/hooks/useTradeInPrefetch.ts
@@ -24,6 +24,13 @@ const notifyListeners = () => {
 // TTL del cache (5 minutos)
 const CACHE_TTL = 5 * 60 * 1000;
 
+// Anti-bucle de reintentos: si el endpoint de Trade-In falla (ej. benefits-ms caído),
+// el efecto de useTradeInDataFromCache se re-dispara con cada notifyListeners y volvería
+// a pedir de inmediato → tormenta de cientos de requests por carga. Tras un fallo,
+// no reintentar durante este cooldown (1 request cada 30s como mucho).
+const FAILURE_COOLDOWN_MS = 30 * 1000;
+let lastFailureAt = 0;
+
 /**
  * Hook para hacer prefetch de los datos de Trade-In
  * Los datos se cargan automáticamente y se almacenan en caché global
@@ -137,6 +144,12 @@ async function prefetchTradeInData(): Promise<TradeInData | null> {
     return tradeInCache.data;
   }
 
+  // Anti-bucle: si falló hace poco, no martillar el backend (corta la tormenta
+  // de reintentos cuando el endpoint está caído). Reintenta pasado el cooldown.
+  if (lastFailureAt && Date.now() - lastFailureAt < FAILURE_COOLDOWN_MS) {
+    return null;
+  }
+
   try {
     tradeInCache.loading = true;
     notifyListeners(); // Notificar inicio de carga
@@ -146,6 +159,7 @@ async function prefetchTradeInData(): Promise<TradeInData | null> {
     if (response.success && response.data) {
       const transformedData = transformHierarchyToTradeInData(response.data);
 
+      lastFailureAt = 0; // éxito: limpiar el cooldown de fallos
       tradeInCache = {
         data: transformedData,
         timestamp: Date.now(),
@@ -156,12 +170,14 @@ async function prefetchTradeInData(): Promise<TradeInData | null> {
       return transformedData;
     } else {
       console.error('❌ [Trade-In Prefetch] Error en respuesta:', response.message);
+      lastFailureAt = Date.now();
       tradeInCache.loading = false;
       notifyListeners(); // Notificar error (fin de carga)
       return null;
     }
   } catch (error) {
     console.error('❌ [Trade-In Prefetch] Error de conexión:', error);
+    lastFailureAt = Date.now();
     tradeInCache.loading = false;
     notifyListeners(); // Notificar error (fin de carga)
     return null;


### PR DESCRIPTION
## Problema
En las páginas de producto, `useTradeInDataFromCache` ([useTradeInPrefetch.ts:117-122](src/hooks/useTradeInPrefetch.ts#L117-L122)) re-dispara su `useEffect` con **cada** `notifyListeners()`. Cuando el fetch de Trade-In falla (ej. `benefits-ms` caído → 500), la función notifica el error → re-render → el efecto se vuelve a ejecutar → pide de nuevo de inmediato → **bucle infinito**: ~**180 requests por carga** de PDP, martillando el backend (visible como cientos de 500 de `/api/benefits/trade-in/hierarchy` en consola).

## Fix
**Cooldown anti-bucle** a nivel de módulo en `prefetchTradeInData`:
- Tras un fallo, no se reintenta durante **30s** (corta la tormenta: máx ~1 request/30s mientras el endpoint esté caído).
- Se limpia (`lastFailureAt = 0`) en éxito → el flujo normal (primera carga, datos OK) **no se ve afectado**.

## Verificación
- `tsc --noEmit`: 0 errores.
- Lógica: primera carga sin fallo previo → pide normal; éxito → resetea; fallo → cooldown 30s antes de reintentar.

## Contexto
Es el lado frontend del incidente de hoy. El **lado backend** (que `benefits-ms` no caiga en crash-loop ni 500 ante un blip del SQL Server) va en `imagiq-backend` PR #629. Juntos: un hipo del backend ya nunca tumba la PDP ni martillea el server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)