### PR TITLE
fix(banners): aspecto proporcional — no recortar banners en portátil

### DIFF
--- a/src/components/banners/DynamicBannerClean.tsx
+++ b/src/components/banners/DynamicBannerClean.tsx
@@ -544,7 +544,12 @@ export default function DynamicBannerClean({
 
   const content = (
     <div className={`relative w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-8 ${className}`}>
-      <div className="relative w-full aspect-[21/29] md:aspect-auto md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden @container/banner">
+      {/* Aspecto proporcional en desktop (imágenes de banner = 1440x800 ≈ 9/5).
+          Antes se usaba altura fija (min-h-[800px]) + object-cover: en portátiles
+          con ancho < 1440px la caja quedaba más "alta" que la imagen y object-cover
+          recortaba ~11% por lado (texto/CTA cortados). Con aspect-[9/5] la caja
+          siempre coincide con la imagen → escala proporcional, sin recorte. */}
+      <div className="relative w-full aspect-[21/29] md:aspect-[9/5] rounded-lg overflow-hidden @container/banner">
         {showOverlay && <div className="absolute inset-0 bg-black/30 z-10" />}
 
         {/* Todos los banners en posición absoluta con transición fade + slide */}


### PR DESCRIPTION
## Problema
En portátiles, los banners de sección (Asombroso / Tu Sala / Bespoke) **se cortan a los lados**, y al bajar el zoom se ven normales. Reporte de cliente.

## Causa
`DynamicBannerClean` usaba **altura fija** (`md:min-h-[800px]`) + `object-cover` con ancho fluido. Las imágenes son 1440×800 (aspecto 1.8), pero en anchos < 1440px la caja queda en aspecto ~1.4 → `object-cover` recorta **~11% por lado** (texto/CTA cortados). El zoom-out ensancha la caja y reduce el recorte (por eso dependía del zoom).

## Fix
Cambiar la altura fija de desktop por **aspecto proporcional** `md:aspect-[9/5]` (= 1440×800), que siempre coincide con la imagen → **0% recorte** en cualquier ancho. Móvil sin cambios (`aspect-[21/29]`).

## Verificación
Localhost a 1180px (apuntando al backend de prod): caja pasa de 1124×800 (recorte 22%) → 1124×624 (recorte 0%), banners completos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)