### PR TITLE
Promote: banners no recortan en portátil + trade-in sin bucle de reintentos

### DIFF
--- a/src/components/banners/DynamicBannerClean.tsx
+++ b/src/components/banners/DynamicBannerClean.tsx
@@ -544,7 +544,12 @@ export default function DynamicBannerClean({
 
   const content = (
     <div className={`relative w-full max-w-[1440px] mx-auto px-4 md:px-6 lg:px-8 ${className}`}>
-      <div className="relative w-full aspect-[21/29] md:aspect-auto md:min-h-[500px] lg:min-h-[800px] rounded-lg overflow-hidden @container/banner">
+      {/* Aspecto proporcional en desktop (imágenes de banner = 1440x800 ≈ 9/5).
+          Antes se usaba altura fija (min-h-[800px]) + object-cover: en portátiles
+          con ancho < 1440px la caja quedaba más "alta" que la imagen y object-cover
+          recortaba ~11% por lado (texto/CTA cortados). Con aspect-[9/5] la caja
+          siempre coincide con la imagen → escala proporcional, sin recorte. */}
+      <div className="relative w-full aspect-[21/29] md:aspect-[9/5] rounded-lg overflow-hidden @container/banner">
         {showOverlay && <div className="absolute inset-0 bg-black/30 z-10" />}
 
         {/* Todos los banners en posición absoluta con transición fade + slide */}

--- a/src/hooks/useTradeInPrefetch.ts
+++ b/src/hooks/useTradeInPrefetch.ts
@@ -24,6 +24,13 @@ const notifyListeners = () => {
 // TTL del cache (5 minutos)
 const CACHE_TTL = 5 * 60 * 1000;
 
+// Anti-bucle de reintentos: si el endpoint de Trade-In falla (ej. benefits-ms caído),
+// el efecto de useTradeInDataFromCache se re-dispara con cada notifyListeners y volvería
+// a pedir de inmediato → tormenta de cientos de requests por carga. Tras un fallo,
+// no reintentar durante este cooldown (1 request cada 30s como mucho).
+const FAILURE_COOLDOWN_MS = 30 * 1000;
+let lastFailureAt = 0;
+
 /**
  * Hook para hacer prefetch de los datos de Trade-In
  * Los datos se cargan automáticamente y se almacenan en caché global
@@ -137,6 +144,12 @@ async function prefetchTradeInData(): Promise<TradeInData | null> {
     return tradeInCache.data;
   }
 
+  // Anti-bucle: si falló hace poco, no martillar el backend (corta la tormenta
+  // de reintentos cuando el endpoint está caído). Reintenta pasado el cooldown.
+  if (lastFailureAt && Date.now() - lastFailureAt < FAILURE_COOLDOWN_MS) {
+    return null;
+  }
+
   try {
     tradeInCache.loading = true;
     notifyListeners(); // Notificar inicio de carga
@@ -146,6 +159,7 @@ async function prefetchTradeInData(): Promise<TradeInData | null> {
     if (response.success && response.data) {
       const transformedData = transformHierarchyToTradeInData(response.data);
 
+      lastFailureAt = 0; // éxito: limpiar el cooldown de fallos
       tradeInCache = {
         data: transformedData,
         timestamp: Date.now(),
@@ -156,12 +170,14 @@ async function prefetchTradeInData(): Promise<TradeInData | null> {
       return transformedData;
     } else {
       console.error('❌ [Trade-In Prefetch] Error en respuesta:', response.message);
+      lastFailureAt = Date.now();
       tradeInCache.loading = false;
       notifyListeners(); // Notificar error (fin de carga)
       return null;
     }
   } catch (error) {
     console.error('❌ [Trade-In Prefetch] Error de conexión:', error);
+    lastFailureAt = Date.now();
     tradeInCache.loading = false;
     notifyListeners(); // Notificar error (fin de carga)
     return null;


### PR DESCRIPTION
Promoción a producción de 2 fixes de frontend:

- **#1029** `fix(banners)`: aspecto proporcional en banners de sección → no se recortan en portátil (antes 22% de recorte lateral por altura fija + object-cover).
- **#1028** `fix(trade-in)`: cooldown anti-bucle en el prefetch → corta la tormenta de ~180 requests/carga cuando el endpoint de trade-in falla.

Ambos verificados (Vercel pass, preview local / tsc 0 errores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)