### PR TITLE
chore(next): eliminar console.* del bundle de producción

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,14 @@ import type { NextConfig } from "next";
 const isDev = process.env.NODE_ENV !== "production";
 
 const nextConfig: NextConfig = {
+  // Elimina los `console.*` del bundle de PRODUCCIÓN para no ensuciar la consola
+  // del navegador ([MULTIMEDIA], [FLIX], [Socket], [AuthContext], [Clarity], etc.).
+  // En `next dev` se conservan para depurar. Se mantiene `console.error` para que
+  // los errores reales sigan visibles y lleguen a Sentry. (Para quitar TAMBIÉN los
+  // console.error, cambiar a `removeConsole: true`.)
+  compiler: {
+    removeConsole: isDev ? false : { exclude: ["error"] },
+  },
   skipTrailingSlashRedirect: true,
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Qué
Limpia la consola del navegador en **producción** quitando los `console.*` del bundle (logs ruidosos `[MULTIMEDIA]`, `[FLIX]`, `[Socket]`, `[AuthContext]`, `[Clarity]`, PostHog, etc.).

## Cómo
`compiler.removeConsole` de Next.js en `next.config.ts`:
```ts
compiler: {
  removeConsole: isDev ? false : { exclude: ["error"] },
}
```
- Solo en **build de producción**. En `next dev` se conservan los logs.
- Se mantiene `console.error` (los errores reales siguen visibles y llegan a Sentry).

## Alcance / seguridad
- Cambio de **1 archivo** (`next.config.ts`), solo configuración de build.
- **Cero impacto en lógica**: únicamente elimina llamadas de logging. No toca checkout, pagos, forms ni ninguna funcionalidad.
- No afecta los errores nativos del navegador (p. ej. fuentes de Flixmedia), que no son `console.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)