### PR TITLE
fix(carrito): arregla logo de Addi roto en selector de pago

### DIFF
--- a/src/app/carrito/components/PaymentForm.tsx
+++ b/src/app/carrito/components/PaymentForm.tsx
@@ -8,7 +8,6 @@ import { useAuthContext } from "@/features/auth/context";
 import CardBrandLogo from "@/components/ui/CardBrandLogo";
 import AddCardForm, { AddCardFormHandle } from "@/components/forms/AddCardForm";
 import pseLogo from "@/img/iconos/logo-pse.png";
-import addiLogo from "@/img/iconos/addi_negro.png";
 import { fetchBanks } from "../utils";
 import { useCardsCache } from "../hooks/useCardsCache";
 import useSecureStorage from "@/hooks/useSecureStorage";
@@ -521,8 +520,8 @@ export default function PaymentForm({
             )}
 
             {/* Addi */}
-            <div className="-mx-3">
-              <label className="flex items-center gap-3 justify-between cursor-pointer hover:bg-gray-50 rounded-lg transition-colors px-3">
+            <div>
+              <label className="flex items-center gap-3 justify-between py-3 cursor-pointer hover:bg-gray-50 rounded-lg transition-colors">
                 <span className="flex items-center gap-3">
                   <input
                     type="radio"
@@ -540,11 +539,11 @@ export default function PaymentForm({
                   </span>
                 </span>
                 <Image
-                  src="https://purrfecthire.com/carrousel-img/addi.png"
+                  src="https://res.cloudinary.com/dzi2p0pqa/image/upload/v1764650798/acd66fce-b218-4a0d-95e9-559410496596.png"
                   alt="Addi"
-                  width={35}
-                  height={35}
-                  className="object-fit"
+                  width={32}
+                  height={32}
+                  className="object-contain w-8 h-8 flex-shrink-0"
                 />
               </label>
               <div className="ml-8">


### PR DESCRIPTION
## Problema
En el paso de pago (`/carrito/step4`) el logo de **Addi** salía roto (ícono de imagen rota "!"). Cargaba desde una URL externa que devuelve **404**:
`https://purrfecthire.com/carrousel-img/addi.png`

Además, el layout con `-mx-3` dentro de un contenedor `overflow-hidden` recortaba el logo a los lados.

## Solución
- Reemplazado por el **ícono redondo oficial de Addi** (Cloudinary — el mismo que ya se usa en "Paga a crédito con addi"), cuadrado 32×32, que no se corta.
- Corregido el layout: quitado el `-mx-3` y añadido `py-3` para igualar el espaciado de las otras opciones (Tarjeta, PSE).
- Eliminado el import `addi_negro.png` que quedó sin uso.

## Notas
- Cloudinary (`res.cloudinary.com`) ya está permitido en `next.config.ts` (imagen + CSP).
- Sin cambios de lógica; solo presentación del logo.
- Mismo fix aplicado en el repo de quioscos (PR aparte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)