### PR TITLE
release: promover develop → main (ADDI doc-type, doble-submit, errores de pago en móvil)

### DIFF
--- a/src/app/carrito/Step7.tsx
+++ b/src/app/carrito/Step7.tsx
@@ -180,6 +180,12 @@ export default function Step7({ onBack }: Step7Props) {
   const [candidateWarehouseCode, setCandidateWarehouseCode] = useState<string | undefined>();
   // Ref para leer el valor actual de isCalculatingShipping en callbacks
   const isCalculatingShippingRef = React.useRef(false);
+  // Synchronous re-entrancy guard for processOrder. `isProcessing` (state) is
+  // set too late — only AFTER the "calculating shipping" wait loop — so rapid
+  // taps queue inside that loop and then all fire concurrently, each creating
+  // an order and a charge (the 4-orders-in-18-min incident). A ref flips
+  // synchronously on the first tap, so subsequent taps bail immediately.
+  const isProcessingRef = React.useRef(false);
 
   // Actualizar ref cuando cambie el estado
   React.useEffect(() => {
@@ -1263,15 +1269,24 @@ export default function Step7({ onBack }: Step7Props) {
 
   // Función que realmente procesa la orden (llamada después del modal o directamente)
   const processOrder = async () => {
+    // Re-entrancy guard: block any second invocation (double-tap, queued click
+    // during shipping calc, multi-tab) BEFORE it can create a duplicate order.
+    // Flips synchronously so concurrent calls can't both pass.
+    if (isProcessingRef.current) return;
+    isProcessingRef.current = true;
+
     // Validar Trade-In antes de confirmar
     const validation = validateTradeInProducts(products);
     if (!validation.isValid) {
+      isProcessingRef.current = false;
       alert(getTradeInValidationMessage(validation));
       return;
     }
 
     if (!billingData) {
       console.error("No billing data available");
+      isProcessingRef.current = false;
+      setError("Faltan tus datos de facturación. Vuelve al paso anterior y complétalos para continuar.");
       return;
     }
 
@@ -1890,6 +1905,7 @@ export default function Step7({ onBack }: Step7Props) {
       // SIEMPRE resetear isProcessing excepto si estamos esperando validación 3DS
       if (!waiting3DS) {
         setIsProcessing(false);
+        isProcessingRef.current = false;
       }
     }
   };
@@ -2913,6 +2929,17 @@ export default function Step7({ onBack }: Step7Props) {
 
       {/* Sticky Bottom Bar - Solo Mobile */}
       <div className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-lg z-50">
+        {/* Error de pago en móvil: antes solo se renderizaba en el aside
+            `hidden md:block`, así que en móvil el fallo era invisible y el
+            cliente reintentaba a ciegas o abandonaba. */}
+        {error && (
+          <div
+            role="alert"
+            className="mx-4 mt-3 -mb-1 rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700 font-medium"
+          >
+            {error}
+          </div>
+        )}
         <div className="p-4 pb-8 flex items-center justify-between gap-4">
           {/* Izquierda: Total y descuentos */}
           <div className="flex-1 min-w-0">
@@ -2934,12 +2961,12 @@ export default function Step7({ onBack }: Step7Props) {
           {/* Derecha: Botón confirmar - destacado con sombra y glow */}
           <button
             className={`flex-shrink-0 font-bold py-4 px-6 rounded-xl text-lg transition-all duration-200 text-white border-2 flex items-center gap-2 ${
-              isProcessing || isValidatingTradeIn || !tradeInValidation.isValid
+              isProcessing || isCalculatingShipping || isValidatingTradeIn || !tradeInValidation.isValid
                 ? "bg-gray-400 border-gray-300 cursor-not-allowed"
                 : "bg-green-600 border-green-500 hover:bg-green-700 hover:border-green-600 cursor-pointer shadow-lg shadow-green-500/40 hover:shadow-xl hover:shadow-green-500/50"
             }`}
             onClick={handleConfirmOrder}
-            disabled={isProcessing || isValidatingTradeIn || !tradeInValidation.isValid}
+            disabled={isProcessing || isCalculatingShipping || isValidatingTradeIn || !tradeInValidation.isValid}
           >
             {(isProcessing || isCalculatingShipping || isValidatingTradeIn) && (
               <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/src/app/carrito/utils/index.ts
+++ b/src/app/carrito/utils/index.ts
@@ -36,6 +36,20 @@ function getFacebookPayload() {
   }
 }
 
+// Traduce el error crudo de ADDI (p.ej. `Addi API error: {"code":"000-008",
+// "message":"El tipo de documento no es válido."}`) a un mensaje que el cliente
+// entienda, en vez de mostrarle el JSON de la API.
+function friendlyAddiError(raw: string): string {
+  const msg = (raw || "").toLowerCase();
+  if (msg.includes("tipo de documento") || msg.includes("000-008")) {
+    return "Hubo un problema con tu tipo de documento. Actualízalo en tu perfil (Cédula, NIT, etc.) e intenta de nuevo, o usa otro medio de pago.";
+  }
+  if (msg.includes("monto") || msg.includes("amount")) {
+    return "El monto de tu compra no cumple los requisitos de financiación de Addi. Intenta con otro medio de pago.";
+  }
+  return "No pudimos iniciar tu financiación con Addi en este momento. Verifica tus datos o intenta con otro medio de pago.";
+}
+
 export async function payWithAddi(
   props: AddiPaymentData
 ): Promise<{ redirectUrl: string } | { error: string; message: string }> {
@@ -49,7 +63,7 @@ export async function payWithAddi(
   } catch (error) {
     console.error("Error initiating Addi payment:", error);
     if (error instanceof Error) {
-      return { error: "payment_failed", message: error.message || "Failed to initiate Addi payment" };
+      return { error: "payment_failed", message: friendlyAddiError(error.message) };
     }
     return { error: "network_error", message: "Error de conexión al procesar el pago" };
   }

--- a/src/features/profile/components/modals/EditProfileModal.tsx
+++ b/src/features/profile/components/modals/EditProfileModal.tsx
@@ -20,12 +20,29 @@ export interface EditProfileData {
   numero_documento: string;
 }
 
+// ADDI y el resto del sistema (registro, checkout, ePayco) usan estos códigos.
+// Enviar los valores en español ("cedula", "pasaporte"…) hacía que ADDI
+// rechazara la financiación con el error 000-008 "El tipo de documento no es
+// válido" y la orden quedaba en INTERNAL_ERROR.
 const DOCUMENT_TYPES = [
-  { value: "cedula", label: "Cédula de Ciudadanía" },
-  { value: "cedula_extranjeria", label: "Cédula de Extranjería" },
-  { value: "pasaporte", label: "Pasaporte" },
-  { value: "nit", label: "NIT" },
+  { value: "CC", label: "Cédula de Ciudadanía" },
+  { value: "CE", label: "Cédula de Extranjería" },
+  { value: "PP", label: "Pasaporte" },
+  { value: "NIT", label: "NIT" },
 ];
+
+// Normaliza valores legacy que quedaron guardados en la BD antes de este fix.
+const DOC_TYPE_ALIASES: Record<string, string> = {
+  cedula: "CC",
+  cedula_extranjeria: "CE",
+  pasaporte: "PP",
+  nit: "NIT",
+};
+const normalizeDocType = (value?: string): string => {
+  if (!value) return "CC";
+  if (DOCUMENT_TYPES.some((t) => t.value === value)) return value;
+  return DOC_TYPE_ALIASES[value.toLowerCase()] ?? "CC";
+};
 
 const EditProfileModal: React.FC<EditProfileModalProps> = ({
   isOpen,
@@ -39,7 +56,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
     apellido: "",
     email: "",
     telefono: "",
-    tipo_documento: "cedula",
+    tipo_documento: "CC",
     numero_documento: "",
   });
 
@@ -51,7 +68,7 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
         apellido: user.apellido || "",
         email: user.email || "",
         telefono: user.telefono || "",
-        tipo_documento: "cedula",
+        tipo_documento: normalizeDocType(user.tipo_documento),
         numero_documento: user.numero_documento || "",
       });
     }

--- a/src/features/profile/types/index.ts
+++ b/src/features/profile/types/index.ts
@@ -76,6 +76,7 @@ export interface ProfileUser {
   apellido: string;
   email: string;
   telefono?: string;
+  tipo_documento?: string;
   numero_documento?: string;
   direcciones: DBAddress[];
   tarjetas: DBCard[];


### PR DESCRIPTION
Promoción a **producción** de los fixes de checkout ya validados en `develop`/staging (deploy staging exitoso).

Contenido (único commit sobre main — #1037):
- **EditProfileModal**: tipo de documento con códigos canónicos `CC/CE/NIT/PP` + respeta el valor real (arregla la raíz del "Error Interno" de ADDI).
- **Guard de doble-submit** en Step7: bloquea órdenes/cobros duplicados.
- **Errores de pago visibles en móvil** (antes invisibles en un `aside` oculto).
- **Mensaje amable** ante error de ADDI (en vez del JSON crudo).

Staging (Vercel `staging`) desplegado OK. Esta promoción despliega a Vercel **Production**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)