### PR TITLE
perf(productos): proxy cacheado server-side para getByCodigoMarket

### DIFF
--- a/src/app/api/pcache/product/route.ts
+++ b/src/app/api/pcache/product/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Proxy cacheado del catálogo: /api/products/filtered?codigoMarket=X
+ *
+ * Esta llamada es el gate de TODA la PDP (view/viewpremium/multimedia): sin
+ * ella no hay MPN y Flixmedia no puede arrancar. Hoy cada navegador la paga
+ * completa contra Railway (~0.3-1.5s). Este proxy la cachea con el Data Cache
+ * de Next (revalidate 120s) compartido entre todos los usuarios: el primer
+ * visitante de un producto la paga una vez, el resto la recibe en ~20-80ms.
+ *
+ * El catálogo es público (las páginas de listado lo consultan sin login) y la
+ * tolerancia a datos con ≤2 min de antigüedad ya existe: el cliente cachea
+ * 10 min en memoria y refresca en background (stale-while-revalidate). El
+ * consumidor (useProduct) mantiene ese refresh en background contra el
+ * endpoint directo, así que cualquier cambio de precio/stock se corrige solo
+ * segundos después del primer render.
+ *
+ * GET /api/pcache/product?codigoMarket=<id>
+ */
+
+const PRODUCT_REVALIDATE_SECONDS = 120;
+
+function backendUrl(): string {
+  return (
+    process.env.INTERNAL_API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "http://localhost:3001"
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const codigoMarket = searchParams.get("codigoMarket");
+
+  if (!codigoMarket || codigoMarket.length > 100) {
+    return NextResponse.json(
+      { success: false, error: "missing_or_invalid_codigoMarket" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const apiKey = process.env.NEXT_PUBLIC_API_KEY;
+    const url = `${backendUrl()}/api/products/filtered?codigoMarket=${encodeURIComponent(codigoMarket)}`;
+    const response = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey && { "X-API-Key": apiKey }),
+      },
+      next: { revalidate: PRODUCT_REVALIDATE_SECONDS },
+    });
+
+    if (!response.ok) {
+      // No cachear errores del backend: el cliente hace fallback al endpoint directo
+      return NextResponse.json(
+        { success: false, error: "upstream_error" },
+        { status: 502 }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control":
+          "public, max-age=60, s-maxage=120, stale-while-revalidate=300",
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "upstream_unreachable" },
+      { status: 502 }
+    );
+  }
+}

--- a/src/features/products/useProducts.ts
+++ b/src/features/products/useProducts.ts
@@ -1206,9 +1206,35 @@ export const useProduct = (productId: string) => {
       try {
         const codigoMarketBase = productId;
 
-        // Usar el endpoint específico para buscar por codigoMarketBase
-        const response = await productEndpoints.getByCodigoMarket(codigoMarketBase);
-        
+        // Primer load vía proxy cacheado server-side (/api/pcache/product):
+        // el Data Cache de Next comparte la respuesta entre TODOS los usuarios,
+        // así que tras el primer visitante de un producto la respuesta llega en
+        // ~20-80ms en vez de pagar Railway completo (~0.3-1.5s). Si falla por
+        // cualquier razón, fallback transparente al endpoint directo.
+        // La frescura (precio/stock) la corrige el refresh en background de abajo.
+        let cameFromPcache = false;
+        const fetchViaPcache = async (): Promise<Awaited<ReturnType<typeof productEndpoints.getByCodigoMarket>> | null> => {
+          try {
+            const res = await fetch(`/api/pcache/product?codigoMarket=${encodeURIComponent(codigoMarketBase)}`);
+            if (!res.ok) return null;
+            const raw = await res.json();
+            // Replicar la normalización de ApiClient.request: el backend puede
+            // devolver { success, data, ... } o el payload directo
+            if (raw && typeof raw === "object" && "success" in raw) {
+              return { data: raw.data, success: !!raw.success, message: raw.message, errors: raw.errors };
+            }
+            return { data: raw, success: true };
+          } catch {
+            return null;
+          }
+        };
+
+        const pcacheResponse = await fetchViaPcache();
+        cameFromPcache = pcacheResponse !== null && pcacheResponse.success;
+        const response = cameFromPcache && pcacheResponse
+          ? pcacheResponse
+          : await productEndpoints.getByCodigoMarket(codigoMarketBase);
+
         // La API puede devolver los productos en 'products' o en 'allGroupedProducts'
         const productsArray = response.data?.products || (response.data as { allGroupedProducts?: typeof response.data.products })?.allGroupedProducts;
 
@@ -1232,6 +1258,29 @@ export const useProduct = (productId: string) => {
               )
               .slice(0, 4);
             if (isMounted) setRelatedProducts(related);
+
+            // Si vino del proxy cacheado (hasta 2 min de antigüedad), refrescar
+            // en background contra el endpoint directo — mismo patrón SWR que el
+            // camino de cache in-memory de arriba
+            if (cameFromPcache) {
+              productEndpoints.getByCodigoMarket(codigoMarketBase)
+                .then((fresh) => {
+                  const freshProducts = fresh.data?.products || (fresh.data as { allGroupedProducts?: typeof fresh.data.products })?.allGroupedProducts;
+                  if (!fresh.success || !freshProducts || freshProducts.length === 0) return;
+                  const freshMapped = mapApiProductsToFrontend(freshProducts);
+                  if (freshMapped.length === 0) return;
+                  productCache.setSingleProduct(productId, fresh, 10 * 60 * 1000);
+                  if (isMounted) {
+                    setProduct((prev) => {
+                      if (!prev || JSON.stringify(prev) !== JSON.stringify(freshMapped[0])) {
+                        return freshMapped[0];
+                      }
+                      return prev;
+                    });
+                  }
+                })
+                .catch(() => { /* ya tenemos datos del proxy cacheado */ });
+            }
           } else {
             if (isMounted) setError("Producto no encontrado");
           }


### PR DESCRIPTION
> **PR apilada sobre #1039** (`perf/flixmedia-cache-preconnect`). Mergear #1039 primero y luego re-apuntar esta a `develop` (GitHub lo hace solo al mergear la base).

## Resumen

La llamada `/api/products/filtered?codigoMarket=X` es el **gate de toda la PDP**: hasta que no responde, no hay MPN y Flixmedia no puede arrancar. Cada navegador la pagaba completa contra Railway.

- **Nuevo proxy `/api/pcache/product?codigoMarket=X`**: Data Cache de Next (revalidate 120s), compartido entre TODOS los usuarios + headers CDN (`s-maxage=120, stale-while-revalidate=300`).
- **`useProduct`**: primer load vía el proxy cacheado con **fallback transparente** al endpoint directo si falla; luego **refresh en background** contra el endpoint directo (mismo patrón SWR que ya usaba el caché in-memory) para corregir precio/stock con hasta 2 min de antigüedad.
- El catálogo es público (los listados lo consultan sin login) → seguro de compartir entre usuarios. La tolerancia a staleness ya existía: caché client-side de 10 min + SWR.

## Medición (servidor de producción local, producto real `EF-CS947CTEGWW`)

| Camino | Tiempo |
|---|---|
| Backend directo (antes, cada usuario) | 263–540ms |
| Proxy fría (solo 1er visitante c/2 min) | 296ms |
| **Proxy cacheada (todos los demás)** | **5–9ms** |

- ✅ Integridad: misma cantidad de productos en respuesta directa vs cacheada
- ✅ Sin `codigoMarket` → 400; el rewrite `/api/:path*` → Railway sigue intacto para las demás rutas
- ✅ `npm run build` exitoso, `tsc --noEmit` limpio, ESLint sin problemas nuevos (los 2 errores de `any` en useProducts.ts:275-277 son preexistentes en main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)