### PR TITLE
fix(telemetry): precisión PostHog + Meta pixel — purchase canónico, add_to_cart centralizado, consent-timing CAPI, AM invitados

### DIFF
--- a/src/app/carrito/Step2.tsx
+++ b/src/app/carrito/Step2.tsx
@@ -24,6 +24,7 @@ import { toast } from "sonner";
 import { associateEmailWithSession, identifyEmailEarly } from "@/lib/posthogClient";
 import { trackCheckoutStep } from "./utils/checkoutTracking";
 import { fbqTrackCustom } from "@/lib/meta-pixel";
+import { applyKnownUserAM } from "@/lib/analytics/emitters/emit.meta";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -546,6 +547,11 @@ export default function Step2({
             localStorage.setItem("imagiq_user", JSON.stringify(userWithRole));
             // console.log("✅ [Step2] Token y usuario guardados en localStorage");
 
+            // Advanced Matching de Meta: el invitado acaba de identificarse
+            // (auto-login) — punto natural para que los eventos siguientes del
+            // pixel (SelectPaymentMethod, AddPaymentInfo, Purchase) lleven em/ph.
+            applyKnownUserAM();
+
             // Guardar userId de forma consistente
             const { saveUserId } = await import('@/app/carrito/utils/getUserId');
             saveUserId(autoLoginResult.user.id, autoLoginResult.user.email, false);
@@ -674,6 +680,10 @@ export default function Step2({
         // Guardar token y usuario - cuenta de invitado creada y verificada
         localStorage.setItem("imagiq_token", result.access_token);
         localStorage.setItem("imagiq_user", JSON.stringify(userWithRole));
+
+        // Advanced Matching de Meta: primer punto donde el invitado queda
+        // identificado (OTP verificado). Consent-safe vía deliverOrQueue.
+        applyKnownUserAM();
 
         // CRÍTICO: Guardar userId de forma consistente en todas las fuentes
         const { saveUserId } = await import('@/app/carrito/utils/getUserId');

--- a/src/app/carrito/components/SuggestionCard.tsx
+++ b/src/app/carrito/components/SuggestionCard.tsx
@@ -226,8 +226,10 @@ export default function SuggestionCard({ product }: SuggestionCardProps) {
         desDetallada: productSelection.selectedVariant?.desDetallada,
         modelo: product.modelo?.[0] || "",
         categoria: product.categoria || "",
-      });
+      }, { source: "suggestion_card" });
 
+      // Evento de intención específico (complementario al add_to_cart_click
+      // centralizado de CartContext, que es el paso de funnel).
       posthogUtils.capture("suggestion_add_to_cart", {
         product_id: product.codigoMarketBase,
         product_name: currentProductName,

--- a/src/app/carrito/step1/page.tsx
+++ b/src/app/carrito/step1/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import Step1 from "../Step1";
 import { addressesService } from "@/services/addresses.service";
 import { useCheckoutAddress } from "@/features/checkout";
+import { trackStep2Skipped } from "../utils/checkoutTracking";
 
 export default function Step1Page() {
   const router = useRouter();
@@ -25,6 +26,7 @@ export default function Step1Page() {
     const token = localStorage.getItem("imagiq_token");
     if (token && loggedUser?.email && userRole !== 3) {
       console.log("✅ [STEP1] Usuario regular autenticado (rol !== 3), yendo directo a step3");
+      trackStep2Skipped("registered", "step1_registered_user");
       router.push("/carrito/step3");
       return;
     }
@@ -34,6 +36,7 @@ export default function Step1Page() {
       // Primero verificar el contexto (más rápido)
       if (selectedAddress && selectedAddress.id) {
         console.log("✅ [STEP1] Usuario invitado con dirección en contexto, yendo a step3");
+        trackStep2Skipped("returning_guest", "step1_guest_address_in_context");
         router.push("/carrito/step3");
         return;
       }
@@ -47,6 +50,7 @@ export default function Step1Page() {
           if (addresses[0]) {
             selectAddress(addresses[0]);
           }
+          trackStep2Skipped("returning_guest", "step1_guest_address_in_db");
           router.push("/carrito/step3");
           return;
         }

--- a/src/app/carrito/step2/page.tsx
+++ b/src/app/carrito/step2/page.tsx
@@ -5,6 +5,7 @@ import Step2 from "../Step2";
 import useSecureStorage from "@/hooks/useSecureStorage";
 import { User } from "@/types/user";
 import { useCheckoutAddress } from "@/features/checkout";
+import { trackStep2Skipped } from "../utils/checkoutTracking";
 
 export default function Step2Page() {
   const router = useRouter();
@@ -54,6 +55,7 @@ export default function Step2Page() {
         // Si es usuario REGULAR (rol 2 o cualquier rol diferente a 3), redirigir a step3
         if (userRole !== 3) {
           console.log("⚠️ [STEP2] Usuario regular detectado (rol !== 3). Redirigiendo a step3...");
+          trackStep2Skipped("registered", "step2_guard_registered_user");
           router.push("/carrito/step3");
           return;
         }
@@ -62,6 +64,7 @@ export default function Step2Page() {
         // Si ya tiene dirección, debe ir a Step3, no quedarse en Step2
         if (selectedAddress && selectedAddress.ciudad && selectedAddress.lineaUno) {
           console.log("⚠️ [STEP2] Usuario invitado YA tiene dirección válida. Redirigiendo a step3...");
+          trackStep2Skipped("returning_guest", "step2_guard_guest_with_address");
           router.push("/carrito/step3");
           return;
         }
@@ -76,6 +79,7 @@ export default function Step2Page() {
       // Si ya hay dirección, redirigir a Step3 (es un invitado que ya completó Step2)
       if (selectedAddress && selectedAddress.ciudad && selectedAddress.lineaUno) {
         console.log("⚠️ [STEP2] Ya hay dirección válida guardada. Redirigiendo a step3...");
+        trackStep2Skipped("restored_session", "step2_guard_persisted_address_no_session");
         router.push("/carrito/step3");
         return;
       }

--- a/src/app/carrito/utils/checkoutTracking.ts
+++ b/src/app/carrito/utils/checkoutTracking.ts
@@ -106,3 +106,28 @@ export function trackCheckoutStep(
     return false;
   }
 }
+
+/**
+ * Marca el paso 2 como SALTADO en este intento — para que el funnel de PostHog
+ * sea monótono: los usuarios registrados y los invitados recurrentes con
+ * dirección persistida son ruteados step1→step3 sin montar Step2, por lo que
+ * `checkout_step2_completed` < `checkout_step3_delivery_selected` por diseño.
+ * En PostHog el paso 2 del funnel debe modelarse como
+ * `checkout_step2_completed OR checkout_step2_skipped`.
+ *
+ * Comparte el slot de dedupe del paso 2 (clave por NÚMERO de paso): máximo un
+ * evento de paso 2 por intento. Caveat aceptado: si un guard emite `skipped` y
+ * el usuario después es devuelto a Step2 (p.ej. domicilio sin dirección desde
+ * Step3) y lo completa de verdad, la completación queda etiquetada como
+ * skipped en ese intento — el conteo del funnel sigue siendo correcto.
+ *
+ * @param userType - población que salta el paso ('registered' | 'returning_guest' | 'restored_session')
+ * @param reason - guard concreto que produjo el salto (para depurar routing)
+ */
+export function trackStep2Skipped(userType: string, reason: string): boolean {
+  return trackCheckoutStep(2, "checkout_step2_skipped", {
+    user_type: userType,
+    reason,
+    skipped: true,
+  });
+}

--- a/src/app/productos/components/ProductCard.tsx
+++ b/src/app/productos/components/ProductCard.tsx
@@ -339,15 +339,9 @@ export default function ProductCard({
         return;
       }
 
-      posthogUtils.capture("add_to_cart_click", {
-        product_id: id,
-        product_name: name,
-        selected_color:
-          selectedColor?.name || productSelection.selection.selectedColor,
-        selected_color_sku: currentSku || "",
-        selected_color_ean: eanToUse,
-        source: isInChat ? "chatbot" : "product_card",
-      });
+      // add_to_cart_click ahora se emite centralizado en CartContext.addProduct
+      // (nivel mutación) — aquí solo pasamos el `source`; así no se dobla el
+      // conteo ni se pierden los adds de otros botones/PDPs.
 
       // Agrega el producto al carrito usando el contexto - SIEMPRE cantidad 1
       // shippingCity y shippingStore se obtienen automáticamente del backend
@@ -411,7 +405,7 @@ export default function ProductCard({
           apiProduct?.indRetoma?.[
           productSelection.selectedVariant?.index || 0
           ] ?? (acceptsTradeIn ? 1 : 0),
-      });
+      }, { source: isInChat ? "chatbot" : "product_card" });
 
       // Si está en el chat, cerrar el chat y redirigir al carrito
       if (isInChat) {
@@ -615,7 +609,7 @@ export default function ProductCard({
           apiProduct?.indRetoma?.[
           productSelection.selectedVariant?.index || 0
           ] ?? (acceptsTradeIn ? 1 : 0),
-      });
+      }, { source: "entrego_estreno" });
 
       // Marcar que debe abrirse el modal de Trade-In automáticamente para este SKU específico
       // Guardar ANTES de navegar para asegurar que esté disponible

--- a/src/app/success-checkout/[orderId]/page.tsx
+++ b/src/app/success-checkout/[orderId]/page.tsx
@@ -141,6 +141,9 @@ export default function SuccessCheckoutPage({
   const { trackPurchase } = useAnalyticsWithUser();
   const whatsappSentRef = useRef(false);
   const analyticsSentRef = useRef(false);
+  // Guard de vuelo: el effect puede re-correr (strict-mode / trackPurchase cambia
+  // de identidad cuando hidrata userData) mientras el fetch sigue en el aire.
+  const analyticsInFlightRef = useRef(false);
   const emailSentRef = useRef(false);
   // Hook para obtener usuario del localStorage encriptado (para usuarios sin sesión activa pero con cuenta creada en Step2)
   const [loggedUser] = useSecureStorage<User | null>("imagiq_user", null);
@@ -148,8 +151,12 @@ export default function SuccessCheckoutPage({
   // Enviar evento de purchase a analytics
   useEffect(() => {
     const sendPurchaseEvent = async () => {
-      if (analyticsSentRef.current) return;
-      analyticsSentRef.current = true;
+      // `analyticsSentRef` se marca solo DESPUÉS de un envío exitoso: un fallo
+      // transitorio del fetch ya no pierde el Purchase para siempre (el effect
+      // re-corre cuando trackPurchase cambia de identidad al hidratar userData).
+      // `analyticsInFlightRef` evita dobles fetch/track concurrentes.
+      if (analyticsSentRef.current || analyticsInFlightRef.current) return;
+      analyticsInFlightRef.current = true;
 
       try {
         const orderResponse = await apiClient.get<OrderData>(
@@ -185,14 +192,21 @@ export default function SuccessCheckoutPage({
             quantity: item.quantity || item.cantidad || 1,
           }));
 
-          // Enviar evento de purchase a GA4/Meta/TikTok
-          trackPurchase(pathParams.orderId, mappedItems, totalValue);
+          // Enviar evento de purchase a GA4/Meta/TikTok. Si el valor no es
+          // positivo (orden aún sin total consistente) NO emitimos: el CAPI
+          // server-side de payments-ms carga la orden con el valor real.
+          if (totalValue > 0) {
+            trackPurchase(pathParams.orderId, mappedItems, totalValue);
+          }
 
-          // Enviar evento de purchase a PostHog (client-side, dedup via $insert_id en server)
+          // Señal de aterrizaje en la página de confirmación (PostHog).
+          // OJO: NO es el evento canónico `purchase` — ese lo emite payments-ms
+          // server-side (idempotente vía posthog_captured_at). El capture
+          // client-side de `purchase` se eliminó porque PostHog NO dedupea por
+          // $insert_id (eso es semántica Mixpanel/Amplitude) y cada compra web
+          // contaba doble.
           try {
-            posthogUtils.capture("purchase", {
-              $insert_id: `purchase_${pathParams.orderId}`,
-              event_id: `purchase_${pathParams.orderId}`,
+            posthogUtils.capture("purchase_confirmation_viewed", {
               order_id: pathParams.orderId,
               transaction_id: pathParams.orderId,
               currency: "COP",
@@ -208,11 +222,16 @@ export default function SuccessCheckoutPage({
               source: "client",
             });
           } catch (e) {
-            console.error("[PostHog] Error capturing purchase:", e);
+            console.error("[PostHog] Error capturing purchase confirmation:", e);
           }
+
+          // Éxito real: recién aquí bloqueamos futuros reenvíos.
+          analyticsSentRef.current = true;
         }
       } catch (error) {
         console.error("[Analytics] Error sending purchase event:", error);
+      } finally {
+        analyticsInFlightRef.current = false;
       }
     };
 

--- a/src/components/PremiumProductInfo.tsx
+++ b/src/components/PremiumProductInfo.tsx
@@ -88,13 +88,7 @@ const PremiumProductInfo: React.FC<{ product: ProductCardProps }> = ({
         categoria: product.apiProduct?.categoria || "",
       });
 
-      posthogUtils.capture("add_to_cart_click", {
-        product_id: product.id,
-        product_name: product.name,
-        selected_color: selectedColor.color,
-        selected_storage: selectedStorage.capacidad,
-        price: currentPrice,
-      });
+      // add_to_cart_click se emite centralizado en CartContext.addProduct.
 
       alert("Producto agregado al carrito");
     } catch (error) {

--- a/src/components/analytics/MetaPixelScript.tsx
+++ b/src/components/analytics/MetaPixelScript.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { hasMarketingConsent } from "@/lib/consent";
+import { applyKnownUserAM } from "@/lib/analytics/emitters/emit.meta";
 
 /**
  * Meta Pixel (Facebook) - First-Party Loading
@@ -69,10 +70,16 @@ export default function MetaPixelScript() {
 
     // Cargar inmediatamente
     loadMetaPixel();
+    // Advanced Matching proactivo para usuario ya conocido (imagiq_user en
+    // localStorage): antes el AM solo se aplicaba como efecto lateral del
+    // siguiente evento con `user` del AuthContext. Consent-safe: la llamada
+    // se encola hasta fbq+consentimiento (deliverOrQueue) y expira si no hay.
+    applyKnownUserAM();
 
     // Escuchar cambios de consentimiento
     const handleConsentChange = () => {
       loadMetaPixel();
+      applyKnownUserAM();
     };
 
     window.addEventListener("consentChange", handleConsentChange);

--- a/src/features/auth/context.tsx
+++ b/src/features/auth/context.tsx
@@ -21,6 +21,7 @@ import { User } from "@/types/user";
 import { addressesService } from "@/services/addresses.service";
 import { setPosthogUserId, posthogUtils } from "@/lib/posthogClient";
 import { mergeSearchHistoryOnLogin } from "@/lib/searchHistory";
+import { applyKnownUserAM } from "@/lib/analytics/emitters/emit.meta";
 
 interface AuthContextType {
   user: User | null;
@@ -184,6 +185,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       telefono: userData.telefono,
       role: userRole,
     });
+
+    // Advanced Matching de Meta para el usuario recién logueado (lee el
+    // imagiq_user que acabamos de persistir; consent-safe vía deliverOrQueue).
+    applyKnownUserAM();
 
     // Merge del historial de búsqueda anónimo → usuario (reasigna las búsquedas
     // pre-login al usuario; espejo del identify() de PostHog). Best-effort.

--- a/src/features/cart/CartContext.tsx
+++ b/src/features/cart/CartContext.tsx
@@ -15,6 +15,7 @@ import { CartProduct, BundleInfo, useCart } from "@/hooks/useCart";
 import { useAnalyticsWithUser } from "@/lib/analytics";
 import { apiClient } from "@/lib/api";
 import { apiPost } from "@/lib/api-client";
+import { posthogUtils } from "@/lib/posthogClient";
 import { preloadCartSuggestions } from "@/lib/preloadCartSuggestions";
 import React, { createContext, useCallback, useContext } from "react";
 
@@ -25,8 +26,13 @@ import React, { createContext, useCallback, useContext } from "react";
 type CartContextType = {
   /** Array de productos en el carrito */
   cart: CartProduct[];
-  /** Añade un producto al carrito (o suma cantidad si ya existe) */
-  addProduct: (product: CartProduct) => Promise<void>;
+  /** Añade un producto al carrito (o suma cantidad si ya existe).
+   *  `options.source` identifica el origen UI del add (product_card, chatbot,
+   *  pdp_view, suggestion_card, …) para el evento PostHog centralizado. */
+  addProduct: (
+    product: CartProduct,
+    options?: { source?: string }
+  ) => Promise<void>;
   /** Elimina un producto por id */
   removeProduct: (id: string) => void;
   /** Actualiza la cantidad de un producto */
@@ -50,7 +56,8 @@ type CartContextType = {
   /** Añade todos los productos de un bundle al carrito */
   addBundleToCart: (
     items: Omit<CartProduct, "quantity">[],
-    bundleInfo: BundleInfo
+    bundleInfo: BundleInfo,
+    options?: { source?: string }
   ) => Promise<void>;
   /** Actualiza la cantidad de todos los productos de un bundle */
   updateBundleQuantity: (
@@ -116,7 +123,7 @@ export const CartProvider = ({ children }: { children: React.ReactNode }) => {
 
   // Memoizar funciones para evitar que cambien en cada render
   const addProduct = useCallback(
-    async (product: CartProduct) => {
+    async (product: CartProduct, options?: { source?: string }) => {
       // Extraer quantity del producto y pasarlo por separado para evitar problemas de tipo
       const { quantity, ...productWithoutQuantity } = product;
       await addToCart(productWithoutQuantity, quantity || 1, user?.id);
@@ -133,6 +140,18 @@ export const CartProvider = ({ children }: { children: React.ReactNode }) => {
         price: Number(product.price),
         quantity: quantity || 1,
         currency: "COP",
+      });
+
+      // PostHog add_to_cart_click a nivel de MUTACIÓN (punto único): todos los
+      // caminos vivos de UI (catálogo, PDPs, sugerencias, entrego-y-estreno)
+      // pasan por aquí, así el funnel no pierde adds instrumentados por-botón.
+      posthogUtils.capture("add_to_cart_click", {
+        product_id: product.id,
+        product_name: product.name,
+        sku: product.sku || product.id,
+        price: Number(product.price),
+        quantity: quantity || 1,
+        source: options?.source || "unknown",
       });
 
       // Precargar sugerencias en background para el popover
@@ -159,7 +178,11 @@ export const CartProvider = ({ children }: { children: React.ReactNode }) => {
   // ==================== MÉTODOS DE BUNDLE ====================
 
   const addBundleToCart = useCallback(
-    async (items: Omit<CartProduct, "quantity">[], bundleInfo: BundleInfo) => {
+    async (
+      items: Omit<CartProduct, "quantity">[],
+      bundleInfo: BundleInfo,
+      options?: { source?: string }
+    ) => {
       await addBundleToCartHook(items, bundleInfo, user?.id);
 
       // Track del evento para analytics (bundle completo con SKU del bundle)
@@ -174,6 +197,19 @@ export const CartProvider = ({ children }: { children: React.ReactNode }) => {
         price: Number(bundleInfo.bundleDiscount),
         quantity: 1,
         currency: "COP",
+      });
+
+      // PostHog add_to_cart_click centralizado (mismo evento que addProduct,
+      // marcado is_bundle para poder segmentar). Precio disponible del bundle:
+      // bundleDiscount (igual que usa trackAddToCart arriba).
+      posthogUtils.capture("add_to_cart_click", {
+        product_id: bundleInfo.productSku,
+        product_name: bundleName,
+        sku: bundleInfo.productSku,
+        price: Number(bundleInfo.bundleDiscount),
+        quantity: 1,
+        source: options?.source || "unknown",
+        is_bundle: true,
       });
 
       // Precargar sugerencias en background para el popover

--- a/src/lib/analytics/controller.ts
+++ b/src/lib/analytics/controller.ts
@@ -82,7 +82,8 @@ export async function processAnalyticsEvent(
     // 1. Generar event_id deduplicable
     const eventId = await generateEventIdForEvent(event);
 
-    // 2. Mapear a cada plataforma
+    // 2. Mapear a cada plataforma. `metaEvent` puede ser null (Purchase con
+    // value inválido/<=0 se omite en Meta; GA4/TikTok no se ven afectados).
     const ga4Event = toGa4Event(event);
     const metaEvent = toMetaEvent(event, eventId, user);
     const tiktokEvent = toTiktokEvent(event, eventId, user);
@@ -112,7 +113,7 @@ export async function processAnalyticsEvent(
       });
       if (Object.keys(pixelAM).length > 0) setMetaAdvancedMatching(pixelAM);
     }
-    sendMeta(metaEvent, eventId);
+    if (metaEvent) sendMeta(metaEvent, eventId);
     sendTiktok(tiktokEvent, eventId);
 
     // 5. SERVER-SIDE: Enviar a CAPI SIEMPRE (modo condicional)
@@ -132,22 +133,29 @@ export async function processAnalyticsEvent(
  * Modo FULL o ANONYMOUS se decide dentro de cada emisor.
  */
 async function sendServerSideEvents(
-  metaEvent: MetaEvent,
+  metaEvent: MetaEvent | null,
   tiktokEvent: TikTokEvent,
   eventId: string,
   user?: AnalyticsUserData
 ): Promise<void> {
   try {
-    // Construir custom_data para Meta CAPI (type-safe extraction)
-    const metaCustomData: MetaCapiCustomData = {
-      value: typeof metaEvent.data.value === 'number' ? metaEvent.data.value : undefined,
-      currency: typeof metaEvent.data.currency === 'string' ? metaEvent.data.currency : undefined,
-      content_type: typeof metaEvent.data.content_type === 'string' ? metaEvent.data.content_type : undefined,
-      content_ids: Array.isArray(metaEvent.data.content_ids) ? metaEvent.data.content_ids : undefined,
-      content_name: typeof metaEvent.data.content_name === 'string' ? metaEvent.data.content_name : undefined,
-      num_items: typeof metaEvent.data.num_items === 'number' ? metaEvent.data.num_items : undefined,
-      search_string: typeof metaEvent.data.search_string === 'string' ? metaEvent.data.search_string : undefined,
-    };
+    const capiSends: Promise<void>[] = [];
+
+    // Meta CAPI solo si el mapper no omitió el evento (paridad con el pixel:
+    // un Purchase con value inválido no se envía por NINGUNA de las dos patas).
+    if (metaEvent) {
+      // Construir custom_data para Meta CAPI (type-safe extraction)
+      const metaCustomData: MetaCapiCustomData = {
+        value: typeof metaEvent.data.value === 'number' ? metaEvent.data.value : undefined,
+        currency: typeof metaEvent.data.currency === 'string' ? metaEvent.data.currency : undefined,
+        content_type: typeof metaEvent.data.content_type === 'string' ? metaEvent.data.content_type : undefined,
+        content_ids: Array.isArray(metaEvent.data.content_ids) ? metaEvent.data.content_ids : undefined,
+        content_name: typeof metaEvent.data.content_name === 'string' ? metaEvent.data.content_name : undefined,
+        num_items: typeof metaEvent.data.num_items === 'number' ? metaEvent.data.num_items : undefined,
+        search_string: typeof metaEvent.data.search_string === 'string' ? metaEvent.data.search_string : undefined,
+      };
+      capiSends.push(sendMetaCapi(metaEvent.name, eventId, metaCustomData, user));
+    }
 
     // Construir properties para TikTok Events API (type-safe extraction)
     const tiktokProperties: TikTokEventsProperties = {
@@ -158,12 +166,10 @@ async function sendServerSideEvents(
       num_items: typeof tiktokEvent.data.num_items === 'number' ? tiktokEvent.data.num_items : undefined,
       search_string: typeof tiktokEvent.data.search_string === 'string' ? tiktokEvent.data.search_string : undefined,
     };
+    capiSends.push(sendTikTokCapi(tiktokEvent.name, eventId, tiktokProperties, user));
 
     // Enviar a ambas APIs en paralelo
-    await Promise.all([
-      sendMetaCapi(metaEvent.name, eventId, metaCustomData, user),
-      sendTikTokCapi(tiktokEvent.name, eventId, tiktokProperties, user),
-    ]);
+    await Promise.all(capiSends);
   } catch (error) {
     console.error('[Analytics] Failed to send server-side events:', error);
   }

--- a/src/lib/analytics/emitters/emit.meta-capi.ts
+++ b/src/lib/analytics/emitters/emit.meta-capi.ts
@@ -19,19 +19,21 @@ import type {
   CapiResponse,
 } from '../types/capi';
 import type { AnalyticsUserData } from '../controller';
-import { canSendAds, logConsentBlocked } from '../utils';
+import { canSendAds, isAdsConsentResolved } from '../utils';
 import { hashUserData } from '../utils/hash';
-import { anonymizeIP, getFacebookCookies } from '../utils/anonymize';
+import { getFacebookCookies } from '../utils/anonymize';
 
 /**
- * Obtiene la IP del cliente (simulado en navegador)
+ * IP del cliente: NO se envía desde el navegador.
  *
- * NOTA: La IP real se captura en el backend desde el request HTTP
- * Esta función retorna una IP genérica para cumplir con el tipo
+ * Devuelve `undefined` para que la clave se OMITA del payload y el backend
+ * (customer-success-ms analytics.controller) haga fallback a `x-forwarded-for`
+ * — la IP real del cliente que el gateway ya reenvía. El antiguo stub
+ * '0.0.0.0' era truthy y mataba ese fallback: TODOS los eventos CAPI del
+ * browser llegaban a Meta con IP 0.0.0.0 (EMQ capado).
  */
-function getClientIP(): string {
-  // En producción, el backend extrae la IP del request
-  return '0.0.0.0';
+function getClientIP(): string | undefined {
+  return undefined;
 }
 
 /**
@@ -77,8 +79,150 @@ export async function sendMetaCapi(
   customData: MetaCapiCustomData,
   userData?: AnalyticsUserData
 ): Promise<void> {
-  const hasConsent = canSendAds();
+  // Consentimiento ya resuelto (concedido o denegado): comportamiento actual,
+  // envío inmediato en el modo que corresponda.
+  if (canSendAds()) {
+    await dispatchMetaCapi(eventName, eventId, customData, userData, true);
+    return;
+  }
+  if (isAdsConsentResolved() || typeof window === 'undefined') {
+    // Denegado explícitamente (o SSR): anónimo de inmediato, sin esperar.
+    await dispatchMetaCapi(eventName, eventId, customData, userData, false);
+    return;
+  }
 
+  // Consentimiento PENDIENTE (banner sin responder): encolar con ventana
+  // acotada — simetría con la pata del pixel (emit.meta.ts deliverOrQueue),
+  // que espera ~10s a consentimiento y luego dispara CON fbc/AM. Antes el
+  // CAPI muestreaba canSendAds() una sola vez y salía ANONYMOUS (sin
+  // fbc/fbp/PII) aunque el usuario consintiera milisegundos después → Meta
+  // veía el evento server sin fbc pareado con el pixel con fbc.
+  //
+  // Fire-and-forget: NO bloqueamos al caller (processAnalyticsEvent awaitea
+  // este promise; esperar 10s retrasaría el abandon-tracking y los hooks).
+  // El event_id se captura al encolar → dedup con el pixel intacto.
+  pendingCapiEvents.push({
+    eventName,
+    eventId,
+    customData,
+    userData,
+    attemptsLeft: CONSENT_MAX_ATTEMPTS,
+  });
+  ensureCapiFlushScheduled();
+}
+
+// ---------------------------------------------------------------------------
+// Cola de espera de consentimiento (solo eventos disparados ANTES de que el
+// usuario responda el banner). No depende de window.fbq: el CAPI debe
+// funcionar aunque un ad-blocker impida cargar el pixel.
+// ---------------------------------------------------------------------------
+
+interface PendingCapiEvent {
+  eventName: string;
+  eventId: string;
+  customData: MetaCapiCustomData;
+  userData?: AnalyticsUserData;
+  attemptsLeft: number;
+}
+
+const CONSENT_RETRY_INTERVAL_MS = 400;
+const CONSENT_MAX_ATTEMPTS = 25; // ~10s: misma ventana que la cola del pixel
+
+const pendingCapiEvents: PendingCapiEvent[] = [];
+let capiFlushTimer: ReturnType<typeof setInterval> | null = null;
+let capiConsentListenerAttached = false;
+
+function stopCapiFlushTimer(): void {
+  if (capiFlushTimer !== null) {
+    clearInterval(capiFlushTimer);
+    capiFlushTimer = null;
+  }
+}
+
+/** Drena la cola enviando cada evento en el modo indicado. */
+function drainPendingCapiEvents(hasConsent: boolean): void {
+  while (pendingCapiEvents.length > 0) {
+    const item = pendingCapiEvents.shift() as PendingCapiEvent;
+    void dispatchMetaCapi(
+      item.eventName,
+      item.eventId,
+      item.customData,
+      item.userData,
+      hasConsent
+    );
+  }
+  stopCapiFlushTimer();
+}
+
+/** Revalida consentimiento en cada tick y resuelve la cola. */
+function flushPendingCapiEvents(): void {
+  if (pendingCapiEvents.length === 0) {
+    stopCapiFlushTimer();
+    return;
+  }
+
+  // Consentimiento concedido dentro de la ventana → FULL (con fbc/fbp/PII).
+  if (canSendAds()) {
+    drainPendingCapiEvents(true);
+    return;
+  }
+
+  // Denegado explícitamente → anónimo ya (no seguir esperando).
+  if (isAdsConsentResolved()) {
+    drainPendingCapiEvents(false);
+    return;
+  }
+
+  // Sigue pendiente: decrementar intentos; los agotados salen en anónimo
+  // (comportamiento pre-fix, solo que ~10s más tarde).
+  for (let i = pendingCapiEvents.length - 1; i >= 0; i--) {
+    pendingCapiEvents[i].attemptsLeft -= 1;
+    if (pendingCapiEvents[i].attemptsLeft <= 0) {
+      const [expired] = pendingCapiEvents.splice(i, 1);
+      void dispatchMetaCapi(
+        expired.eventName,
+        expired.eventId,
+        expired.customData,
+        expired.userData,
+        false
+      );
+    }
+  }
+
+  if (pendingCapiEvents.length === 0) {
+    stopCapiFlushTimer();
+  }
+}
+
+function ensureCapiFlushScheduled(): void {
+  if (typeof window === 'undefined') return;
+
+  if (capiFlushTimer === null && pendingCapiEvents.length > 0) {
+    capiFlushTimer = setInterval(flushPendingCapiEvents, CONSENT_RETRY_INTERVAL_MS);
+  }
+
+  // Resolución inmediata al responder el banner (mismo CustomEvent que usa la
+  // pata del pixel): no esperar al próximo tick del intervalo.
+  if (!capiConsentListenerAttached) {
+    capiConsentListenerAttached = true;
+    window.addEventListener('consentChange', () => {
+      setTimeout(flushPendingCapiEvents, 0);
+    });
+  }
+}
+
+/**
+ * Construye y envía el evento CAPI al backend en el modo indicado.
+ * `event_time` se calcula al ENVIAR (no al encolar) — irrelevante para el
+ * dedup de Meta (ventana de 48h por event_id).
+ */
+async function dispatchMetaCapi(
+  eventName: string,
+  eventId: string,
+  customData: MetaCapiCustomData,
+  userData: AnalyticsUserData | undefined,
+  hasConsent: boolean
+): Promise<void> {
   try {
     // Construir user_data según consentimiento
     const user_data: MetaCapiUserData = hasConsent
@@ -149,13 +293,13 @@ async function buildFullUserData(
 
 /**
  * Construye user_data ANÓNIMO (sin consentimiento)
+ *
+ * Sin IP hardcodeada: `getClientIP()` devuelve undefined → la clave se omite
+ * y el backend resuelve/anonimiza la IP real desde x-forwarded-for.
  */
 function buildAnonymousUserData(): MetaCapiUserData {
-  const ip = getClientIP();
-  const anonymizedIP = anonymizeIP(ip);
-
   return {
-    client_ip_address: anonymizedIP,
+    client_ip_address: getClientIP(),
   };
 }
 

--- a/src/lib/analytics/emitters/emit.meta.ts
+++ b/src/lib/analytics/emitters/emit.meta.ts
@@ -17,7 +17,7 @@
  */
 
 import type { MetaEvent } from '../mappers';
-import { canSendAds, logConsentBlocked } from '../utils';
+import { canSendAds, logConsentBlocked, normalizeUserDataForPixel } from '../utils';
 
 interface PendingMetaEvent {
   /** Nombre del evento (para logs) */
@@ -181,6 +181,55 @@ export function setMetaAdvancedMatching(userData: Record<string, string>): void 
       lastAppliedAMKey = key; // marcar solo tras aplicar realmente
     }
   });
+}
+
+/**
+ * Aplica Advanced Matching para el usuario CONOCIDO persistido en localStorage.
+ *
+ * Problema que resuelve: el AM solo se aplicaba como efecto lateral de
+ * processAnalyticsEvent cuando el evento traía `user` (derivado del estado
+ * React del AuthContext) — en hard loads el evento del mount (p.ej.
+ * InitiateCheckout en Step1) disparaba ANTES de que loadSession() poblara el
+ * contexto, así que ni los usuarios logueados aportaban `em`.
+ *
+ * Lee `imagiq_user` directo de localStorage (clave en WHITELIST_KEYS de
+ * secureStorage → nombre plano; el valor lo escriben AuthContext.login() y el
+ * flujo OTP de Step2 como JSON plano), normaliza para el píxel (plaintext —
+ * el píxel hashea internamente) y delega en setMetaAdvancedMatching, que ya es
+ * consent-safe (deliverOrQueue revalida canSendAds en cada intento) e
+ * idempotente por contenido.
+ *
+ * Llamar: al montar la app (bootstrap del pixel / listener de consentChange),
+ * en AuthContext.login(), y al identificarse un invitado (Step2 OTP/auto-login).
+ */
+export function applyKnownUserAM(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem('imagiq_user');
+    if (!raw) return;
+
+    const user = JSON.parse(raw) as {
+      id?: string;
+      email?: string;
+      telefono?: string;
+      nombre?: string;
+      apellido?: string;
+    } | null;
+    if (!user || typeof user !== 'object') return;
+
+    const amData = normalizeUserDataForPixel({
+      id: user.id,
+      email: user.email,
+      phone: user.telefono,
+      firstName: user.nombre,
+      lastName: user.apellido,
+    });
+    if (Object.keys(amData).length > 0) {
+      setMetaAdvancedMatching(amData);
+    }
+  } catch {
+    // best-effort: valor corrupto/encriptado → sin AM (igual que hoy)
+  }
 }
 
 /**

--- a/src/lib/analytics/emitters/index.ts
+++ b/src/lib/analytics/emitters/index.ts
@@ -3,7 +3,7 @@
  */
 
 export { sendGa4 } from './emit.ga4';
-export { sendMeta, sendMetaCustom, setMetaAdvancedMatching } from './emit.meta';
+export { sendMeta, sendMetaCustom, setMetaAdvancedMatching, applyKnownUserAM } from './emit.meta';
 export { sendTiktok } from './emit.tiktok';
 export { sendMetaCapi } from './emit.meta-capi';
 export { sendTikTokCapi } from './emit.tiktok-capi';

--- a/src/lib/analytics/mappers/map.meta.ts
+++ b/src/lib/analytics/mappers/map.meta.ts
@@ -31,7 +31,9 @@ export interface MetaEvent {
  * @param event - Evento del dataLayer
  * @param eventId - Event ID para deduplicación (generado con utils/id.ts)
  * @param user - Datos de usuario para Advanced Matching (opcional)
- * @returns Evento formateado para Meta Pixel
+ * @returns Evento formateado para Meta Pixel, o `null` si el evento debe
+ *   OMITIRSE (p.ej. Purchase con value no finito o <= 0 — un Purchase sin
+ *   precio válido dispara los diagnósticos "invalid prices" de Meta)
  *
  * @example
  * ```typescript
@@ -50,7 +52,7 @@ export function toMetaEvent(
   event: DlAny,
   eventId: string,
   user?: { email?: string; phone?: string }
-): MetaEvent {
+): MetaEvent | null {
   switch (event.event) {
     case 'view_item':
       return {
@@ -104,18 +106,28 @@ export function toMetaEvent(
         },
       };
 
-    case 'purchase':
+    case 'purchase': {
+      // Hardening del value: coercionar a número y validar. Un Purchase con
+      // value no finito (string de pg-numeric, NaN) o <= 0 se OMITE — es
+      // exactamente lo que Meta marca como "invalid prices" / "all same
+      // price"; el CAPI server-side (payments-ms) carga la orden con el
+      // valor real de ordenes.total_amount.
+      const purchaseValue = Number(event.ecommerce.value);
+      if (!Number.isFinite(purchaseValue) || purchaseValue <= 0) {
+        return null;
+      }
       return {
         name: 'Purchase',
         data: {
           content_ids: event.ecommerce.items.map((i) => i.item_id),
           content_type: 'product',
           contents: mapContents(event.ecommerce.items),
-          value: event.ecommerce.value,
-          currency: event.ecommerce.currency,
+          value: purchaseValue,
+          currency: event.ecommerce.currency || 'COP',
           num_items: event.ecommerce.items.reduce((sum, i) => sum + (i.quantity || 1), 0),
         },
       };
+    }
 
     case 'search':
       return {

--- a/src/lib/analytics/utils/consent.ts
+++ b/src/lib/analytics/utils/consent.ts
@@ -3,7 +3,7 @@
  * Wrapper sobre la API de consentimiento existente
  */
 
-import { hasAdsConsent as hasAdsConsentBase, hasAnalyticsConsent as hasAnalyticsConsentBase } from '@/lib/consent';
+import { getConsent, hasAdsConsent as hasAdsConsentBase, hasAnalyticsConsent as hasAnalyticsConsentBase } from '@/lib/consent';
 
 /**
  * Verifica si se puede enviar eventos de analytics (GA4, Clarity)
@@ -21,6 +21,18 @@ export function canSendAnalytics(): boolean {
  */
 export function canSendAds(): boolean {
   return hasAdsConsentBase();
+}
+
+/**
+ * ¿El usuario YA respondió el banner de consentimiento (aceptar o rechazar)?
+ *
+ * Distingue "pendiente" (banner sin responder → vale la pena esperar/encolar)
+ * de "denegado" (respuesta explícita → no esperar, degradar de inmediato).
+ *
+ * @returns true si hay un estado de consentimiento persistido (concedido O denegado)
+ */
+export function isAdsConsentResolved(): boolean {
+  return getConsent() !== null;
 }
 
 /**

--- a/src/lib/analytics/utils/index.ts
+++ b/src/lib/analytics/utils/index.ts
@@ -12,4 +12,4 @@ export {
   hashUserData,
   normalizeUserDataForPixel,
 } from './hash';
-export { canSendAnalytics, canSendAds, logConsentBlocked } from './consent';
+export { canSendAnalytics, canSendAds, isAdsConsentResolved, logConsentBlocked } from './consent';


### PR DESCRIPTION
## Contexto

Lado browser de la corrección de instrumentación (PR hermano: imagiq-backend#642, que debe **desplegar primero** — este PR deja de enviar `client_ip_address: '0.0.0.0'` y depende del fallback a `x-forwarded-for` + validador anónimo nuevo de customer-success-ms).

## Fixes

### PostHog
1. **`purchase` canónico server-side**: el capture client-side de `purchase` en success-checkout se reemplaza por `purchase_confirmation_viewed` (señal de aterrizaje). PostHog NO dedupea por `$insert_id` (semántica Mixpanel/Amplitude — el comentario del código era incorrecto) y cada compra web contaba doble. El evento canónico lo emite payments-ms (idempotente vía `posthog_captured_at`). Bonus: el flag `analyticsSentRef` ahora se marca tras éxito (un fetch transitorio fallido ya no pierde el tracking para siempre) + guard de vuelo para strict-mode.
2. **`add_to_cart_click` a nivel de mutación** (`CartContext.addProduct`/`addBundleToCart`, con `source`): cubre PDPs, "Entrego y Estreno", bundles y sugerencias — antes solo ProductCard emitía y el funnel perdía la mayoría de adds. Captures por-botón duplicados eliminados.
3. **`checkout_step2_skipped`** en los 6 guards que saltan Step2 (usuarios registrados, invitados con dirección persistida, sesiones restauradas) → funnel monótono (antes: step2=22 < step3=31 personas).

### Meta
4. **Value hardening**: Purchase con value no finito o ≤0 se omite en paridad pixel+CAPI (era el diagnóstico "invalid prices"; GA4/TikTok intactos).
5. **IP real**: `getClientIP()` deja de hardcodear `'0.0.0.0'` → el backend rellena la IP real desde XFF (mayor palanca del EMQ 6.4/10).
6. **Consent-timing del CAPI**: cola acotada (~10s, simétrica al pixel) — antes el CAPI muestreaba el consentimiento una sola vez y salía ANONYMOUS sin fbc aunque el usuario consintiera ms después; era la causa del diagnóstico "el servidor envía fbc vacío" (mismo event_id, dedup intacto; early-exit si el usuario rechaza; no depende de `fbq`).
7. **`applyKnownUserAM()`**: advanced matching proactivo desde `imagiq_user` (mount + consentChange + login + OTP de invitado en Step2). Sube la cobertura de email (~20% → usuarios conocidos). Consent-safe vía `deliverOrQueue`; `meta-pixel.d.ts`/`dataLayer.ts` intactos.

## Verificación
- `tsc --noEmit`: 0 errores nuevos (21 preexistentes de `@/img/*` en develop)
- `bun run build`: exit 0
- grep: cero `posthogUtils.capture('purchase'` restante; `add_to_cart_click` solo se emite desde CartContext

## Post-merge
- Actualizar el insight de funnel en PostHog a la nueva semántica (queda a cargo del equipo de datos / ya coordinado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)