### PR TITLE
perf(flixmedia): primera carga más rápida — skipMatchApi, skeleton y prefetch en hover

### DIFF
--- a/src/app/productos/components/ProductCard.tsx
+++ b/src/app/productos/components/ProductCard.tsx
@@ -40,8 +40,47 @@ import StockNotificationModal from "@/components/StockNotificationModal";
 import { useStockNotification } from "@/hooks/useStockNotification";
 import { shouldRenderValue, shouldRenderColor } from "./utils/shouldRenderValue";
 import { prefetchFlixmediaScript } from "@/lib/flixmedia";
+import { productCache } from "@/lib/productCache";
 import CeroInteresSection from "@/components/CeroInteresSection";
 import { ZeroInterestSkuResult } from "@/services/cero-interes-sku.service";
+
+// Dedup a nivel módulo: un solo prefetch por producto mientras viva la página
+const hoverPrefetchedProducts = new Set<string>();
+
+/**
+ * Prefetch de datos de producto al hacer hover en la card, vía el proxy
+ * cacheado server-side (/api/pcache/product — Data Cache compartido, ~5-80ms).
+ * Deja la respuesta en productCache con la MISMA forma que guarda useProduct,
+ * así el click siguiente renderiza la PDP sin esperar al backend.
+ * Si falla, se limpia el dedup y la PDP carga por su camino normal.
+ */
+async function prefetchProductDataOnHover(codigoMarket: string): Promise<void> {
+  if (!codigoMarket || hoverPrefetchedProducts.has(codigoMarket)) return;
+  hoverPrefetchedProducts.add(codigoMarket);
+  if (productCache.getSingleProduct(codigoMarket)) return;
+  try {
+    const res = await fetch(
+      `/api/pcache/product?codigoMarket=${encodeURIComponent(codigoMarket)}`
+    );
+    if (!res.ok) return;
+    const raw = await res.json();
+    // Misma normalización que ApiClient.request: {success,data,...} o payload directo
+    const response =
+      raw && typeof raw === "object" && "success" in raw
+        ? { data: raw.data, success: !!raw.success }
+        : { data: raw, success: true };
+    if (response.success && response.data) {
+      productCache.setSingleProduct(
+        codigoMarket,
+        response as Parameters<typeof productCache.setSingleProduct>[1],
+        10 * 60 * 1000
+      );
+    }
+  } catch {
+    // permitir reintento en un próximo hover
+    hoverPrefetchedProducts.delete(codigoMarket);
+  }
+}
 
 export interface ProductColor {
   name: string; // Nombre técnico del color (ej: "black", "white")
@@ -675,6 +714,10 @@ export default function ProductCard({
 
   const handleMouseEnter = () => {
     prefetchFlixmediaScript();
+    // Precargar los DATOS del producto vía el proxy cacheado (/api/pcache):
+    // al hacer click, useProduct los encuentra en productCache y la PDP
+    // renderiza sin esperar al backend — Flixmedia arranca de inmediato.
+    prefetchProductDataOnHover(String(id).split("/")[0]);
   };
 
   return (

--- a/src/app/productos/multimedia/[id]/page.tsx
+++ b/src/app/productos/multimedia/[id]/page.tsx
@@ -381,6 +381,10 @@ export default function MultimediaPage({
       <div
         className="flex-1 pt-[55px] xl:pt-[70px] bg-white"
       >
+        {/* skipMatchApi: inyectar loader.js sin esperar el Match API. El await del
+            Match era peso muerto serial (~100-700ms en frío): no gatea el render ni
+            el redirect — "sin contenido" lo detectan el callback noshow y el timeout
+            de 4s del player, que siguen redirigiendo a view/viewpremium. */}
         <FlixmediaPlayer
           mpn={productSku}
           ean={productEan}
@@ -389,7 +393,7 @@ export default function MultimediaPage({
           segmento={segmento}
           apiProduct={product?.apiProduct}
           productColors={product?.colors}
-          skipMatchApi={false}
+          skipMatchApi={true}
           className=""
         />
       </div>

--- a/src/components/FlixmediaPlayer.tsx
+++ b/src/components/FlixmediaPlayer.tsx
@@ -68,6 +68,22 @@ function FlixmediaPlayerComponent({
   const containerId = `flix-inpage-${productId || 'default'}`;
   const [hasContent, setHasContent] = useState<boolean | null>(null);
   const [hasFlixError, setHasFlixError] = useState(false);
+  // contentReady es INDEPENDIENTE de hasContent: en modo embebido/skipMatchApi
+  // hasContent se pone true de inmediato (antes de que exista contenido visible),
+  // así que el skeleton necesita su propia señal de "ya hay contenido real".
+  // La alimentan: callback inpage, callback registrado, MutationObserver
+  // (primer elemento real en el container) y la rama positiva del timeout de 4s.
+  const [contentReady, setContentReady] = useState(false);
+  const [skeletonGone, setSkeletonGone] = useState(false);
+
+  // Crossfade de salida: al confirmar contenido, el skeleton se desvanece
+  // (transition-opacity 300ms) y se desmonta después — nunca display:none en
+  // seco, para enmascarar el swap de lazysizes sin flash de placeholders.
+  useEffect(() => {
+    if (!contentReady) return;
+    const t = setTimeout(() => setSkeletonGone(true), 450);
+    return () => clearTimeout(t);
+  }, [contentReady]);
 
   // Refs para mantener valores actuales (evitar stale closures)
   // Router ref es CLAVE: useRouter() cambia de referencia en Next.js, lo que
@@ -143,6 +159,8 @@ function FlixmediaPlayerComponent({
     // Reset estado para nueva inicialización (evita stale state de producto anterior en SPA nav)
     setHasContent(null);
     setHasFlixError(false);
+    setContentReady(false);
+    setSkeletonGone(false);
 
     // Durante SPA navigation, mpn pasa brevemente por null mientras selectedProductData
     // se resetea y useProduct carga datos frescos. NO inicializar en este estado transitorio:
@@ -283,7 +301,10 @@ function FlixmediaPlayerComponent({
           if (callbackType === 'inpage') {
             console.log(`[FLIX] Callback INPAGE: contenido listo (+${Math.round(performance.now() - initStartTime)}ms)`);
             applyStyles();
-            if (isMounted) setHasContent(true);
+            if (isMounted) {
+              setHasContent(true);
+              setContentReady(true);
+            }
           } else if (callbackType === 'noshow') {
             console.log(`[FLIX] Callback NOSHOW: sin contenido (+${Math.round(performance.now() - initStartTime)}ms)`);
             if (!isMounted) return;
@@ -324,10 +345,23 @@ function FlixmediaPlayerComponent({
         return hasErrorText || hasBlueBackground;
       };
 
-      // MutationObserver SOLO para detección de errores visuales (fondo azul)
-      // La detección de contenido/no-contenido la manejan los callbacks inpage/noshow
+      // Verificar si loader.js renderizó contenido multimedia real
+      const hasRealContent = (cont: HTMLElement): boolean => {
+        if (cont.children.length === 0) return false;
+        return cont.querySelector('iframe') !== null ||
+               cont.querySelectorAll('img').length > 1 ||
+               cont.querySelector('video') !== null ||
+               cont.querySelector('[class*="flix-"]') !== null;
+      };
+
+      // MutationObserver: detección de errores visuales (fondo azul) + primera
+      // aparición de contenido real (dispara el crossfade del skeleton)
       observer = new MutationObserver(() => {
         if (!isMounted) { observer?.disconnect(); return; }
+        const cont = document.getElementById(containerId);
+        if (cont && hasRealContent(cont)) {
+          setContentReady(true);
+        }
         if (checkForFlixError()) {
           console.log('[FLIX] Error visual de Flixmedia detectado → redirigiendo');
           observer?.disconnect();
@@ -364,7 +398,10 @@ function FlixmediaPlayerComponent({
             window.flixJsCallbacks.setLoadCallback(() => {
               console.log(`[FLIX] Registered INPAGE callback fired (+${Math.round(performance.now() - initStartTime)}ms)`);
               applyStyles();
-                if (isMounted) setHasContent(true);
+              if (isMounted) {
+                setHasContent(true);
+                setContentReady(true);
+              }
             }, 'inpage');
             window.flixJsCallbacks.setLoadCallback(() => {
               console.log(`[FLIX] Registered NOSHOW callback fired (+${Math.round(performance.now() - initStartTime)}ms)`);
@@ -386,15 +423,6 @@ function FlixmediaPlayerComponent({
       script.src = "//media.flixfacts.com/js/loader.js";
       document.head.appendChild(script);
 
-      // Verificar si loader.js renderizó contenido multimedia real
-      const hasRealContent = (cont: HTMLElement): boolean => {
-        if (cont.children.length === 0) return false;
-        return cont.querySelector('iframe') !== null ||
-               cont.querySelectorAll('img').length > 1 ||
-               cont.querySelector('video') !== null ||
-               cont.querySelector('[class*="flix-"]') !== null;
-      };
-
       // Verificación a los 4s: si loader.js cargó pero no renderizó contenido real → redirigir
       // Esto cubre el caso donde ni inpage ni noshow callbacks se disparan
       setTimeout(() => {
@@ -413,6 +441,10 @@ function FlixmediaPlayerComponent({
           setHasContent(false);
           setHasFlixError(true);
           if (!preventRedirectRef.current) redirectToView();
+        } else {
+          // Sí hay contenido real: asegurar que el skeleton se retire aunque
+          // ningún callback ni mutación lo haya marcado (red de seguridad)
+          setContentReady(true);
         }
       }, 4000);
     };
@@ -445,13 +477,36 @@ function FlixmediaPlayerComponent({
   if (!mpn && !ean) return null;
   if (hasContent === false || hasFlixError) return null;
 
-  // Renderizar container - visible cuando hay contenido o aún cargando (null)
+  // Renderizar container - visible cuando hay contenido o aún cargando (null).
+  // El skeleton va como OVERLAY absoluto sobre el container SIEMPRE montado:
+  // el container es el target data-flix-inpage y desmontarlo/condicionarlo
+  // rompe los scripts de Flixmedia que lo buscan por id.
   return (
     <div className={`${className} w-full min-h-[200px] relative`}>
       <div
         id={containerId}
         className="w-full"
       />
+      {!skeletonGone && (
+        <div
+          aria-hidden="true"
+          className={`absolute inset-0 z-[1] overflow-hidden pointer-events-none bg-white transition-opacity duration-300 ${contentReady ? "opacity-0" : "opacity-100"}`}
+        >
+          <div className="h-full w-full animate-pulse px-4 py-8">
+            <div className="mx-auto max-w-5xl space-y-4">
+              <div className="mx-auto h-7 w-2/3 rounded-lg bg-gray-200" />
+              <div className="mx-auto h-4 w-1/2 rounded bg-gray-100" />
+              <div className="mt-6 h-56 w-full rounded-2xl bg-gray-100" />
+              <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                <div className="h-20 rounded-xl bg-gray-100" />
+                <div className="h-20 rounded-xl bg-gray-100" />
+                <div className="h-20 rounded-xl bg-gray-100" />
+                <div className="h-20 rounded-xl bg-gray-100" />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
> **PR apilada**: #1039 → #1040 → esta. Mergear en orden; GitHub re-apunta las bases automáticamente.

## Resumen

Tres palancas para la **primera visita** (frío), ranqueadas por una revisión adversarial multi-agente (25 agentes, 0 veredictos disputados) tras dos rondas de deep-research que confirmaron que **no existe API directa de Flixmedia** para saltarse su cascada de scripts:

1. **`skipMatchApi=true` en multimedia** — el `await` del Match API era peso muerto serial (~100–700ms en frío): no gatea el render ni el redirect. El redirect por "sin contenido" lo manejan el callback `noshow` y el timeout de 4s.
2. **Skeleton con crossfade en `FlixmediaPlayer`** — overlay absoluto sobre el container **siempre montado** (invariante: es el target `data-flix-inpage`). Nuevo estado `contentReady` independiente de `hasContent` (que en modo embebido se pone `true` antes de que exista contenido visible), alimentado por las 4 señales positivas: callback inpage, callback registrado, MutationObserver (primer contenido real) y rama positiva del timeout. Salida con fade de 300ms para enmascarar el swap de lazysizes.
3. **Prefetch de datos en hover de las cards** — extiende el `onMouseEnter` existente: además de precargar loader.js, trae el producto vía `/api/pcache/product` (Data Cache compartido, ~5–80ms) y lo deja en `productCache` con la misma forma que guarda `useProduct` → el click renderiza la PDP sin esperar al backend.

## Verificación (Puppeteer contra build de producción local)

- ✅ **Producto sin contenido** (`EF-CS947CTEGWW`): sigue redirigiendo a `/productos/view/` (4.7s, timeout+noshow) — el invariante crítico de `skipMatchApi=true`
- ✅ **Producto premium** (`BSM-S931BE`): redirect respeta el segmento (→ `/productos/viewpremium/`)
- ✅ Skeleton aparece y se retira sin quedarse pegado en ambos escenarios
- ✅ `npm run build` OK, `tsc --noEmit` limpio, ESLint sin problemas nuevos
- ⚠️ **El camino feliz (contenido renderiza + crossfade) requiere validación en el dominio de producción**: verificamos con un control de HTML plano + snippet oficial que Flixmedia hace **gating por dominio** y nunca entrega contenido en localhost (se queda en un stub de 294 bytes sin disparar callbacks — por eso en dev local la página multimedia siempre termina redirigiendo tras ~4s)

## Contexto de las decisiones (research verificado)

- "Guardar el HTML renderizado": **inviable** — el DOM de Flixmedia no es autocontenido (imágenes lazy vía lazysizes, carruseles jQuery, hotspots), rehostearlo rompe interactividad/analytics y roza sus ToS
- Prerender con Speculation Rules: **descartado** — la navegación interna es soft navigation (router.push) y Chrome solo activa prerenders en navegación hard; se pagaría el costo (impresiones fantasma incluidas) sin el beneficio
- Service Worker / self-host de loader.js: **inviable** — no ayuda en frío y las repeat visits ya son gratis (loader.js immutable 1 año, content webcall 24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)