### PR TITLE
perf(flixmedia): primera carga más rápida — skipMatchApi, skeleton, prefetch en hover + fix del proxy

### DIFF
--- a/src/app/api/flixmedia/match/route.ts
+++ b/src/app/api/flixmedia/match/route.ts
@@ -46,6 +46,19 @@ export async function GET(request: NextRequest) {
     const response = await fetch(url, {
       next: { revalidate: MATCH_REVALIDATE_SECONDS },
     });
+
+    // NO interpretar el body si el upstream falló (4xx/5xx). Un error de
+    // Flixmedia con cuerpo JSON produciría {available:false} con status 200 y
+    // el header CDN de 24h, envenenando un falso negativo compartido para ese
+    // MPN. Devolver 502 hace que el cliente caiga al Match API directo (mismo
+    // contrato que el catch de red) y evita cachear el error en el CDN.
+    if (!response.ok) {
+      return NextResponse.json(
+        { available: false, error: "match_upstream_status" },
+        { status: 502 }
+      );
+    }
+
     const data = await response.json();
 
     const matched = data?.event === "matchhit" && data?.product_id;

--- a/src/app/productos/components/ProductCard.tsx
+++ b/src/app/productos/components/ProductCard.tsx
@@ -40,8 +40,47 @@ import StockNotificationModal from "@/components/StockNotificationModal";
 import { useStockNotification } from "@/hooks/useStockNotification";
 import { shouldRenderValue, shouldRenderColor } from "./utils/shouldRenderValue";
 import { prefetchFlixmediaScript } from "@/lib/flixmedia";
+import { productCache } from "@/lib/productCache";
 import CeroInteresSection from "@/components/CeroInteresSection";
 import { ZeroInterestSkuResult } from "@/services/cero-interes-sku.service";
+
+// Dedup a nivel módulo: un solo prefetch por producto mientras viva la página
+const hoverPrefetchedProducts = new Set<string>();
+
+/**
+ * Prefetch de datos de producto al hacer hover en la card, vía el proxy
+ * cacheado server-side (/api/pcache/product — Data Cache compartido, ~5-80ms).
+ * Deja la respuesta en productCache con la MISMA forma que guarda useProduct,
+ * así el click siguiente renderiza la PDP sin esperar al backend.
+ * Si falla, se limpia el dedup y la PDP carga por su camino normal.
+ */
+async function prefetchProductDataOnHover(codigoMarket: string): Promise<void> {
+  if (!codigoMarket || hoverPrefetchedProducts.has(codigoMarket)) return;
+  hoverPrefetchedProducts.add(codigoMarket);
+  if (productCache.getSingleProduct(codigoMarket)) return;
+  try {
+    const res = await fetch(
+      `/api/pcache/product?codigoMarket=${encodeURIComponent(codigoMarket)}`
+    );
+    if (!res.ok) return;
+    const raw = await res.json();
+    // Misma normalización que ApiClient.request: {success,data,...} o payload directo
+    const response =
+      raw && typeof raw === "object" && "success" in raw
+        ? { data: raw.data, success: !!raw.success }
+        : { data: raw, success: true };
+    if (response.success && response.data) {
+      productCache.setSingleProduct(
+        codigoMarket,
+        response as Parameters<typeof productCache.setSingleProduct>[1],
+        10 * 60 * 1000
+      );
+    }
+  } catch {
+    // permitir reintento en un próximo hover
+    hoverPrefetchedProducts.delete(codigoMarket);
+  }
+}
 
 export interface ProductColor {
   name: string; // Nombre técnico del color (ej: "black", "white")
@@ -669,6 +708,10 @@ export default function ProductCard({
 
   const handleMouseEnter = () => {
     prefetchFlixmediaScript();
+    // Precargar los DATOS del producto vía el proxy cacheado (/api/pcache):
+    // al hacer click, useProduct los encuentra en productCache y la PDP
+    // renderiza sin esperar al backend — Flixmedia arranca de inmediato.
+    prefetchProductDataOnHover(String(id).split("/")[0]);
   };
 
   return (

--- a/src/app/productos/multimedia/[id]/page.tsx
+++ b/src/app/productos/multimedia/[id]/page.tsx
@@ -381,6 +381,10 @@ export default function MultimediaPage({
       <div
         className="flex-1 pt-[55px] xl:pt-[70px] bg-white"
       >
+        {/* skipMatchApi: inyectar loader.js sin esperar el Match API. El await del
+            Match era peso muerto serial (~100-700ms en frío): no gatea el render ni
+            el redirect — "sin contenido" lo detectan el callback noshow y el timeout
+            de 4s del player, que siguen redirigiendo a view/viewpremium. */}
         <FlixmediaPlayer
           mpn={productSku}
           ean={productEan}
@@ -389,7 +393,7 @@ export default function MultimediaPage({
           segmento={segmento}
           apiProduct={product?.apiProduct}
           productColors={product?.colors}
-          skipMatchApi={false}
+          skipMatchApi={true}
           className=""
         />
       </div>

--- a/src/components/FlixmediaPlayer.tsx
+++ b/src/components/FlixmediaPlayer.tsx
@@ -68,6 +68,22 @@ function FlixmediaPlayerComponent({
   const containerId = `flix-inpage-${productId || 'default'}`;
   const [hasContent, setHasContent] = useState<boolean | null>(null);
   const [hasFlixError, setHasFlixError] = useState(false);
+  // contentReady es INDEPENDIENTE de hasContent: en modo embebido/skipMatchApi
+  // hasContent se pone true de inmediato (antes de que exista contenido visible),
+  // así que el skeleton necesita su propia señal de "ya hay contenido real".
+  // La alimentan: callback inpage, callback registrado, MutationObserver
+  // (primer elemento real en el container) y la rama positiva del timeout de 4s.
+  const [contentReady, setContentReady] = useState(false);
+  const [skeletonGone, setSkeletonGone] = useState(false);
+
+  // Crossfade de salida: al confirmar contenido, el skeleton se desvanece
+  // (transition-opacity 300ms) y se desmonta después — nunca display:none en
+  // seco, para enmascarar el swap de lazysizes sin flash de placeholders.
+  useEffect(() => {
+    if (!contentReady) return;
+    const t = setTimeout(() => setSkeletonGone(true), 450);
+    return () => clearTimeout(t);
+  }, [contentReady]);
 
   // Refs para mantener valores actuales (evitar stale closures)
   // Router ref es CLAVE: useRouter() cambia de referencia en Next.js, lo que
@@ -143,6 +159,8 @@ function FlixmediaPlayerComponent({
     // Reset estado para nueva inicialización (evita stale state de producto anterior en SPA nav)
     setHasContent(null);
     setHasFlixError(false);
+    setContentReady(false);
+    setSkeletonGone(false);
 
     // Durante SPA navigation, mpn pasa brevemente por null mientras selectedProductData
     // se resetea y useProduct carga datos frescos. NO inicializar en este estado transitorio:
@@ -283,7 +301,10 @@ function FlixmediaPlayerComponent({
           if (callbackType === 'inpage') {
             console.log(`[FLIX] Callback INPAGE: contenido listo (+${Math.round(performance.now() - initStartTime)}ms)`);
             applyStyles();
-            if (isMounted) setHasContent(true);
+            if (isMounted) {
+              setHasContent(true);
+              setContentReady(true);
+            }
           } else if (callbackType === 'noshow') {
             console.log(`[FLIX] Callback NOSHOW: sin contenido (+${Math.round(performance.now() - initStartTime)}ms)`);
             if (!isMounted) return;
@@ -324,10 +345,23 @@ function FlixmediaPlayerComponent({
         return hasErrorText || hasBlueBackground;
       };
 
-      // MutationObserver SOLO para detección de errores visuales (fondo azul)
-      // La detección de contenido/no-contenido la manejan los callbacks inpage/noshow
+      // Verificar si loader.js renderizó contenido multimedia real
+      const hasRealContent = (cont: HTMLElement): boolean => {
+        if (cont.children.length === 0) return false;
+        return cont.querySelector('iframe') !== null ||
+               cont.querySelectorAll('img').length > 1 ||
+               cont.querySelector('video') !== null ||
+               cont.querySelector('[class*="flix-"]') !== null;
+      };
+
+      // MutationObserver: detección de errores visuales (fondo azul) + primera
+      // aparición de contenido real (dispara el crossfade del skeleton)
       observer = new MutationObserver(() => {
         if (!isMounted) { observer?.disconnect(); return; }
+        const cont = document.getElementById(containerId);
+        if (cont && hasRealContent(cont)) {
+          setContentReady(true);
+        }
         if (checkForFlixError()) {
           console.log('[FLIX] Error visual de Flixmedia detectado → redirigiendo');
           observer?.disconnect();
@@ -364,7 +398,10 @@ function FlixmediaPlayerComponent({
             window.flixJsCallbacks.setLoadCallback(() => {
               console.log(`[FLIX] Registered INPAGE callback fired (+${Math.round(performance.now() - initStartTime)}ms)`);
               applyStyles();
-                if (isMounted) setHasContent(true);
+              if (isMounted) {
+                setHasContent(true);
+                setContentReady(true);
+              }
             }, 'inpage');
             window.flixJsCallbacks.setLoadCallback(() => {
               console.log(`[FLIX] Registered NOSHOW callback fired (+${Math.round(performance.now() - initStartTime)}ms)`);
@@ -386,15 +423,6 @@ function FlixmediaPlayerComponent({
       script.src = "//media.flixfacts.com/js/loader.js";
       document.head.appendChild(script);
 
-      // Verificar si loader.js renderizó contenido multimedia real
-      const hasRealContent = (cont: HTMLElement): boolean => {
-        if (cont.children.length === 0) return false;
-        return cont.querySelector('iframe') !== null ||
-               cont.querySelectorAll('img').length > 1 ||
-               cont.querySelector('video') !== null ||
-               cont.querySelector('[class*="flix-"]') !== null;
-      };
-
       // Verificación a los 4s: si loader.js cargó pero no renderizó contenido real → redirigir
       // Esto cubre el caso donde ni inpage ni noshow callbacks se disparan
       setTimeout(() => {
@@ -413,6 +441,10 @@ function FlixmediaPlayerComponent({
           setHasContent(false);
           setHasFlixError(true);
           if (!preventRedirectRef.current) redirectToView();
+        } else {
+          // Sí hay contenido real: asegurar que el skeleton se retire aunque
+          // ningún callback ni mutación lo haya marcado (red de seguridad)
+          setContentReady(true);
         }
       }, 4000);
     };
@@ -445,13 +477,36 @@ function FlixmediaPlayerComponent({
   if (!mpn && !ean) return null;
   if (hasContent === false || hasFlixError) return null;
 
-  // Renderizar container - visible cuando hay contenido o aún cargando (null)
+  // Renderizar container - visible cuando hay contenido o aún cargando (null).
+  // El skeleton va como OVERLAY absoluto sobre el container SIEMPRE montado:
+  // el container es el target data-flix-inpage y desmontarlo/condicionarlo
+  // rompe los scripts de Flixmedia que lo buscan por id.
   return (
     <div className={`${className} w-full min-h-[200px] relative`}>
       <div
         id={containerId}
         className="w-full"
       />
+      {!skeletonGone && (
+        <div
+          aria-hidden="true"
+          className={`absolute inset-0 z-[1] overflow-hidden pointer-events-none bg-white transition-opacity duration-300 ${contentReady ? "opacity-0" : "opacity-100"}`}
+        >
+          <div className="h-full w-full animate-pulse px-4 py-8">
+            <div className="mx-auto max-w-5xl space-y-4">
+              <div className="mx-auto h-7 w-2/3 rounded-lg bg-gray-200" />
+              <div className="mx-auto h-4 w-1/2 rounded bg-gray-100" />
+              <div className="mt-6 h-56 w-full rounded-2xl bg-gray-100" />
+              <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                <div className="h-20 rounded-xl bg-gray-100" />
+                <div className="h-20 rounded-xl bg-gray-100" />
+                <div className="h-20 rounded-xl bg-gray-100" />
+                <div className="h-20 rounded-xl bg-gray-100" />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
> Rama creada **desde develop actualizado** (post-merge de #1039). Reemplaza a #1043 (que quedó apuntando a una base ya cerrada) — se puede cerrar esa.

## Qué trae (2 commits)

### 1. Fix del proxy de match que quedó por fuera del merge de #1039
Validar `response.ok` del upstream: sin esto, un error 4xx/5xx de Flixmedia con cuerpo JSON se convierte en `{available:false}` con status 200 y el header CDN de 24h — un **falso negativo compartido para todos los usuarios** de ese MPN en el edge de Vercel. Hallazgo confirmado por revisión adversarial (3 verificadores). Ahora un upstream no-OK devuelve 502 y el cliente cae al Match API directo.

### 2. Primera carga más rápida (3 palancas, ranking verificado por revisión multi-agente)

- **`skipMatchApi=true` en multimedia** — el `await` del Match API era peso muerto serial en el camino crítico (~100–700ms en frío): no gatea render ni redirect ("sin contenido" lo detectan el callback `noshow` y el timeout de 4s).
- **Skeleton con crossfade en `FlixmediaPlayer`** — overlay absoluto sobre el container **siempre montado** (es el target `data-flix-inpage`). Estado `contentReady` independiente de `hasContent`, alimentado por las 4 señales positivas (callback inpage, callback registrado, MutationObserver con primer contenido real, rama positiva del timeout). Fade de 300ms para enmascarar el swap de lazysizes.
- **Prefetch de datos en hover de las cards** — extiende el `onMouseEnter` existente: trae el producto vía `/api/pcache/product` y lo deja en `productCache` con la misma forma que guarda `useProduct` → el click renderiza la PDP sin esperar al backend.

## Benchmark A/B local (build de producción, 5 visitas frías c/u, Chrome real)

Métrica: ms desde navegación hasta que **arranca la cascada de Flixmedia** (inyección de loader.js):

| Versión | Mediana | Rango |
|---|---|---|
| develop | **828ms** | 449–1484ms |
| esta rama | **169–195ms** | 165–199ms |

**~4-5× más rápido y mucho más estable** (ya no depende de Railway ni del Match API por visita).

## Verificación

- ✅ Cherry-picks limpios sobre develop actualizado; `tsc --noEmit` y `npm run build` OK
- ✅ Smoke test Puppeteer: producto sin contenido sigue redirigiendo a `view` (4.7s); premium → `viewpremium`; skeleton aparece y se retira sin pegarse
- ⚠️ El render final del contenido no es verificable en local: Flixmedia hace **gating por dominio** (en localhost nunca entrega contenido — verificado con HTML plano + snippet oficial). Validar el camino feliz en producción tras el merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)