### PR TITLE
release: promover develop → main (RamSelector en cards + fix slug smartphones)

### DIFF
--- a/src/app/productos/components/ProductCard.tsx
+++ b/src/app/productos/components/ProductCard.tsx
@@ -29,12 +29,18 @@ import {
   calculateSavings,
   formatCapacityLabel,
 } from "./utils/productCardHelpers";
-import { ColorSelector, CapacitySelector } from "./ProductCardComponents";
+import {
+  ColorSelector,
+  CapacitySelector,
+  RamSelector,
+  type ProductRamOption,
+} from "./ProductCardComponents";
 import { getCloudinaryUrl } from "@/lib/cloudinary";
 import { ProductApiData } from "@/lib/api";
 import {
   shouldShowColorSelector,
   shouldShowCapacitySelector,
+  shouldShowRamSelector,
 } from "./utils/categoryColorConfig";
 import StockNotificationModal from "@/components/StockNotificationModal";
 import { useStockNotification } from "@/hooks/useStockNotification";
@@ -213,6 +219,10 @@ export default function ProductCard({
     apiProduct?.categoria,
     apiProduct?.subcategoria
   );
+  const showRamSelector = shouldShowRamSelector(
+    apiProduct?.categoria,
+    apiProduct?.subcategoria
+  );
 
   // Integración con el contexto del carrito
   const { addProduct, getQuantityBySku } = useCartContext();
@@ -338,6 +348,34 @@ export default function ProductCard({
       capacity_sku: capacity.sku,
       capacity_ean: capacity.ean,
     });
+  };
+
+  // Opciones de RAM del producto (todas las válidas, marcando disponibilidad
+  // para el color/capacidad seleccionados — mismo mecanismo que capacidad).
+  // Solo aplica al flujo con apiProduct: el legacy no trae datos de RAM.
+  const ramOptions = useMemo((): ProductRamOption[] => {
+    if (!apiProduct) return [];
+    return productSelection.allMemoriaram.map((ramName) => ({
+      value: ramName,
+      label: ramName,
+      available: productSelection.availableMemoriaram.includes(ramName),
+    }));
+  }, [apiProduct, productSelection]);
+
+  const selectedRamOption = useMemo((): ProductRamOption | null => {
+    const selectedRam = productSelection.selection.selectedMemoriaram;
+    if (!selectedRam) return null;
+    return ramOptions.find((ram) => ram.value === selectedRam) || null;
+  }, [ramOptions, productSelection.selection.selectedMemoriaram]);
+
+  const handleRamSelect = (ram: ProductRamOption) => {
+    // Resuelve la variante color+capacidad+RAM vía el hook (actualiza SKU,
+    // precio, stock e imagen igual que selectCapacity).
+    // Nota: sin evento de analytics propio en este cambio (a diferencia de
+    // product_capacity_selected) — pendiente de definir con producto.
+    if (apiProduct) {
+      productSelection.selectMemoriaram(ram.value);
+    }
   };
 
   // Calcular precios dinámicos: usar el nuevo sistema si está disponible, sino usar el legacy
@@ -1017,6 +1055,19 @@ export default function ProductCard({
                     />
                   </div>
                 )}
+
+              {/* Selector de RAM - Solo cuando hay ≥2 opciones de RAM válidas
+                  (productos cuyas variantes difieren solo en RAM, ej: Galaxy A07
+                  Negro 128GB 4GB vs 6GB, quedarían incomprables sin este selector) */}
+              {showRamSelector && ramOptions.length >= 2 && (
+                <div className="min-h-[48px]">
+                  <RamSelector
+                    rams={ramOptions}
+                    selectedRam={selectedRamOption}
+                    onRamSelect={handleRamSelect}
+                  />
+                </div>
+              )}
             </div>
 
             {/* Columna derecha: Botón de Entrego y Estreno - Mostrar solo si indRetoma === 1 */}

--- a/src/app/productos/components/ProductCardComponents.tsx
+++ b/src/app/productos/components/ProductCardComponents.tsx
@@ -4,6 +4,7 @@
  * Componentes auxiliares reutilizables para ProductCard:
  * - ColorSelector: Selector de colores con círculos de color
  * - CapacitySelector: Selector de capacidades con botones
+ * - RamSelector: Selector de memoria RAM (mismo estilo de chips que CapacitySelector)
  */
 
 "use client";
@@ -175,5 +176,45 @@ export const CapacitySelector = ({
         })}
       </div>
     </div>
+  );
+};
+
+/**
+ * Opción de memoria RAM para RamSelector
+ */
+export interface ProductRamOption {
+  value: string; // Valor de RAM tal como llega del API (ej: "4GB", "6GB")
+  label: string; // Etiqueta mostrada al usuario
+  available?: boolean; // Si está disponible para el color/capacidad seleccionados
+}
+
+/**
+ * Props para RamSelector
+ */
+export interface RamSelectorProps {
+  rams: ProductRamOption[];
+  selectedRam: ProductRamOption | null;
+  onRamSelect: (ram: ProductRamOption) => void;
+}
+
+/**
+ * Componente para seleccionar la memoria RAM del producto.
+ * Espejo del CapacitySelector: mismos chips, con las opciones no disponibles
+ * cruzadas con línea diagonal y deshabilitadas. Delegamos el render en
+ * CapacitySelector para garantizar el mismo estilo visual sin duplicar markup.
+ */
+export const RamSelector = ({
+  rams,
+  selectedRam,
+  onRamSelect,
+}: RamSelectorProps) => {
+  if (!rams || rams.length === 0) return null;
+
+  return (
+    <CapacitySelector
+      capacities={rams}
+      selectedCapacity={selectedRam}
+      onCapacitySelect={onRamSelect}
+    />
   );
 };

--- a/src/components/footer/footer-config.ts
+++ b/src/components/footer/footer-config.ts
@@ -65,7 +65,7 @@ export const getFooterSections = (
       links: [
         {
           name: "Smartphones Galaxy",
-          href: "/productos/dispositivos-moviles?seccion=smartphones-galaxy",
+          href: "/productos/dispositivos-moviles?seccion=smartphones",
         },
         {
           name: "Galaxy Tab",

--- a/src/components/navbar/components/AccesoriosSubmenu.tsx
+++ b/src/components/navbar/components/AccesoriosSubmenu.tsx
@@ -14,7 +14,7 @@ type SubMenuItem = {
 const ACCESORIOS_ITEMS: SubMenuItem[] = [
   {
     name: "Accesorios para Smartphones Galaxy",
-    href: "/productos/accesorios?seccion=smartphones-galaxy",
+    href: "/productos/accesorios?seccion=smartphones",
     imageSrc: "https://res.cloudinary.com/dqay3uml6/image/upload/v1759801666/Acc-smartphone_ngj5pq.webp",
     imageAlt: "Accesorios para Smartphones Galaxy",
   },

--- a/src/hooks/useProductSelection.ts
+++ b/src/hooks/useProductSelection.ts
@@ -69,6 +69,9 @@ export interface UseProductSelectionReturn {
   // Todas las capacidades únicas del producto (sin filtrar por color/RAM)
   allCapacities: string[];
 
+  // Todas las opciones de RAM únicas del producto (sin filtrar por color/capacidad)
+  allMemoriaram: string[];
+
   // Información del producto seleccionado
   selectedSku: string | null;
   selectedSkuPostback: string | null;
@@ -461,6 +464,32 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
     return Array.from(capacities);
   }, [allVariants]);
 
+  // Todas las opciones de RAM únicas del producto (sin filtrar por color/capacidad)
+  // Espejo de allCapacitiesUnfiltered: permite renderizar todos los chips de RAM
+  // y cruzar/deshabilitar los que no apliquen a la selección actual.
+  const allMemoriaramUnfiltered = useMemo(() => {
+    const memoriaram = new Set<string>();
+
+    for (const variant of allVariants) {
+      const memoriaramValue = variant.memoriaram?.trim();
+      const isValidMemoriaram = memoriaramValue &&
+        memoriaramValue !== '' &&
+        memoriaramValue !== '-' &&
+        memoriaramValue.toLowerCase() !== 'no aplica' &&
+        memoriaramValue.toLowerCase() !== 'n/a' &&
+        memoriaramValue.toLowerCase() !== 'na' &&
+        memoriaramValue.toLowerCase() !== 'no' &&
+        memoriaramValue.toLowerCase() !== 'no especifica' &&
+        memoriaramValue.toLowerCase() !== 'no especificado';
+
+      if (isValidMemoriaram) {
+        memoriaram.add(variant.memoriaram);
+      }
+    }
+
+    return Array.from(memoriaram);
+  }, [allVariants]);
+
   // Función auxiliar para encontrar la variante exacta que coincida con los parámetros
   // Si hay múltiples variantes que coinciden, selecciona la que tenga mayor stockTotal
   const findVariant = useCallback((color: string, capacity?: string | null, memoriaram?: string | null) => {
@@ -708,6 +737,7 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
     availableCapacities: availableCapacitiesFiltered,
     availableMemoriaram: availableMemoriaramFiltered,
     allCapacities: allCapacitiesUnfiltered,
+    allMemoriaram: allMemoriaramUnfiltered,
     selectedSku,
     selectedSkuPostback: selectedVariant?.skuPostback || null,
     selectedSkuflixmedia: selectedVariant?.skuflixmedia || null,


### PR DESCRIPTION
Promoción de develop a main. Embarca únicamente el PR #1049 (verificado: 3 commits, nada más pendiente en develop):

- **RamSelector en ProductCard**: variantes que solo difieren en RAM (Galaxy A07 Negro 4GB/6GB) eran incomprables desde el catálogo. E2E verificado en el deployment de develop: cross-filtro correcto (Morado→6GB disabled), Negro→ambos chips, 4GB→resuelve SM-A075MZKGLTC $559.900.
- **Fix slug muerto**: `seccion=smartphones-galaxy` → `smartphones` en footer y submenu accesorios (0 links al slug viejo en el DOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)