### PR TITLE
release: promover develop → main (auto-ajuste de variantes)

### DIFF
--- a/src/app/productos/components/ProductCard.tsx
+++ b/src/app/productos/components/ProductCard.tsx
@@ -112,7 +112,6 @@ export interface ProductCapacity {
   discount?: string; // Descuento
   sku?: string; // SKU específico
   ean?: string; // SKU específico
-  available?: boolean; // Si está disponible para el color seleccionado
 }
 
 export interface ProductCardProps {
@@ -350,15 +349,14 @@ export default function ProductCard({
     });
   };
 
-  // Opciones de RAM del producto (todas las válidas, marcando disponibilidad
-  // para el color/capacidad seleccionados — mismo mecanismo que capacidad).
+  // Opciones de RAM del producto (todas las válidas, siempre clickeables: el hook
+  // auto-ajusta color/capacidad si la combinación clickeada no existe).
   // Solo aplica al flujo con apiProduct: el legacy no trae datos de RAM.
   const ramOptions = useMemo((): ProductRamOption[] => {
     if (!apiProduct) return [];
     return productSelection.allMemoriaram.map((ramName) => ({
       value: ramName,
       label: ramName,
-      available: productSelection.availableMemoriaram.includes(ramName),
     }));
   }, [apiProduct, productSelection]);
 
@@ -1017,10 +1015,7 @@ export default function ProductCard({
                                 sku: "",
                                 ean: "",
                               };
-                              return {
-                                ...capacityInfo,
-                                available: productSelection.availableCapacities.includes(capacityName),
-                              };
+                              return capacityInfo;
                             }
                           )
                           : capacities || []

--- a/src/app/productos/components/ProductCardComponents.tsx
+++ b/src/app/productos/components/ProductCardComponents.tsx
@@ -126,7 +126,9 @@ export interface CapacitySelectorProps {
 
 /**
  * Componente para seleccionar capacidades del producto
- * Muestra todas las capacidades del dispositivo, con las no disponibles cruzadas con línea diagonal
+ * Muestra todas las capacidades del dispositivo, siempre clickeables: al elegir una
+ * combinación que no existe, el hook de selección auto-ajusta los demás parámetros
+ * (color/RAM) a la variante válida más cercana en lugar de bloquear la opción.
  */
 export const CapacitySelector = ({
   capacities,
@@ -139,38 +141,23 @@ export const CapacitySelector = ({
     <div className="space-y-1.5">
       <div className="flex gap-2 flex-wrap">
         {capacities.map((capacity) => {
-          const isAvailable = capacity.available !== false;
           const isSelected = selectedCapacity?.value === capacity.value;
 
           return (
             <button
               key={capacity.value}
-              disabled={!isAvailable}
               onClick={(e) => {
                 e.stopPropagation();
-                if (isAvailable) {
-                  onCapacitySelect(capacity);
-                }
+                onCapacitySelect(capacity);
               }}
               className={cn(
-                "relative px-2.5 py-1.5 text-xs font-medium rounded-md border transition-all duration-200 overflow-hidden",
-                !isAvailable
-                  ? "border-gray-200 bg-gray-50 text-gray-400 cursor-not-allowed"
-                  : isSelected
-                    ? "border-black bg-black text-white cursor-pointer"
-                    : "border-gray-300 bg-white text-gray-700 hover:border-gray-400 cursor-pointer"
+                "relative px-2.5 py-1.5 text-xs font-medium rounded-md border transition-all duration-200 cursor-pointer",
+                isSelected
+                  ? "border-black bg-black text-white"
+                  : "border-gray-300 bg-white text-gray-700 hover:border-gray-400"
               )}
             >
-              <span className="relative z-10">{capacity.label}</span>
-              {/* Línea diagonal de izquierda a derecha cuando no está disponible */}
-              {!isAvailable && (
-                <span
-                  className="absolute inset-0 pointer-events-none z-0"
-                  style={{
-                    background: "linear-gradient(to top right, transparent calc(50% - 0.5px), #9ca3af calc(50% - 0.5px), #9ca3af calc(50% + 0.5px), transparent calc(50% + 0.5px))",
-                  }}
-                />
-              )}
+              {capacity.label}
             </button>
           );
         })}
@@ -185,7 +172,6 @@ export const CapacitySelector = ({
 export interface ProductRamOption {
   value: string; // Valor de RAM tal como llega del API (ej: "4GB", "6GB")
   label: string; // Etiqueta mostrada al usuario
-  available?: boolean; // Si está disponible para el color/capacidad seleccionados
 }
 
 /**
@@ -199,9 +185,10 @@ export interface RamSelectorProps {
 
 /**
  * Componente para seleccionar la memoria RAM del producto.
- * Espejo del CapacitySelector: mismos chips, con las opciones no disponibles
- * cruzadas con línea diagonal y deshabilitadas. Delegamos el render en
- * CapacitySelector para garantizar el mismo estilo visual sin duplicar markup.
+ * Espejo del CapacitySelector: mismos chips, todos siempre clickeables (el hook
+ * auto-ajusta color/capacidad al hacer clic en una combinación inexistente).
+ * Delegamos el render en CapacitySelector para garantizar el mismo estilo visual
+ * sin duplicar markup.
  */
 export const RamSelector = ({
   rams,

--- a/src/hooks/useProductSelection.ts
+++ b/src/hooks/useProductSelection.ts
@@ -1,6 +1,8 @@
 /**
  * Hook para manejar la selección inteligente de productos
- * - Filtra colores y capacidades basado en las selecciones mutuas
+ * - AUTO-AJUSTE DE VARIANTES: ninguna opción (color/capacidad/RAM) se bloquea;
+ *   al hacer clic en una opción incompatible con la selección actual, los demás
+ *   parámetros se ajustan a la combinación válida más cercana (resolveVariantCascade)
  * - Calcula precios y SKUs dinámicamente según las opciones seleccionadas
  * - Maneja la lógica de arrays indexados donde cada índice representa un producto único
  */
@@ -55,6 +57,63 @@ export interface ActiveFilterHints {
   capacidad?: string[];
   color?: string[];
   memoriaram?: string[];
+}
+
+/**
+ * Criterios parciales para buscar una variante.
+ * Los ejes ausentes/vacíos actúan como comodín (no restringen la búsqueda).
+ */
+export interface VariantCriteria {
+  color?: string | null;
+  capacity?: string | null;
+  memoriaram?: string | null;
+}
+
+/**
+ * Elige la mejor variante dentro de un grupo de candidatas:
+ * prioriza las que tienen stock disponible (>0) y, entre ellas, la de mayor stockTotal.
+ */
+export function pickBestVariant(candidates: ProductVariant[]): ProductVariant | undefined {
+  if (candidates.length === 0) return undefined;
+  return candidates.reduce((best, current) => {
+    const bestHasStock = best.stockDisponible > 0;
+    const currentHasStock = current.stockDisponible > 0;
+    if (currentHasStock !== bestHasStock) {
+      return currentHasStock ? current : best;
+    }
+    return current.stockTotal > best.stockTotal ? current : best;
+  });
+}
+
+function matchesCriteria(variant: ProductVariant, criteria: VariantCriteria): boolean {
+  const colorOk = !criteria.color || variant.color === criteria.color;
+  const capacityOk = !criteria.capacity || variant.capacity === criteria.capacity;
+  const ramOk = !criteria.memoriaram || variant.memoriaram === criteria.memoriaram;
+  return colorOk && capacityOk && ramOk;
+}
+
+/**
+ * Cascada de auto-ajuste de variantes.
+ *
+ * En lugar de bloquear/tachar combinaciones incompatibles, el clic del usuario se
+ * trata como intención dura: el eje clickeado queda fijo y los demás parámetros se
+ * relajan paso a paso hasta encontrar una variante existente. Cada paso de la
+ * cascada es un criterio; se devuelve la mejor variante (stock>0 primero, luego
+ * mayor stockTotal) del PRIMER paso que tenga coincidencias.
+ *
+ * Nota: una variante agotada NO se descarta — si el paso solo tiene variantes sin
+ * stock se devuelve igual, y la UI existente de "Notifícame"/"Sin unidades" se
+ * encarga de comunicarlo.
+ */
+export function resolveVariantCascade(
+  variants: ProductVariant[],
+  steps: VariantCriteria[]
+): ProductVariant | undefined {
+  for (const step of steps) {
+    const best = pickBestVariant(variants.filter(v => matchesCriteria(v, step)));
+    if (best) return best;
+  }
+  return undefined;
 }
 
 export interface UseProductSelectionReturn {
@@ -298,11 +357,6 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
     return sortedByPrice[0];
   };
 
-  // Estados para rastrear qué filtros están activos (seleccionados explícitamente por el usuario)
-  // Al inicio, aunque selectedColor tenga valores, estos filtros están inactivos hasta que el usuario los seleccione
-  const [activeCapacityFilter, setActiveCapacityFilter] = useState<string | undefined>();
-  const [activeRamFilter, setActiveRamFilter] = useState<string | undefined>();
-
   // Serializar hints para estabilidad en dependencias de useEffect
   const activeFilterHintsSerialized = useMemo(() => JSON.stringify(activeFilterHints || null), [activeFilterHints]);
 
@@ -360,34 +414,35 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeFilterHintsSerialized]);
 
-  // Colores disponibles basado en SOLO los filtros activos (no en la selección actual)
+  // Colores del producto siempre seleccionables.
+  // AUTO-AJUSTE DE VARIANTES: ya no se hace filtrado cruzado por capacidad/RAM —
+  // toda opción que exista a nivel de producto se muestra y es clickeable; al hacer
+  // clic, selectColor/selectCapacity/selectMemoriaram resuelven la variante válida
+  // más cercana (ver resolveVariantCascade). Solo se respetan los filtros del
+  // catálogo (activeFilterHints).
   const availableColorsFiltered = useMemo(() => {
     const colors = new Set<string>();
 
     for (const variant of allVariants) {
-      // Filtrado cruzado: solo mostrar colores que tengan la capacidad y RAM activos
-      const capacityMatch = !activeCapacityFilter || variant.capacity === activeCapacityFilter;
-      const memoriaramMatch = !activeRamFilter || variant.memoriaram === activeRamFilter;
       // Si hay filtro de color del catálogo, solo mostrar esos colores
       const hintColorMatch = !activeFilterHints?.color?.length ||
         activeFilterHints.color.some(h => h.trim().toLowerCase() === variant.color?.trim().toLowerCase());
 
-      if (capacityMatch && memoriaramMatch && hintColorMatch && variant.color && variant.color.trim() !== '') {
+      if (hintColorMatch && variant.color && variant.color.trim() !== '') {
         colors.add(variant.color);
       }
     }
 
     return Array.from(colors);
-  }, [allVariants, activeCapacityFilter, activeRamFilter, activeFilterHints]);
+  }, [allVariants, activeFilterHints]);
 
-  // Capacidades disponibles basado en el color seleccionado y RAM activo
+  // Capacidades del producto siempre seleccionables (sin filtrado cruzado por
+  // color/RAM — ver nota de auto-ajuste arriba). Solo se excluyen valores
+  // inválidos y los que no pasen el filtro del catálogo.
   const availableCapacitiesFiltered = useMemo(() => {
     const capacities = new Set<string>();
 
     for (const variant of allVariants) {
-      // Filtrado cruzado: solo mostrar capacidades que tengan el color seleccionado y RAM activo
-      const colorMatch = !selection.selectedColor || variant.color === selection.selectedColor;
-      const memoriaramMatch = !activeRamFilter || variant.memoriaram === activeRamFilter;
       // Si hay filtro de capacidad del catálogo, solo mostrar esas capacidades
       const hintCapMatch = !activeFilterHints?.capacidad?.length ||
         activeFilterHints.capacidad.some(h => h.trim().toLowerCase() === variant.capacity?.trim().toLowerCase());
@@ -403,22 +458,21 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
         capacityValue.toLowerCase() !== 'no especifica' &&
         capacityValue.toLowerCase() !== 'no especificado';
 
-      if (colorMatch && memoriaramMatch && hintCapMatch && isValidCapacity) {
+      if (hintCapMatch && isValidCapacity) {
         capacities.add(variant.capacity);
       }
     }
 
     return Array.from(capacities);
-  }, [allVariants, selection.selectedColor, activeRamFilter, activeFilterHints]);
+  }, [allVariants, activeFilterHints]);
 
-  // Memoria RAM disponible basado en el color seleccionado y capacidad activa
+  // Opciones de RAM del producto siempre seleccionables (sin filtrado cruzado por
+  // color/capacidad — ver nota de auto-ajuste arriba). Solo se excluyen valores
+  // inválidos y los que no pasen el filtro del catálogo.
   const availableMemoriaramFiltered = useMemo(() => {
     const memoriaram = new Set<string>();
 
     for (const variant of allVariants) {
-      // Filtrado cruzado: solo mostrar RAM que tengan el color seleccionado y capacidad activa
-      const colorMatch = !selection.selectedColor || variant.color === selection.selectedColor;
-      const capacityMatch = !activeCapacityFilter || variant.capacity === activeCapacityFilter;
       // Si hay filtro de RAM del catálogo, solo mostrar esas opciones
       const hintRamMatch = !activeFilterHints?.memoriaram?.length ||
         activeFilterHints.memoriaram.some(h => h.trim().toLowerCase() === variant.memoriaram?.trim().toLowerCase());
@@ -434,13 +488,13 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
         memoriaramValue.toLowerCase() !== 'no especifica' &&
         memoriaramValue.toLowerCase() !== 'no especificado';
 
-      if (colorMatch && capacityMatch && hintRamMatch && isValidMemoriaram) {
+      if (hintRamMatch && isValidMemoriaram) {
         memoriaram.add(variant.memoriaram);
       }
     }
 
     return Array.from(memoriaram);
-  }, [allVariants, selection.selectedColor, activeCapacityFilter, activeFilterHints]);
+  }, [allVariants, activeFilterHints]);
 
   // Todas las capacidades únicas del producto (sin filtrar por color/RAM)
   const allCapacitiesUnfiltered = useMemo(() => {
@@ -465,8 +519,8 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
   }, [allVariants]);
 
   // Todas las opciones de RAM únicas del producto (sin filtrar por color/capacidad)
-  // Espejo de allCapacitiesUnfiltered: permite renderizar todos los chips de RAM
-  // y cruzar/deshabilitar los que no apliquen a la selección actual.
+  // Espejo de allCapacitiesUnfiltered: permite renderizar todos los chips de RAM,
+  // siempre clickeables (el clic auto-ajusta el resto de la selección).
   const allMemoriaramUnfiltered = useMemo(() => {
     const memoriaram = new Set<string>();
 
@@ -488,33 +542,6 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
     }
 
     return Array.from(memoriaram);
-  }, [allVariants]);
-
-  // Función auxiliar para encontrar la variante exacta que coincida con los parámetros
-  // Si hay múltiples variantes que coinciden, selecciona la que tenga mayor stockTotal
-  const findVariant = useCallback((color: string, capacity?: string | null, memoriaram?: string | null) => {
-    const matchingVariants = allVariants.filter((variant) => {
-      const matchesColor = variant.color === color;
-      const matchesCapacity = !capacity || capacity === '' || variant.capacity === capacity;
-      const matchesMemoriaram = !memoriaram || memoriaram === '' || variant.memoriaram === memoriaram;
-
-      return matchesColor && matchesCapacity && matchesMemoriaram;
-    });
-
-    // Si no hay coincidencias, retornar undefined
-    if (matchingVariants.length === 0) {
-      return undefined;
-    }
-
-    // Si hay una sola coincidencia, retornarla
-    if (matchingVariants.length === 1) {
-      return matchingVariants[0];
-    }
-
-    // Si hay múltiples coincidencias, seleccionar la que tenga mayor stockTotal
-    return matchingVariants.reduce((best, current) => {
-      return current.stockTotal > best.stockTotal ? current : best;
-    });
   }, [allVariants]);
 
   // Variante seleccionada actualmente
@@ -569,74 +596,56 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
     : null;
   const selectedStockTotal = selectedVariant?.stockTotal ?? null;
 
-  // Funciones de selección con lógica de filtros activos
+  // Aplica una variante resuelta al estado de selección
+  const applyVariant = useCallback((variant: ProductVariant) => {
+    setSelection({
+      selectedColor: variant.color || null,
+      selectedCapacity: variant.capacity || null,
+      selectedMemoriaram: variant.memoriaram || null,
+      selectedVariant: variant
+    });
+  }, []);
+
+  /**
+   * Funciones de selección con AUTO-AJUSTE (el eje clickeado es fijo, el resto se
+   * ajusta a la combinación válida más cercana — ver resolveVariantCascade).
+   * Ninguna opción se bloquea: si la combinación actual no existe con el nuevo
+   * valor, se relajan los demás parámetros en orden de cercanía.
+   */
+
+  // Clic en color — cascada: (a) mantener capacidad y RAM actuales;
+  // (b) mantener solo capacidad; (c) mantener solo RAM; (d) cualquier variante del color.
   const selectColor = useCallback((color: string) => {
-    // Buscar la primera variante con este color que coincida con los filtros activos
-    const variant = findVariant(color, activeCapacityFilter, activeRamFilter);
+    const variant = resolveVariantCascade(allVariants, [
+      { color, capacity: selection.selectedCapacity, memoriaram: selection.selectedMemoriaram },
+      { color, capacity: selection.selectedCapacity },
+      { color, memoriaram: selection.selectedMemoriaram },
+      { color },
+    ]);
+    if (variant) applyVariant(variant);
+  }, [allVariants, selection.selectedCapacity, selection.selectedMemoriaram, applyVariant]);
 
-    if (variant) {
-      setSelection({
-        selectedColor: variant.color,
-        selectedCapacity: variant.capacity,
-        selectedMemoriaram: variant.memoriaram,
-        selectedVariant: variant
-      });
-    } else {
-      // Si no hay coincidencia con los filtros, buscar cualquier variante de ese color
-      // Si hay múltiples variantes con ese color, seleccionar la que tenga mayor stockTotal
-      const colorVariants = allVariants.filter((v) => v.color === color);
-      if (colorVariants.length > 0) {
-        const anyVariant = colorVariants.reduce((best, current) => {
-          return current.stockTotal > best.stockTotal ? current : best;
-        });
-        setSelection({
-          selectedColor: anyVariant.color,
-          selectedCapacity: anyVariant.capacity,
-          selectedMemoriaram: anyVariant.memoriaram,
-          selectedVariant: anyVariant
-        });
-        // Actualizar los filtros activos con los valores de la nueva variante
-        setActiveCapacityFilter(anyVariant.capacity);
-        setActiveRamFilter(anyVariant.memoriaram);
-      }
-    }
-  }, [allVariants, findVariant, activeCapacityFilter, activeRamFilter]);
-
+  // Clic en capacidad — cascada: (a) mantener color y RAM actuales;
+  // (b) mantener color, ajustar RAM; (c) ajustar también color.
   const selectCapacity = useCallback((capacity: string) => {
-    // Activar filtro de capacidad
-    setActiveCapacityFilter(capacity);
+    const variant = resolveVariantCascade(allVariants, [
+      { capacity, color: selection.selectedColor, memoriaram: selection.selectedMemoriaram },
+      { capacity, color: selection.selectedColor },
+      { capacity },
+    ]);
+    if (variant) applyVariant(variant);
+  }, [allVariants, selection.selectedColor, selection.selectedMemoriaram, applyVariant]);
 
-    if (!selection.selectedColor) return;
-
-    // Buscar la primera variante con este color y capacidad (manteniendo RAM si es compatible)
-    const variant = findVariant(selection.selectedColor, capacity, activeRamFilter);
-    if (variant) {
-      setSelection({
-        selectedColor: variant.color,
-        selectedCapacity: variant.capacity,
-        selectedMemoriaram: variant.memoriaram,
-        selectedVariant: variant
-      });
-    }
-  }, [selection.selectedColor, findVariant, activeRamFilter]);
-
+  // Clic en RAM — cascada: (a) mantener color y capacidad actuales;
+  // (b) mantener color, ajustar capacidad; (c) ajustar también color.
   const selectMemoriaram = useCallback((memoriaram: string) => {
-    // Activar filtro de RAM
-    setActiveRamFilter(memoriaram);
-
-    if (!selection.selectedColor) return;
-
-    // Buscar la primera variante con este color y RAM (manteniendo capacidad si es compatible)
-    const variant = findVariant(selection.selectedColor, activeCapacityFilter, memoriaram);
-    if (variant) {
-      setSelection({
-        selectedColor: variant.color,
-        selectedCapacity: variant.capacity,
-        selectedMemoriaram: variant.memoriaram,
-        selectedVariant: variant
-      });
-    }
-  }, [selection.selectedColor, findVariant, activeCapacityFilter]);
+    const variant = resolveVariantCascade(allVariants, [
+      { memoriaram, color: selection.selectedColor, capacity: selection.selectedCapacity },
+      { memoriaram, color: selection.selectedColor },
+      { memoriaram },
+    ]);
+    if (variant) applyVariant(variant);
+  }, [allVariants, selection.selectedColor, selection.selectedCapacity, applyVariant]);
 
   const resetSelection = useCallback(() => {
     setSelection({
@@ -645,9 +654,6 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
       selectedMemoriaram: null,
       selectedVariant: null
     });
-    // Resetear también los filtros activos
-    setActiveCapacityFilter(undefined);
-    setActiveRamFilter(undefined);
   }, []);
 
   // Función para seleccionar una variante completa directamente
@@ -658,9 +664,6 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
       selectedMemoriaram: variant.memoriaram,
       selectedVariant: variant
     });
-    // Actualizar filtros activos
-    setActiveCapacityFilter(variant.capacity);
-    setActiveRamFilter(variant.memoriaram);
   }, []);
 
   // Función helper para extraer nombre de color de desDetallada


### PR DESCRIPTION
Promoción de develop a main. Embarca únicamente el PR #1051 (verificado: 3 commits, nada más pendiente en develop):

- **Auto-ajuste de variantes**: en vez de tachar/bloquear la opción incompatible del otro selector, el clic auto-ajusta el resto de parámetros a la combinación válida más cercana (cascada color→spec→color, gana stock>0 + mayor stockTotal). Feedback directo de cliente. El agotado sigue mostrando "Notifícame" (no se bloquea). 8/8 casos de aceptación PASS con datos reales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)