### PR TITLE
fix(inweb): pop-up no aparecía en carga directa por canal del socket

### DIFF
--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -2,7 +2,15 @@
 
 import { io, Socket } from "socket.io-client";
 
-let socket: Socket | null = null;
+// Un socket POR canal (no un singleton único). Antes había un solo `socket`
+// compartido y el canal se fijaba con la PRIMERA conexión: como los grids del
+// home conectan 'products' antes de que ClientLayout conecte 'inweb' (React
+// corre los efectos hijo→padre), el socket quedaba con channel='products' y el
+// backend —que hace el catch-up de la campaña activa SOLO a channel='inweb'
+// (campaigns-proxy.gateway.ts)— se lo saltaba → el pop-up no salía en cargas
+// directas. Con una conexión independiente por canal, 'inweb' SIEMPRE conecta
+// como 'inweb' y recibe la campaña activa.
+const sockets: Record<string, Socket> = {};
 
 function getSocketUrl(): string {
   const envUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
@@ -19,42 +27,51 @@ function getSocketUrl(): string {
 }
 
 export function connectSocket(channel: string): Socket {
-  if (!socket) {
-    const url = `${getSocketUrl()}/realtime`;
-    console.log(`[Socket] Creating NEW socket -> ${url} (channel: ${channel})`);
-    socket = io(url, {
-      transports: ["websocket", "polling"],
-      query: { channel },
-      withCredentials: true,
-    });
-
-    socket.on("connect", () => {
-      console.log(`[Socket] Connected! id: ${socket?.id}, channel: ${channel}`);
-    });
-
-    socket.on("connect_error", (error) => {
-      console.error("[Socket] Connection error:", error.message);
-    });
-
-    socket.on("reconnect_error", (error) => {
-      console.error("[Socket] Reconnection error:", error.message);
-    });
-
-    socket.on("reconnect_failed", () => {
-      console.error("[Socket] Reconnection failed after all attempts");
-    });
-
-    socket.on("disconnect", (reason) => {
-      console.log(`[Socket] Disconnected: ${reason}`);
-    });
-
-    // Debug: log ALL incoming events for products_updated
-    socket.on("products_updated", (data: unknown) => {
-      console.log(`[Socket] RAW products_updated event received:`, data);
-    });
-  } else {
-    console.log(`[Socket] Reusing existing socket (id: ${socket.id}, original channel: ${socket.io.opts.query?.channel}, requested: ${channel})`);
+  const existing = sockets[channel];
+  if (existing) {
+    console.log(
+      `[Socket] Reusing existing socket for channel '${channel}' (id: ${existing.id})`,
+    );
+    return existing;
   }
 
+  const url = `${getSocketUrl()}/realtime`;
+  console.log(`[Socket] Creating NEW socket -> ${url} (channel: ${channel})`);
+  const socket = io(url, {
+    transports: ["websocket", "polling"],
+    query: { channel },
+    withCredentials: true,
+    // CRÍTICO: forzar una conexión NUEVA por canal. Sin esto, socket.io reusa
+    // el Manager de la primera conexión al mismo host e IGNORA el `query.channel`
+    // distinto → volveríamos al bug del canal compartido.
+    forceNew: true,
+  });
+
+  socket.on("connect", () => {
+    console.log(`[Socket] Connected! id: ${socket.id}, channel: ${channel}`);
+  });
+
+  socket.on("connect_error", (error) => {
+    console.error(`[Socket] Connection error (channel: ${channel}):`, error.message);
+  });
+
+  socket.on("reconnect_error", (error) => {
+    console.error(`[Socket] Reconnection error (channel: ${channel}):`, error.message);
+  });
+
+  socket.on("reconnect_failed", () => {
+    console.error(`[Socket] Reconnection failed after all attempts (channel: ${channel})`);
+  });
+
+  socket.on("disconnect", (reason) => {
+    console.log(`[Socket] Disconnected (channel: ${channel}): ${reason}`);
+  });
+
+  // Debug: log ALL incoming products_updated events (relevante para el canal 'products')
+  socket.on("products_updated", (data: unknown) => {
+    console.log(`[Socket] RAW products_updated event received (channel: ${channel}):`, data);
+  });
+
+  sockets[channel] = socket;
   return socket;
 }


### PR DESCRIPTION
## Problema
Las campañas In-Web (pop-up bloqueante) no aparecían en **carga directa del home**, aunque la campaña estuviera activa y bien configurada (`display_style: modal`, `preview_url: /`). Solo salían al entrar vía **login → home**.

## Causa raíz
`src/lib/socket.ts` era un socket **singleton**: el `channel` se fijaba con la PRIMERA conexión. Los grids del home (`useProducts` → `connectSocket('products')`) conectan **antes** que `ClientLayout` → `useInWebCampaign` → `connectSocket('inweb')` (React ejecuta los efectos hijo→padre). El socket quedaba con `channel='products'`, y el gateway (`campaigns-proxy.gateway.ts`) solo hace el **catch-up de la campaña activa** a conexiones con `channel='inweb'` → se lo saltaba. Por eso funcionaba tras login (la página `/login` no carga productos, así que ahí ganaba `inweb`).

## Fix
Un socket **por canal** (`sockets[channel]`) + `forceNew: true` (crítico: sin él socket.io reusa el Manager e ignora el 2º `channel`). Así `inweb` siempre conecta como `inweb`.

## Verificación
- Home directo abre **ambos** canales: `["inweb","products"]` (verificado por CDP)
- El pop-up (modal + imagen de la campaña) **aparece** en carga directa
- Sin regresiones en home/categoría/login; `tsc` limpio; build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)