### PR TITLE
Checkout: modal login invitado (OTP), place_id en direcciones manuales, quitar campo Nombre, indicador de pasos y ajustes UX

### DIFF
--- a/src/app/api/pcache/ofertas/route.ts
+++ b/src/app/api/pcache/ofertas/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Proxy cacheado de la query de OFERTAS (/api/products/v2/filtered?conDescuento=true...).
+ *
+ * Esa query es la más pesada del sitio: filtra por descuento sobre TODO el
+ * catálogo (comparación precioNormal vs precioEccommerce sin índice), sin
+ * acotar por categoría, y trae 50 items. Medido: ~6s en frío contra Railway
+ * vs ~0.8s de una categoría normal. Este proxy la cachea con el Data Cache de
+ * Next (revalidate 300s) compartido entre TODOS los usuarios: el primer
+ * visitante de una sección paga los ~6s una vez, el resto la recibe en ~ms.
+ *
+ * Repasa TODOS los query params al backend (conDescuento, seccion, sortBy,
+ * limit, page, etc.) para que la cache-key sea por combinación exacta. El
+ * consumidor (OfertasSection→useProducts) hace fallback al endpoint directo
+ * si el proxy falla, así nunca rompe.
+ *
+ * GET /api/pcache/ofertas?<mismos params que /api/products/v2/filtered>
+ */
+
+const OFERTAS_REVALIDATE_SECONDS = 300; // 5 min: precio/stock de ofertas cambia lento
+
+function backendUrl(): string {
+  return (
+    process.env.INTERNAL_API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "http://localhost:3001"
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+
+  // Seguridad básica: exigir el filtro de descuento (este proxy es solo ofertas)
+  if (searchParams.get("conDescuento") !== "true") {
+    return NextResponse.json(
+      { success: false, error: "not_an_offers_query" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const apiKey = process.env.NEXT_PUBLIC_API_KEY;
+    // Cache-key estable: ordenar los params alfabéticamente para que combinaciones
+    // equivalentes con distinto orden compartan la misma entrada del Data Cache.
+    // (TODO seguridad: allowlist estricta de params para evitar amplificación de
+    // cache con claves basura — requiere inventario exacto de params de ofertas.)
+    const sorted = new URLSearchParams(
+      [...searchParams.entries()].sort(([a], [b]) => a.localeCompare(b))
+    );
+    const url = `${backendUrl()}/api/products/v2/filtered?${sorted.toString()}`;
+    const response = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey && { "X-API-Key": apiKey }),
+      },
+      next: { revalidate: OFERTAS_REVALIDATE_SECONDS },
+    });
+
+    if (!response.ok) {
+      // No cachear errores: el cliente cae al endpoint directo
+      return NextResponse.json(
+        { success: false, error: "upstream_error" },
+        { status: 502 }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control":
+          "public, max-age=120, s-maxage=300, stale-while-revalidate=600",
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "upstream_unreachable" },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/carrito/Step2.tsx
+++ b/src/app/carrito/Step2.tsx
@@ -13,6 +13,8 @@ import { tradeInEndpoints } from "@/lib/api";
 import Step4OrderSummary from "./components/Step4OrderSummary";
 import TradeInCompletedSummary from "@/app/productos/dispositivos-moviles/detalles-producto/estreno-y-entrego/TradeInCompletedSummary";
 import TradeInModal from "@/app/productos/dispositivos-moviles/detalles-producto/estreno-y-entrego/TradeInModal";
+import CheckoutLoginModal from "./components/CheckoutLoginModal";
+import { useAuthContext } from "@/features/auth/context";
 import AddNewAddressForm from "./components/AddNewAddressForm";
 import type { Address } from "@/types/address";
 import { OTPStep } from "@/app/login/create-account/components/OTPStep";
@@ -124,6 +126,17 @@ export default function Step2({
 
   // Estado para verificar si ya se registró como invitado
   const [isRegisteredAsGuest, setIsRegisteredAsGuest] = useState(false);
+  // Modal de inicio de sesión: se abre cuando el correo del invitado pertenece
+  // a una cuenta REGISTRADA (rol 2). Ofrece login por clave o por OTP (email/tel).
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const [loginModalEmail, setLoginModalEmail] = useState("");
+  // Teléfono enmascarado de la cuenta (últimos 4 dígitos) para mostrar en el
+  // modal a qué número llega el OTP por WhatsApp. Lo devuelve check-email (rol 2).
+  const [loginModalPhoneHint, setLoginModalPhoneHint] = useState<string | null>(null);
+  // login() del contexto: al autenticar desde el modal refresca el navbar/estado
+  // global (setUser + token en apiClient + evento user-changed), evitando que
+  // la UI quede "sin sesión" hasta recargar.
+  const { login: loginContext } = useAuthContext();
 
   // Analytics: garantiza un único evento CheckoutStep2 por avance del paso 2
   const step2TrackedRef = useRef(false);
@@ -319,6 +332,50 @@ export default function Step2({
    * Maneja el envío del formulario de invitado.
    * Solo registra sin verificar y envía OTP. La cuenta se crea después de verificar OTP.
    */
+  /**
+   * Persiste la sesión del invitado (token + user rol 3) y avanza a 'verified'.
+   * Extraído para reutilizar entre el flujo sin-OTP (auto-login) y el legacy
+   * de verificación OTP. Preserva el carrito a través del guardado del usuario.
+   */
+  const finalizeGuestSession = async (
+    accessToken: string,
+    guestUser: { id: string; email: string; rol?: number },
+  ) => {
+    const currentCart = localStorage.getItem("cart-items");
+    try {
+      const { clearPreviousUserData } = await import('@/app/carrito/utils/getUserId');
+      clearPreviousUserData();
+    } catch (err) {
+      console.error('❌ [Step2] Error limpiando datos anteriores:', err);
+    }
+
+    const userWithRole = { ...guestUser, role: guestUser.rol || 3, rol: guestUser.rol || 3 };
+    localStorage.setItem("imagiq_token", accessToken);
+    localStorage.setItem("imagiq_user", JSON.stringify(userWithRole));
+    applyKnownUserAM();
+
+    const { saveUserId } = await import('@/app/carrito/utils/getUserId');
+    saveUserId(guestUser.id, guestUser.email, false);
+
+    if (globalThis.window !== undefined) {
+      globalThis.window.localStorage.setItem("checkout-document", guestForm.cedula);
+    }
+    if (currentCart) {
+      try {
+        const cartData = JSON.parse(currentCart);
+        if (Array.isArray(cartData) && cartData.length > 0) {
+          localStorage.setItem("cart-items", currentCart);
+          globalThis.window?.dispatchEvent(new Event("storage"));
+        }
+      } catch (cartErr) {
+        console.error("Error restaurando carrito:", cartErr);
+      }
+    }
+    sessionStorage.removeItem("guest-otp-process");
+    setIsRegisteredAsGuest(true);
+    setGuestStep('verified');
+  };
+
   const handleGuestSubmit = async (e?: React.FormEvent) => {
     if (e) {
       e.preventDefault();
@@ -336,9 +393,34 @@ export default function Step2({
 
     setLoading(true);
     try {
+      // 0. ¿El correo pertenece a una cuenta REGISTRADA (rol 2)? → modal de login.
+      //    check-email devuelve { exists:true } SOLO para rol 2; para invitados
+      //    (rol 3) devuelve { exists:false, isGuest:true } y seguimos como invitado.
+      const emailLower = guestForm.email.toLowerCase();
+      try {
+        const emailCheck = await apiPost<{ exists: boolean; isGuest?: boolean; telefonoMask?: string | null }>(
+          "/api/auth/check-email",
+          { email: emailLower }
+        );
+        if (emailCheck?.exists) {
+          setLoginModalEmail(emailLower);
+          setLoginModalPhoneHint(emailCheck.telefonoMask ?? null);
+          setShowLoginModal(true);
+          setFieldErrors((prev) => ({
+            ...prev,
+            email: "Este correo ya tiene una cuenta. Inicia sesión para continuar.",
+          }));
+          setLoading(false);
+          return;
+        }
+      } catch {
+        // Si check-email falla, seguir con el registro (register-unverified
+        // valida de nuevo y su error de "ya registrado" se maneja abajo).
+      }
+
       // 1. Registrar usuario sin verificar como invitado (rol 3, sin contraseña)
       const registerResult = await apiPost<{ message: string; userId: string }>("/api/auth/register-unverified", {
-        email: guestForm.email.toLowerCase(),
+        email: emailLower,
         nombre: guestForm.nombre,
         apellido: guestForm.apellido,
         contrasena: "", // Cuenta invitado sin contraseña → rol 3
@@ -349,28 +431,43 @@ export default function Step2({
         numero_documento: guestForm.cedula,
       });
 
-      // Guardar userId temporalmente (solo en estado, no en localStorage todavía)
       setGuestUserId(registerResult.userId);
-
-      // Associate guest email with PostHog session
-      associateEmailWithSession(guestForm.email.toLowerCase(), {
+      associateEmailWithSession(emailLower, {
         $name: `${guestForm.nombre} ${guestForm.apellido}`.trim(),
       });
 
-      // 2. Establecer estado inicial para OTP pero SIN enviarlo aún
-      // Esto permite que el usuario seleccione el método de envío (WhatsApp o Email)
-      setOtpSent(false);
+      // 2. SIN OTP: intentar autenticar de una vez con auto-login-guest.
+      //    IMPORTANTE: envuelto en su propio try/catch. El backend actual
+      //    (autoLoginGuest) RECHAZA con 400 a un invitado no verificado, y
+      //    apiPost lanza excepción en no-2xx; si no lo capturáramos aquí, el
+      //    invitado quedaría atascado. Ante CUALQUIER fallo → OTP legacy, así
+      //    el peor caso es "vuelve al OTP de hoy", nunca "checkout roto".
+      //    Cuando el backend permita login de invitado sin verificar (rol 3),
+      //    esta rama tendrá éxito y el flujo será realmente sin-OTP.
+      try {
+        const autoLogin = await apiPost<{
+          access_token: string;
+          user: { id: string; nombre: string; apellido: string; email: string; numero_documento: string; telefono: string; rol?: number };
+        }>("/api/auth/auto-login-guest", { userId: registerResult.userId });
 
-      // 3. Guardar estado temporal en sessionStorage (se elimina al cerrar navegador)
+        if (autoLogin?.access_token && autoLogin?.user) {
+          await finalizeGuestSession(autoLogin.access_token, autoLogin.user);
+          setLoading(false);
+          return;
+        }
+      } catch (autoLoginErr) {
+        console.warn("[Step2] auto-login-guest no disponible → fallback a OTP", autoLoginErr);
+      }
+
+      // Fallback OTP legacy (garantiza que el invitado SIEMPRE pueda continuar)
+      setOtpSent(false);
       sessionStorage.setItem("guest-otp-process", JSON.stringify({
         guestForm,
         userId: registerResult.userId,
-        sendMethod, // Método por defecto, pero no enviado aún
+        sendMethod,
         timestamp: Date.now(),
-        otpSent: false // Flag explícito
+        otpSent: false,
       }));
-
-      // 4. Cambiar a paso de OTP
       setGuestStep('otp');
       setLoading(false);
     } catch (error) {
@@ -402,13 +499,16 @@ export default function Step2({
           lowerErrorMessage.includes("registered") ||
           lowerErrorMessage.includes("duplicate"))
       ) {
-        setError(
-          `El correo ${guestForm.email} ya está asociado a una cuenta. Por favor, inicia sesión para continuar.`
-        );
+        // Cuenta registrada (rol 2): abrir el modal de inicio de sesión.
+        // Reset del phoneHint: este path no viene de check-email, así que sin
+        // limpiarlo se mostraría la máscara del teléfono de una cuenta anterior.
+        setLoginModalEmail(guestForm.email.toLowerCase());
+        setLoginModalPhoneHint(null);
+        setShowLoginModal(true);
         setFieldErrors((prev) => ({
           ...prev,
           email:
-            "Este correo ya está registrado. Inicia sesión para continuar.",
+            "Este correo ya tiene una cuenta. Inicia sesión para continuar.",
         }));
         return;
       }
@@ -1325,11 +1425,10 @@ export default function Step2({
       console.error('❌ Error limpiando caché:', error);
     }
 
-    // IMPORTANTE: Esperar un momento para que la dirección se guarde completamente en la BD
-    // antes de consultar candidate stores
-    // console.log('⏳ Esperando a que la dirección se guarde completamente...');
-    await new Promise(resolve => setTimeout(resolve, 500));
-    // console.log('✅ Delay completado');
+    // Pequeño buffer por si hay lag de réplica antes de consultar candidate
+    // stores. La dirección ya se guardó (con ID) antes de este punto, así que
+    // no necesita 500ms; 100ms basta y hace el "Guardando" más rápido.
+    await new Promise(resolve => setTimeout(resolve, 100));
 
     // Llamar al endpoint de candidate stores y esperar la respuesta
     try {
@@ -2020,7 +2119,8 @@ export default function Step2({
               }
               shouldCalculateCanPickUp={false}
               buttonVariant="green"
-              hideButton={guestStep === 'otp' || (isRegisteredAsGuest && !hasAddedAddress)}
+              hideButton={guestStep === 'otp'}
+              skipPickupCheck={isRegisteredAsGuest && !hasAddedAddress}
               shouldAnimateButton={shouldAnimateButton}
             />
           </div>
@@ -2099,6 +2199,41 @@ export default function Step2({
         productName={selectedProductForTradeIn?.name}
         skuPostback={selectedProductForTradeIn?.skuPostback}
       />
+
+      {/* Modal de inicio de sesión: correo del invitado = cuenta registrada (rol 2) */}
+      {showLoginModal && (
+        <CheckoutLoginModal
+          email={loginModalEmail}
+          phoneHint={loginModalPhoneHint}
+          onClose={() => setShowLoginModal(false)}
+          onSuccess={async (result) => {
+            // Cuenta registrada autenticada: persistir sesión con su rol real y
+            // avanzar al flujo de usuario registrado (step3, salta identificación).
+            const currentCart = localStorage.getItem("cart-items");
+            const roleNum = (result.user.rol ?? 2) as 1 | 2 | 3 | 4;
+            const userWithRole = { ...result.user, role: roleNum, rol: roleNum };
+            // Persistir el token ANTES de login(): el contexto lo lee de
+            // localStorage para setearlo en apiClient.
+            localStorage.setItem("imagiq_token", result.access_token);
+            // login() refresca el contexto (navbar), limpia datos del usuario
+            // anterior, guarda userId, setea el token en apiClient y dispara
+            // 'user-changed' + Advanced Matching. Reemplaza el seteo manual.
+            await loginContext(userWithRole);
+            // Persistir el documento del usuario para que el paso de pago lo
+            // autocomplete (useCheckoutLogic lee 'checkout-document'); el flujo
+            // invitado ya lo hace, el registrado por el modal no lo hacía.
+            if (result.user.numero_documento) {
+              localStorage.setItem("checkout-document", result.user.numero_documento);
+            }
+            if (currentCart) {
+              localStorage.setItem("cart-items", currentCart);
+              globalThis.window?.dispatchEvent(new Event("storage"));
+            }
+            setShowLoginModal(false);
+            router.push("/carrito/step3");
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/carrito/Step7.tsx
+++ b/src/app/carrito/Step7.tsx
@@ -11,7 +11,9 @@ import {
   Store,
   Edit2,
   User as UserIcon,
+  Package,
 } from "lucide-react";
+import Image from "next/image";
 import { useAuthContext } from "@/features/auth/context";
 import { useCheckoutAddress } from "@/features/checkout";
 import { profileService } from "@/services/profile.service";
@@ -1948,32 +1950,13 @@ export default function Step7({ onBack }: Step7Props) {
         console.warn("❌ [STEP7] No se encontró usuario en authContext ni en loggedUser");
       }
 
-      // Verificar si tiene contraseña (usuario verdadero invitado sin contraseña)
-      const hasPassword = user?.contrasena || user?.password;
-      const isGuestWithoutPassword = userRole === 3 && !hasPassword;
-
-      // console.log("🔍 [STEP7] Verificando usuario para modal:", {
-      // rol: userRole,
-      // tieneContrasena: !!hasPassword,
-      // esInvitadoSinContrasena: isGuestWithoutPassword,
-      // showPasswordModal: showPasswordModal
-      // });
-
-      // Si es usuario invitado (rol 3) SIN contraseña, mostrar modal de registro
-      if (isGuestWithoutPassword) {
-        //         console.log("✅ [STEP7] ========== USUARIO INVITADO SIN CONTRASEÑA DETECTADO ==========");
-        //         console.log("✅ [STEP7] Activando modal de registro...");
-        setShowPasswordModal(true);
-        setPendingOrder(true);
-        //         console.log("✅ [STEP7] Estados actualizados:");
-        //         console.log("  - showPasswordModal: true");
-        //         console.log("  - pendingOrder: true");
-        //         console.log("✅ [STEP7] ================================================");
-        return;
-      }
-
-      // Si no es invitado, procesar la orden directamente
-      //       console.log("✅ [STEP7] Usuario regular (rol:", userRole, "), procesando orden directamente");
+      // El invitado YA NO ve el modal "Registra tu cuenta" al finalizar: se
+      // procesa la orden directamente, sin insistir en crear contraseña (a
+      // pedido del usuario). Equivale a que siempre eligiera "Continuar como
+      // invitado". Si algún día se quiere reactivar, este es el punto donde se
+      // abría RegisterGuestPasswordModal (según userRole === 3 && sin contraseña).
+      void user;
+      void userRole;
       await processOrder();
     } catch (error) {
       console.error("❌ [STEP7] ERROR en handleConfirmOrder:", error);
@@ -2595,6 +2578,52 @@ export default function Step7({ onBack }: Step7Props) {
                     </div>
                   </div>
                 )}
+
+                {/* Detalle de productos del carrito (igual que en quioscos):
+                    lo que el cliente está comprando, debajo de facturación */}
+                <div className="bg-white rounded-lg p-4 border border-gray-300">
+                  <div className="flex items-center gap-3 mb-4">
+                    <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
+                      <Package className="w-5 h-5 text-gray-600" />
+                    </div>
+                    <div>
+                      <h2 className="text-lg font-bold text-gray-900">
+                        Detalle de compra
+                      </h2>
+                      <p className="text-sm text-gray-600">
+                        {products.reduce((acc, p) => acc + p.quantity, 0)} producto{products.reduce((acc, p) => acc + p.quantity, 0) !== 1 ? "s" : ""}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="space-y-3">
+                    {products.map((product) => (
+                      <div key={product.id} className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
+                        <div className="relative w-20 h-20 flex-shrink-0 bg-white rounded-lg overflow-hidden border border-gray-200">
+                          {product.image ? (
+                            <Image
+                              src={product.image}
+                              alt={product.name}
+                              fill
+                              className="object-contain p-1"
+                              sizes="80px"
+                            />
+                          ) : (
+                            <div className="w-full h-full flex items-center justify-center">
+                              <Package className="w-6 h-6 text-gray-300" />
+                            </div>
+                          )}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-gray-900 truncate">{product.name}</p>
+                          <p className="text-xs text-gray-500">Cant: {product.quantity}</p>
+                        </div>
+                        <p className="text-sm font-bold text-gray-900 flex-shrink-0">
+                          $ {Number(product.price * product.quantity).toLocaleString()}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
 
                 {/* Información del comprador: solo cuando la facturación es de otra persona */}
                 {compradorData &&

--- a/src/app/carrito/components/AddNewAddressForm.tsx
+++ b/src/app/carrito/components/AddNewAddressForm.tsx
@@ -68,6 +68,10 @@ export default function AddNewAddressForm({
 }: AddNewAddressFormProps) {
   const { user, login } = useAuthContext();
   const [isLoading, setIsLoading] = useState(false);
+  // Guarda de reentrada SÍNCRONA para el submit: isLoading (estado) llega tarde
+  // frente a dos taps rápidos; este ref bloquea el segundo submit al instante y
+  // evita crear la dirección dos veces.
+  const isSubmittingRef = React.useRef(false);
   const [selectedAddress, setSelectedAddress] =
     useState<ExtendedPlaceDetails | null>(null);
   const [selectedBillingAddress, setSelectedBillingAddress] =
@@ -114,7 +118,6 @@ export default function AddNewAddressForm({
     if (currentStep !== 2) return false;
     
     return !!(
-      formData.nombreDireccion.trim() &&
       formData.instruccionesEntrega.trim() &&
       formData.departamento.trim() &&
       formData.ciudad.trim() &&
@@ -124,7 +127,6 @@ export default function AddNewAddressForm({
     );
   }, [
     currentStep,
-    formData.nombreDireccion,
     formData.instruccionesEntrega,
     formData.departamento,
     formData.ciudad,
@@ -471,7 +473,10 @@ export default function AddNewAddressForm({
       formData.numeroPrincipal.trim() &&
       formData.numeroSecundario.trim() &&
       formData.numeroComplementario.trim() &&
-      formData.setsReferencia.trim()
+      formData.setsReferencia.trim() &&
+      // Formulario de un solo paso: nombre + observación (instrucciones de
+      // entrega) ahora viven en el paso 1. En billingOnly no aplican.
+      (billingOnly || formData.instruccionesEntrega.trim())
     );
   }, [
     formData.departamento,
@@ -480,7 +485,9 @@ export default function AddNewAddressForm({
     formData.numeroPrincipal,
     formData.numeroSecundario,
     formData.numeroComplementario,
-    formData.setsReferencia
+    formData.setsReferencia,
+    formData.instruccionesEntrega,
+    billingOnly
   ]);
 
   // Notificar validez del paso 1 al padre
@@ -518,13 +525,9 @@ export default function AddNewAddressForm({
   const validateForm = () => {
     const newErrors: { [key: string]: string } = {};
 
-    // Solo validar nombreDireccion e instruccionesEntrega si NO es billingOnly
-    // (en billingOnly se usa nombre automático y no requiere instrucciones)
+    // Solo validar instruccionesEntrega si NO es billingOnly (el "Nombre de la
+    // dirección" se eliminó del formulario; se genera automático en el submit).
     if (!billingOnly) {
-      if (!formData.nombreDireccion.trim()) {
-        newErrors.nombreDireccion = "El nombre de la dirección es requerido";
-      }
-
       if (!formData.instruccionesEntrega.trim()) {
         newErrors.instruccionesEntrega = "Las instrucciones de entrega son requeridas";
       }
@@ -584,6 +587,10 @@ export default function AddNewAddressForm({
     if (!validateForm()) {
       return;
     }
+
+    // Reentrada: si ya hay un submit en vuelo, ignorar (evita direcciones duplicadas)
+    if (isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
 
     setIsLoading(true);
 
@@ -653,7 +660,14 @@ export default function AddNewAddressForm({
       // Crear dirección de envío (o facturación si billingOnly)
       const shippingAddressRequest: CreateAddressRequest = {
         // Si es billingOnly, usar nombre automático "Dirección de facturación"
-        nombreDireccion: billingOnly ? "Dirección de facturación" : formData.nombreDireccion,
+        // El campo "Nombre de la dirección" se eliminó del formulario. Se genera
+        // uno automático (la calle) para no romper el modelo de datos ni las
+        // tarjetas que lo muestran.
+        nombreDireccion: billingOnly
+          ? "Dirección de facturación"
+          : (formData.nombreDireccion.trim() ||
+             `${formData.nombreCalle} ${formData.numeroPrincipal}`.trim() ||
+             "Mi dirección"),
         tipoDireccion: formData.tipoDireccion,
         // Si es billingOnly, siempre es tipo FACTURACION
         tipo: billingOnly ? "FACTURACION" : (formData.usarMismaParaFacturacion ? "AMBOS" : "ENVIO"),
@@ -890,6 +904,7 @@ export default function AddNewAddressForm({
       setErrors({ submit: `Error al guardar la dirección: ${errorMessage}` });
     } finally {
       setIsLoading(false);
+      isSubmittingRef.current = false;
     }
   };
 
@@ -1166,41 +1181,31 @@ export default function AddNewAddressForm({
     }
   };
 
-  // Exponer handleSubmit a través del ref si se proporciona
+  // Exponer handleSubmit a través del ref. SIN dep array: se reasigna en CADA
+  // render para que el handler expuesto al padre siempre cierre sobre el
+  // formData ACTUAL. Con dep array (campos incompletos) se guardaban valores
+  // viejos de la dirección → guías a direcciones equivocadas.
   React.useEffect(() => {
     if (onSubmitRef) {
       onSubmitRef.current = async () => {
-        // Validar antes de proceder
-        if (!validateForm()) {
-          return;
-        }
-        // Llamar a handleSubmitInternal
+        if (!validateForm()) return;
         await handleSubmitInternal();
       };
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onSubmitRef, selectedAddress?.placeId, formData.nombreDireccion, formData.instruccionesEntrega, formData.usarMismaParaFacturacion]);
+  });
 
-  // Exponer función de continuar (paso 1 → 2 o submit en paso 2) a través del ref
+  // Exponer función de continuar (submit del paso único) a través del ref.
+  // También SIN dep array por la misma razón: evitar el stale closure de los
+  // campos de dirección.
   React.useEffect(() => {
     if (onContinueRef) {
       onContinueRef.current = async () => {
-        if (currentStep === 1) {
-          // En paso 1: verificar que esté completo y avanzar a paso 2
-          if (isStep1Complete) {
-            setCurrentStep(2);
-          }
-        } else {
-          // En paso 2: hacer submit
-          if (!validateForm()) {
-            return;
-          }
-          await handleSubmitInternal();
-        }
+        if (!isStep1Complete) return;
+        if (!validateForm()) return;
+        await handleSubmitInternal();
       };
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onContinueRef, currentStep, isStep1Complete, selectedAddress?.placeId, formData.nombreDireccion, formData.instruccionesEntrega, formData.usarMismaParaFacturacion]);
+  });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -1222,23 +1227,8 @@ export default function AddNewAddressForm({
             <h2 className="text-xl sm:text-2xl font-bold whitespace-nowrap">{headerTitle}</h2>
           )}
 
-          {/* Solo mostrar indicador de pasos si NO es billingOnly */}
-          {!billingOnly ? (
-            <div className={`flex items-center ${!withContainer ? 'gap-1' : 'gap-2'}`}>
-              <div className={`flex items-center justify-center ${!withContainer ? 'w-6 h-6 text-xs' : 'w-8 h-8 text-sm'} rounded-full font-bold ${
-                currentStep === 1 ? "bg-black text-white" : "bg-gray-200 text-gray-600"
-              }`}>
-                1
-              </div>
-              <div className={`${!withContainer ? 'w-8' : 'w-12'} h-0.5 bg-gray-300`}></div>
-              <div className={`flex items-center justify-center ${!withContainer ? 'w-6 h-6 text-xs' : 'w-8 h-8 text-sm'} rounded-full font-bold ${
-                currentStep === 2 ? "bg-black text-white" : "bg-gray-200 text-gray-600"
-              }`}>
-                2
-              </div>
-            </div>
-          ) : (
-            /* Título para modo billingOnly */
+          {/* Formulario de un solo paso: ya no hay indicador 1→2 */}
+          {billingOnly && (
             <h3 className="text-lg font-semibold text-gray-900">Nueva dirección de facturación</h3>
           )}
         </div>
@@ -1277,16 +1267,23 @@ export default function AddNewAddressForm({
             <button
               type="button"
               onClick={() => {
+                // Formulario de un solo paso: guardar directo (ya no hay paso 2).
                 if (billingOnly) {
                   handleSubmitInternal();
-                } else {
-                  setCurrentStep(2);
+                } else if (validateForm()) {
+                  handleSubmitInternal();
                 }
               }}
-              disabled={!isStep1Complete || (billingOnly && isLoading)}
+              disabled={!isStep1Complete || isLoading}
               onMouseEnter={() => !isStep1Complete && setShowTooltip(true)}
               onMouseLeave={() => setShowTooltip(false)}
+              /* En desktop (lg+) el "Continuar" vive en el panel derecho
+                 (Step4OrderSummary, junto a "Volver"). Aquí se oculta para no
+                 duplicarlo. En mobile/tablet (sin panel) se mantiene. billingOnly
+                 es modal aparte: siempre muestra su botón. */
               className={`px-6 py-2 text-white rounded-xl font-bold transition border-2 ${
+                onContinueRef && !billingOnly ? "lg:hidden" : ""
+              } ${
                 isStep1Complete && !(billingOnly && isLoading)
                   ? "bg-green-600 border-green-500 hover:bg-green-700 hover:border-green-600 shadow-lg shadow-green-500/40 hover:shadow-xl hover:shadow-green-500/50"
                   : "bg-gray-400 border-gray-300 cursor-not-allowed"
@@ -1633,47 +1630,55 @@ export default function AddNewAddressForm({
           </div>
         )}
 
+        {/* Formulario de UN SOLO PASO: nombre + observación aquí mismo
+            (antes vivían en el paso 2). Solo para envío, no para billingOnly. */}
+        {!billingOnly && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
+            <div>
+              <label htmlFor="tipoDireccionPropiedadPaso1" className="block text-sm font-bold text-gray-900 mb-1">
+                Tipo de propiedad <span className="text-red-500">*</span>
+              </label>
+              <select
+                id="tipoDireccionPropiedadPaso1"
+                value={formData.tipoDireccion}
+                onChange={(e) => handleInputChange("tipoDireccion", e.target.value)}
+                disabled={disabled}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-gray-50 focus:border-blue-500 focus:outline-none disabled:bg-gray-100"
+              >
+                <option value="casa">Casa</option>
+                <option value="apartamento">Apartamento</option>
+                <option value="oficina">Oficina</option>
+                <option value="otro">Otro</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="instruccionesEntrega" className="block text-sm font-bold text-gray-900 mb-1">
+                Observación / Instrucciones de entrega <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="instruccionesEntrega"
+                type="text"
+                value={formData.instruccionesEntrega}
+                onChange={(e) => handleInputChange("instruccionesEntrega", e.target.value)}
+                placeholder="ej: Torre 3, apto 502. Dejar en portería."
+                disabled={disabled}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:border-blue-500 focus:outline-none disabled:bg-gray-100"
+              />
+              {errors.instruccionesEntrega && (
+                <p className="text-red-500 text-xs mt-1">{errors.instruccionesEntrega}</p>
+              )}
+            </div>
+          </div>
+        )}
+
         </div>
       )}
 
-      {/* PASO 2: Información adicional */}
+      {/* PASO 2 (legacy, ya no se usa en el flujo de un solo paso): Información adicional */}
       {currentStep === 2 && (
         <div className="space-y-4">
-          {/* Nombre de la dirección y Tipo de propiedad en la misma fila */}
+          {/* Tipo de propiedad */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Nombre de la dirección */}
-            <div>
-              <label
-                htmlFor="nombreDireccion"
-                className="block text-sm font-bold text-gray-900 mb-1"
-              >
-                Nombre de la dirección <span className="text-red-500">*</span>
-              </label>
-              <input
-                id="nombreDireccion"
-                type="text"
-                value={formData.nombreDireccion}
-                onChange={(e) =>
-                  handleInputChange("nombreDireccion", e.target.value)
-                }
-                placeholder="ej: Casa, Oficina, Casa de mamá"
-                disabled={disabled}
-                className={`w-full px-3 py-2 border rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent transition ${
-                  disabled
-                    ? "bg-gray-100 cursor-not-allowed opacity-60"
-                    : getFieldBackgroundClass(formData.nombreDireccion)
-                } ${
-                  errors.nombreDireccion ? "border-red-500" : "border-gray-300"
-                }`}
-              />
-              {errors.nombreDireccion && (
-                <p className="text-red-500 text-xs mt-1">
-                  {errors.nombreDireccion}
-                </p>
-              )}
-            </div>
-
-            {/* Tipo de propiedad */}
             <div>
               <label
                 htmlFor="tipoDireccionPropiedad"
@@ -1738,7 +1743,9 @@ export default function AddNewAddressForm({
       )}
 
       {/* Errores generales - Solo en paso 2 */}
-      {currentStep === 2 && errors.submit && (
+      {/* Flujo de un solo paso: el error de guardado NO puede depender de
+          currentStep (que ahora queda fijo en 1), o sería silencioso. */}
+      {errors.submit && (
         <div className="bg-red-50 border border-red-200 rounded-md p-3">
           <p className="text-red-500 text-sm">{errors.submit}</p>
         </div>
@@ -1772,12 +1779,11 @@ export default function AddNewAddressForm({
                   disabled ||
                   isLoading ||
                   !selectedAddress ||
-                  !formData.nombreDireccion ||
                   !formData.instruccionesEntrega ||
                   (!formData.usarMismaParaFacturacion && !selectedBillingAddress)
                 }
                 className={`flex-1 text-white px-6 py-3 rounded-xl font-bold transition border-2 ${
-                  !(disabled || isLoading || !selectedAddress || !formData.nombreDireccion || !formData.instruccionesEntrega || (!formData.usarMismaParaFacturacion && !selectedBillingAddress))
+                  !(disabled || isLoading || !selectedAddress || !formData.instruccionesEntrega || (!formData.usarMismaParaFacturacion && !selectedBillingAddress))
                     ? "bg-green-600 border-green-500 hover:bg-green-700 hover:border-green-600 shadow-lg shadow-green-500/40 hover:shadow-xl hover:shadow-green-500/50"
                     : "bg-gray-400 border-gray-300 cursor-not-allowed"
                 }`}
@@ -1820,12 +1826,11 @@ export default function AddNewAddressForm({
                 type="submit"
                 disabled={
                   isLoading ||
-                  !formData.nombreDireccion ||
                   !formData.instruccionesEntrega ||
                   (!formData.usarMismaParaFacturacion && !selectedBillingAddress)
                 }
                 className={`flex-1 text-white px-6 py-3 rounded-xl font-bold transition border-2 ${
-                  !(isLoading || !formData.nombreDireccion || !formData.instruccionesEntrega || (!formData.usarMismaParaFacturacion && !selectedBillingAddress))
+                  !(isLoading || !formData.instruccionesEntrega || (!formData.usarMismaParaFacturacion && !selectedBillingAddress))
                     ? "bg-green-600 border-green-500 hover:bg-green-700 hover:border-green-600 shadow-lg shadow-green-500/40 hover:shadow-xl hover:shadow-green-500/50"
                     : "bg-gray-400 border-gray-300 cursor-not-allowed"
                 }`}

--- a/src/app/carrito/components/CheckoutLoginModal.tsx
+++ b/src/app/carrito/components/CheckoutLoginModal.tsx
@@ -1,0 +1,564 @@
+"use client";
+
+/**
+ * CheckoutLoginModal
+ *
+ * Se abre en el checkout cuando el correo que ingresó el invitado pertenece a
+ * una cuenta REGISTRADA (rol 2). Ofrece dos formas de iniciar sesión:
+ *  - Clave: POST /api/auth/login
+ *  - Código (OTP): POST /api/auth/otp/send-login → /api/auth/otp/verify-login,
+ *    por email o por teléfono.
+ *
+ * Al iniciar sesión con éxito devuelve { access_token, user } vía onSuccess;
+ * el padre (Step2) persiste la sesión y avanza el checkout.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, ClipboardEvent as ReactClipboardEvent } from "react";
+import { X, Loader2, Eye, EyeOff } from "lucide-react";
+import { FaWhatsapp } from "react-icons/fa";
+import { apiPost } from "@/lib/api-client";
+
+/** Logo oficial de Gmail (multicolor de Google) para el canal de correo. */
+function GmailIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 48 48" className={className} aria-hidden="true">
+      <path fill="#4caf50" d="M45,16.2l-5,2.75l-5,4.75L35,40h7c1.657,0,3-1.343,3-3V16.2z" />
+      <path fill="#1e88e5" d="M3,16.2l3.614,1.71L13,23.7V40H6c-1.657,0-3-1.343-3-3V16.2z" />
+      <polygon fill="#e53935" points="35,11.2 24,19.45 13,11.2 12,17 13,23.7 24,31.95 35,23.7 36,17" />
+      <path fill="#c62828" d="M3,12.298V16.2l10,7.5V11.2L9.876,8.859C9.132,8.301,8.228,8,7.298,8h0C4.924,8,3,9.924,3,12.298z" />
+      <path fill="#fbc02d" d="M45,12.298V16.2l-10,7.5V11.2l3.124-2.341C38.868,8.301,39.772,8,40.702,8h0C43.076,8,45,9.924,45,12.298z" />
+    </svg>
+  );
+}
+
+// Guard de intentos del código: máximo 5, luego bloqueo de 20 min. Se persiste
+// por email en localStorage para que sobreviva a recargas de la página.
+const MAX_OTP_ATTEMPTS = 5;
+const OTP_LOCK_MS = 20 * 60 * 1000;
+const otpLockKey = (email: string) => `checkout_otp_lock_${email.toLowerCase()}`;
+
+function readOtpLock(email: string): { count: number; lockedUntil: number | null } {
+  try {
+    const raw = localStorage.getItem(otpLockKey(email));
+    if (!raw) return { count: 0, lockedUntil: null };
+    const parsed = JSON.parse(raw) as { count?: number; lockedUntil?: number | null };
+    return { count: parsed.count ?? 0, lockedUntil: parsed.lockedUntil ?? null };
+  } catch {
+    return { count: 0, lockedUntil: null };
+  }
+}
+
+function writeOtpLock(
+  email: string,
+  data: { count: number; lockedUntil: number | null },
+) {
+  try {
+    localStorage.setItem(otpLockKey(email), JSON.stringify(data));
+  } catch {
+    /* localStorage no disponible: el guard queda solo en memoria */
+  }
+}
+
+function clearOtpLock(email: string) {
+  try {
+    localStorage.removeItem(otpLockKey(email));
+  } catch {
+    /* noop */
+  }
+}
+
+/**
+ * Entrada de código OTP en 6 casillas. Se llena de izquierda a derecha, avanza y
+ * retrocede el foco solo, acepta pegar el código completo y llama a onComplete
+ * cuando se completan los 6 dígitos (para auto-verificar sin pulsar el botón).
+ */
+function OtpInput({
+  value,
+  onChange,
+  onComplete,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onComplete: (v: string) => void;
+  disabled?: boolean;
+}) {
+  const refs = useRef<Array<HTMLInputElement | null>>([]);
+  const prevLen = useRef(value.length);
+
+  useEffect(() => {
+    // Enfocar la primera casilla vacía al montar.
+    refs.current[Math.min(value.length, 5)]?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    // Si las casillas se vacían (p.ej. tras un intento fallido) devolver el
+    // foco a la primera para reintentar sin tener que hacer clic.
+    if (value.length === 0 && prevLen.current > 0) refs.current[0]?.focus();
+    prevLen.current = value.length;
+  }, [value.length]);
+
+  const focusAt = (i: number) =>
+    refs.current[Math.max(0, Math.min(i, 5))]?.focus();
+
+  const commit = (raw: string) => {
+    const clean = raw.replace(/\D/g, "").slice(0, 6);
+    onChange(clean);
+    if (clean.length === 6) onComplete(clean);
+  };
+
+  const handleChange = (index: number, raw: string) => {
+    const only = raw.replace(/\D/g, "");
+    if (!only) return;
+    commit(value.slice(0, index) + only + value.slice(index + 1));
+    focusAt(Math.min(index + only.length, 5));
+  };
+
+  const handleKeyDown = (
+    index: number,
+    e: ReactKeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (e.key === "Backspace") {
+      e.preventDefault();
+      if (value[index]) {
+        onChange((value.slice(0, index) + value.slice(index + 1)).replace(/\D/g, ""));
+        focusAt(index);
+      } else if (index > 0) {
+        onChange((value.slice(0, index - 1) + value.slice(index)).replace(/\D/g, ""));
+        focusAt(index - 1);
+      }
+    } else if (e.key === "ArrowLeft") {
+      focusAt(index - 1);
+    } else if (e.key === "ArrowRight") {
+      focusAt(index + 1);
+    }
+  };
+
+  const handlePaste = (
+    index: number,
+    e: ReactClipboardEvent<HTMLInputElement>,
+  ) => {
+    e.preventDefault();
+    const pasted = (e.clipboardData.getData("text") || "").replace(/\D/g, "");
+    if (!pasted) return;
+    commit(value.slice(0, index) + pasted);
+    focusAt(Math.min(index + pasted.length, 5));
+  };
+
+  return (
+    <div className="flex justify-between gap-2">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <input
+          key={i}
+          ref={(el) => {
+            refs.current[i] = el;
+          }}
+          inputMode="numeric"
+          autoComplete={i === 0 ? "one-time-code" : "off"}
+          maxLength={1}
+          disabled={disabled}
+          value={value[i] ?? ""}
+          onChange={(e) => handleChange(i, e.target.value)}
+          onKeyDown={(e) => handleKeyDown(i, e)}
+          onPaste={(e) => handlePaste(i, e)}
+          onFocus={(e) => e.target.select()}
+          className="h-12 w-full rounded-lg border border-gray-300 text-center text-xl font-semibold text-gray-900 focus:border-gray-900 focus:outline-none disabled:bg-gray-100 disabled:text-gray-400"
+        />
+      ))}
+    </div>
+  );
+}
+
+interface LoginResult {
+  access_token: string;
+  user: {
+    id: string;
+    email: string;
+    nombre: string;
+    apellido: string;
+    numero_documento: string;
+    telefono: string;
+    rol?: number;
+  };
+}
+
+interface CheckoutLoginModalProps {
+  email: string;
+  /** Teléfono enmascarado de la cuenta (p.ej. "•••••• 8092") para el canal WhatsApp. */
+  phoneHint?: string | null;
+  onClose: () => void;
+  onSuccess: (result: LoginResult) => void;
+}
+
+type Mode = "password" | "otp";
+type OtpChannel = "email" | "telefono";
+
+export default function CheckoutLoginModal({
+  email,
+  phoneHint,
+  onClose,
+  onSuccess,
+}: CheckoutLoginModalProps) {
+  const [mode, setMode] = useState<Mode>("password");
+  const [password, setPassword] = useState("");
+  const [otpChannel, setOtpChannel] = useState<OtpChannel>("email");
+  const [otpSent, setOtpSent] = useState(false);
+  const [otpCode, setOtpCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [otpAttempts, setOtpAttempts] = useState(0);
+  const [lockedUntil, setLockedUntil] = useState<number | null>(null);
+  const [nowTs, setNowTs] = useState<number>(() => Date.now());
+  // Teléfono enmascarado a mostrar en el canal WhatsApp. Si el padre no lo pasó
+  // (según por qué camino se abrió el modal), lo resolvemos aquí con el email.
+  const [hint, setHint] = useState<string | null>(phoneHint ?? null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState<number | undefined>(undefined);
+
+  // Cerrar con Escape + enfocar el modal al abrir (accesibilidad).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    dialogRef.current?.focus();
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Resolver el teléfono enmascarado si no vino por props (p.ej. el modal se
+  // abrió por el catch de "ya registrado", que no trae telefonoMask).
+  useEffect(() => {
+    if (phoneHint) {
+      setHint(phoneHint);
+      return;
+    }
+    let cancelled = false;
+    apiPost<{ telefonoMask?: string | null }>("/api/auth/check-email", { email })
+      .then((r) => {
+        if (!cancelled) setHint(r?.telefonoMask ?? null);
+      })
+      .catch(() => {
+        /* sin hint: se mostrará el texto genérico */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [email, phoneHint]);
+
+  // Cargar el estado de bloqueo por intentos (persistido por email).
+  useEffect(() => {
+    const lock = readOtpLock(email);
+    setOtpAttempts(lock.count);
+    if (lock.lockedUntil && lock.lockedUntil > Date.now()) {
+      setLockedUntil(lock.lockedUntil);
+    } else if (lock.lockedUntil) {
+      clearOtpLock(email);
+    }
+  }, [email]);
+
+  // Cuenta regresiva del bloqueo: tick cada segundo y auto-liberar al vencer.
+  useEffect(() => {
+    if (!lockedUntil) return;
+    const id = setInterval(() => {
+      const t = Date.now();
+      setNowTs(t);
+      if (t >= lockedUntil) {
+        setLockedUntil(null);
+        setOtpAttempts(0);
+        clearOtpLock(email);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [lockedUntil, email]);
+
+  const remainingMs = lockedUntil ? Math.max(0, lockedUntil - nowTs) : 0;
+  const isLocked = remainingMs > 0;
+  const remainingLabel = `${Math.floor(remainingMs / 60000)}:${String(
+    Math.floor((remainingMs % 60000) / 1000),
+  ).padStart(2, "0")}`;
+
+  // Medir el contenido para animar la altura del modal entre estados: cada modo
+  // usa su altura natural (nada de espacio vacío) pero la transición es suave.
+  useEffect(() => {
+    const el = contentRef.current;
+    if (el) setContentHeight(el.scrollHeight);
+  }, [mode, otpSent, isLocked, error, hint, otpChannel]);
+
+  const handlePasswordLogin = async () => {
+    if (loading) return; // evitar doble envío (Enter repetido)
+    if (!password) {
+      setError("Ingresa tu contraseña.");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const result = await apiPost<LoginResult>("/api/auth/login", {
+        email,
+        contrasena: password,
+      });
+      if (!result?.access_token || !result?.user) {
+        throw new Error("Respuesta de inicio de sesión inválida.");
+      }
+      onSuccess(result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "No se pudo iniciar sesión.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSendOtp = async () => {
+    if (loading) return; // evitar spam de OTP (Enter repetido)
+    if (isLocked) return; // bloqueado por demasiados intentos
+    setLoading(true);
+    setError("");
+    setOtpCode(""); // limpiar cualquier código previo al (re)enviar
+    try {
+      // La identidad SIEMPRE es el email (único por cuenta). El canal solo
+      // decide el medio de entrega: 'email' o 'whatsapp' (al teléfono
+      // registrado de la cuenta, que el backend resuelve por el email). Así el
+      // teléfono no hace de identidad aunque se repita en otra cuenta.
+      await apiPost("/api/auth/otp/send-login", {
+        metodo: otpChannel === "email" ? "email" : "whatsapp",
+        email,
+      });
+      setOtpSent(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "No se pudo enviar el código.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerifyOtp = async (codeArg?: string) => {
+    if (loading) return; // evitar doble verificación (Enter/auto-verify repetido)
+    if (isLocked) return; // bloqueado por demasiados intentos
+    const code = codeArg ?? otpCode;
+    if (code.length !== 6) {
+      setError("El código debe tener 6 dígitos.");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      // Verificación SIEMPRE por email: el código quedó atado a la cuenta del
+      // email, sin importar por qué canal se entregó.
+      const result = await apiPost<LoginResult>("/api/auth/otp/verify-login", {
+        codigo: code,
+        email,
+      });
+      if (!result?.access_token || !result?.user) {
+        throw new Error("Código inválido o expirado.");
+      }
+      clearOtpLock(email); // éxito: reiniciar el contador de intentos
+      onSuccess(result);
+    } catch (e) {
+      // Intento fallido: contar y, al llegar al máximo, bloquear 20 min.
+      const count = otpAttempts + 1;
+      if (count >= MAX_OTP_ATTEMPTS) {
+        const until = Date.now() + OTP_LOCK_MS;
+        writeOtpLock(email, { count, lockedUntil: until });
+        setOtpAttempts(count);
+        setLockedUntil(until);
+        setError("Demasiados intentos. Por seguridad, intenta de nuevo en 20 minutos.");
+      } else {
+        writeOtpLock(email, { count, lockedUntil: null });
+        setOtpAttempts(count);
+        const base = e instanceof Error ? e.message : "Código incorrecto.";
+        const left = MAX_OTP_ATTEMPTS - count;
+        setError(`${base} Te ${left === 1 ? "queda" : "quedan"} ${left} intento${left === 1 ? "" : "s"}.`);
+      }
+      setOtpCode(""); // limpiar las casillas para reintentar
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="checkout-login-title"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        className="relative w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl outline-none"
+      >
+        <button
+          onClick={onClose}
+          aria-label="Cerrar"
+          className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        {/* Logo Samsung (mismo asset que el navbar) */}
+        <div className="-mt-1 mb-4 flex justify-center">
+          <img
+            src="https://res.cloudinary.com/dnglv0zqg/image/upload/v1760575601/Samsung_black_ec1b9h.svg"
+            alt="Samsung"
+            className="h-10 w-auto"
+          />
+        </div>
+
+        <h2 id="checkout-login-title" className="mb-1 text-xl font-semibold text-gray-900">Inicia sesión</h2>
+        <p className="mb-4 text-sm text-gray-500">
+          El correo <span className="font-medium text-gray-700">{email}</span> ya
+          tiene una cuenta. Inicia sesión para continuar con tu compra.
+        </p>
+
+        {/* Tabs clave / código */}
+        <div className="mb-4 flex rounded-lg bg-gray-100 p-1 text-sm font-medium">
+          <button
+            onClick={() => { setMode("password"); setError(""); }}
+            className={`flex-1 rounded-md py-2 transition ${mode === "password" ? "bg-white shadow text-gray-900" : "text-gray-500"}`}
+          >
+            Con contraseña
+          </button>
+          <button
+            onClick={() => { setMode("otp"); setError(""); }}
+            className={`flex-1 rounded-md py-2 transition ${mode === "otp" ? "bg-white shadow text-gray-900" : "text-gray-500"}`}
+          >
+            Con código
+          </button>
+        </div>
+
+        {/* Alto animado: cada estado usa su altura natural, con transición suave
+            para que no salte al cambiar de pestaña/estado. */}
+        <div
+          style={{ height: contentHeight }}
+          className="overflow-hidden transition-[height] duration-200 ease-out"
+        >
+          <div ref={contentRef}>
+        {mode === "password" ? (
+          <div className="space-y-3">
+            <div className="relative">
+              <input
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handlePasswordLogin()}
+                placeholder="Tu contraseña"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2.5 pr-10 text-sm focus:border-gray-900 focus:outline-none"
+                autoFocus
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+                className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+            <button
+              onClick={handlePasswordLogin}
+              disabled={loading}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-black py-2.5 text-sm font-semibold text-white hover:bg-gray-800 disabled:opacity-60"
+            >
+              {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+              Iniciar sesión
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {/* Canal del código */}
+            <div className="flex gap-2 text-sm">
+              <button
+                onClick={() => { setOtpChannel("email"); setOtpSent(false); setError(""); }}
+                className={`flex flex-1 items-center justify-center gap-2 rounded-lg border py-2 ${otpChannel === "email" ? "border-black bg-gray-100 text-gray-900" : "border-gray-300 text-gray-600"}`}
+              >
+                <GmailIcon className="h-4 w-5" />
+                Al correo
+              </button>
+              <button
+                onClick={() => { setOtpChannel("telefono"); setOtpSent(false); setError(""); }}
+                className={`flex flex-1 items-center justify-center gap-2 rounded-lg border py-2 ${otpChannel === "telefono" ? "border-black bg-gray-100 text-gray-900" : "border-gray-300 text-gray-600"}`}
+              >
+                <FaWhatsapp className="h-4 w-4 text-[#25D366]" />
+                Al teléfono
+              </button>
+            </div>
+
+            {isLocked ? (
+              <div className="rounded-lg bg-red-50 px-3 py-3 text-center text-sm text-red-600">
+                Demasiados intentos.
+                <br />
+                Podrás intentar de nuevo en{" "}
+                <span className="font-semibold tabular-nums">{remainingLabel}</span> min.
+              </div>
+            ) : !otpSent ? (
+              <>
+                <p className="text-xs text-gray-500">
+                  {otpChannel === "email" ? (
+                    <>Te enviaremos un código a <span className="font-medium text-gray-700">{email}</span>.</>
+                  ) : hint ? (
+                    <>Te enviaremos un código por WhatsApp al <span className="font-medium text-gray-700">{hint}</span>.</>
+                  ) : (
+                    "Te enviaremos un código por WhatsApp al teléfono registrado en tu cuenta."
+                  )}
+                </p>
+                <button
+                  onClick={handleSendOtp}
+                  disabled={loading}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-black py-2.5 text-sm font-semibold text-white hover:bg-gray-800 disabled:opacity-60"
+                >
+                  {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+                  Enviar código
+                </button>
+              </>
+            ) : (
+              <>
+                <p className="text-xs text-gray-500">
+                  Ingresa el código de 6 dígitos que enviamos{" "}
+                  {otpChannel === "email" ? (
+                    <>a <span className="font-medium text-gray-700">{email}</span></>
+                  ) : hint ? (
+                    <>por WhatsApp al <span className="font-medium text-gray-700">{hint}</span></>
+                  ) : (
+                    "por WhatsApp a tu teléfono"
+                  )}
+                  .
+                </p>
+                <OtpInput
+                  value={otpCode}
+                  onChange={setOtpCode}
+                  onComplete={(v) => handleVerifyOtp(v)}
+                  disabled={loading}
+                />
+                <button
+                  onClick={() => handleVerifyOtp()}
+                  disabled={loading || otpCode.length !== 6}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-black py-2.5 text-sm font-semibold text-white hover:bg-gray-800 disabled:opacity-60"
+                >
+                  {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+                  Verificar y continuar
+                </button>
+                <button
+                  onClick={handleSendOtp}
+                  disabled={loading}
+                  className="w-full text-xs text-gray-500 hover:text-gray-700"
+                >
+                  Reenviar código
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/carrito/components/CheckoutShell.tsx
+++ b/src/app/carrito/components/CheckoutShell.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+/**
+ * Shell del checkout: agrega la columna del indicador de pasos SOLO a partir
+ * de step2 (cuando el usuario dio "Continuar" en el carrito). En /carrito y
+ * /carrito/step1 los children se renderizan a ancho completo, igual que antes
+ * de introducir el indicador.
+ */
+
+import { usePathname } from "next/navigation";
+import CheckoutStepIndicator, { milestoneFromPath } from "./CheckoutStepIndicator";
+
+export default function CheckoutShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname() || "";
+  const inProgress = milestoneFromPath(pathname) !== null;
+
+  if (!inProgress) return <>{children}</>;
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1400px] flex-col gap-4 px-4 md:flex-row md:gap-8 md:px-6">
+      {/* Patrón correcto de sticky en flex: el ASIDE mismo es sticky +
+          self-start (no se estira), así se queda FIJO a top-28 al hacer scroll
+          dentro de la fila. */}
+      <aside className="w-full pt-4 md:w-56 md:flex-shrink-0 md:self-start md:sticky md:top-28 md:pt-10">
+        <CheckoutStepIndicator />
+      </aside>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}

--- a/src/app/carrito/components/CheckoutStepIndicator.tsx
+++ b/src/app/carrito/components/CheckoutStepIndicator.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+/**
+ * Indicador de progreso del checkout.
+ *
+ * Empieza DESPUÉS del carrito (cuando el usuario da "Continuar"): el carrito
+ * no es un paso, es el punto de partida. Hitos: Tus datos → Entrega → Pago →
+ * Confirmar (los steps internos 4/5/6 se agrupan en "Pago" porque cuotas y
+ * facturación son sub-pasos condicionales que confundirían el conteo).
+ *
+ * Desktop: riel vertical fino — hecho (círculo negro + check), actual (negro
+ * con halo suave + label bold), pendiente (borde gris). Móvil: barra
+ * segmentada compacta + "Paso X de 4".
+ */
+
+import { usePathname } from "next/navigation";
+import { Check } from "lucide-react";
+
+const MILESTONES = [
+  { id: 1, name: "Tus datos" },
+  { id: 2, name: "Entrega" },
+  { id: 3, name: "Pago" },
+  { id: 4, name: "Confirmar" },
+];
+
+/** null = aún en el carrito (no mostrar indicador) */
+export function milestoneFromPath(pathname: string): number | null {
+  if (pathname.includes("/step2")) return 1;
+  if (pathname.includes("/step3")) return 2;
+  if (pathname.includes("/step4") || pathname.includes("/step5") || pathname.includes("/step6")) return 3;
+  if (pathname.includes("/step7")) return 4;
+  return null; // /carrito y /carrito/step1: sin indicador
+}
+
+export default function CheckoutStepIndicator() {
+  const pathname = usePathname() || "";
+  const current = milestoneFromPath(pathname);
+  if (current === null) return null;
+
+  return (
+    <nav aria-label="Progreso de compra">
+      {/* ---------- Móvil: barra segmentada + paso actual ---------- */}
+      <div className="md:hidden">
+        <div className="mb-2 flex items-baseline justify-between">
+          <span className="text-sm font-bold text-gray-900">
+            {MILESTONES[current - 1].name}
+          </span>
+          <span className="text-xs font-medium text-gray-400">
+            Paso {current} de {MILESTONES.length}
+          </span>
+        </div>
+        <div className="flex gap-1.5">
+          {MILESTONES.map((s) => (
+            <div
+              key={s.id}
+              className={`h-1.5 flex-1 rounded-full transition-colors duration-300 ${
+                s.id <= current ? "bg-gray-900" : "bg-gray-200"
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* ---------- Desktop: riel vertical ---------- */}
+      <ol className="hidden md:flex md:flex-col">
+        {MILESTONES.map((step, i) => {
+          const done = current > step.id;
+          const active = current === step.id;
+          return (
+            <li key={step.id} aria-current={active ? "step" : undefined}>
+              <div className="flex items-center gap-4">
+                <span
+                  className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full text-base font-semibold transition-all duration-300 ${
+                    done
+                      ? "bg-gray-900 text-white"
+                      : active
+                        ? "bg-gray-900 text-white shadow-[0_0_0_5px_rgba(17,24,39,0.12)]"
+                        : "border-2 border-gray-200 bg-white text-gray-400"
+                  }`}
+                >
+                  {done ? <Check strokeWidth={3} className="h-5 w-5" /> : step.id}
+                </span>
+                <span
+                  className={`text-base transition-colors duration-300 ${
+                    active
+                      ? "font-bold text-gray-900"
+                      : done
+                        ? "font-semibold text-gray-700"
+                        : "font-medium text-gray-400"
+                  }`}
+                >
+                  {step.name}
+                </span>
+              </div>
+              {i < MILESTONES.length - 1 && (
+                <div
+                  className={`ml-6 h-12 w-0.5 -translate-x-1/2 transition-colors duration-300 ${
+                    done ? "bg-gray-900" : "bg-gray-200"
+                  }`}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/app/carrito/components/Step4OrderSummary.tsx
+++ b/src/app/carrito/components/Step4OrderSummary.tsx
@@ -51,6 +51,7 @@ interface Step4OrderSummaryProps {
   readonly buttonVariant?: "default" | "green"; // Variante de color del botón
   readonly hideButton?: boolean; // Ocultar el botón principal (útil para pasos intermedios como OTP)
   readonly shouldAnimateButton?: boolean; // Animación bounce cuando el botón se habilita
+  readonly skipPickupCheck?: boolean; // Paso de dirección: enviar el form directo, sin la lógica de pickup (evita doble clic)
 }
 
 export default function Step4OrderSummary({
@@ -73,6 +74,7 @@ export default function Step4OrderSummary({
   buttonVariant = "default",
   hideButton = false,
   shouldAnimateButton = false,
+  skipPickupCheck = false,
 }: Step4OrderSummaryProps) {
   const router = useRouter();
   const {
@@ -1318,6 +1320,15 @@ export default function Step4OrderSummary({
             data-button-text={buttonText}
             aria-busy={isProcessing || userClickedWhileLoading || isArtificialLoading}
             onClick={async () => {
+            // Paso de dirección (skipPickupCheck): enviar el formulario directo,
+            // sin la lógica de pickup/canPickUp — esa se calcula DENTRO de
+            // handleAddressAdded tras guardar, y ahí mismo auto-avanza. Evita el
+            // doble clic que causaba reusar el botón de pago para guardar dirección.
+            if (skipPickupCheck) {
+              onFinishPayment();
+              return;
+            }
+
             // console.log(`🎯 [Step4OrderSummary] Button clicked - isLoadingCanPickUp: ${isLoadingCanPickUp}, globalCanPickUp: ${globalCanPickUp}, shouldCalculateCanPickUp: ${shouldCalculateCanPickUp}, userClickedWhileLoading: ${userClickedWhileLoading}`);
 
             // Usar loading artificial para feedback visual inmediato SIN activar el auto-advance del useEffect

--- a/src/app/carrito/layout.tsx
+++ b/src/app/carrito/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { CheckoutAddressProvider } from "@/features/checkout";
+import CheckoutShell from "./components/CheckoutShell";
 
 export const metadata: Metadata = {
   title: "Carrito de compras",
@@ -12,5 +13,11 @@ export default function CarritoLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <CheckoutAddressProvider>{children}</CheckoutAddressProvider>;
+  return (
+    <CheckoutAddressProvider>
+      {/* El indicador de pasos aparece desde step2 (tras "Continuar" en el
+          carrito); en /carrito y step1 los children van a ancho completo. */}
+      <CheckoutShell>{children}</CheckoutShell>
+    </CheckoutAddressProvider>
+  );
 }

--- a/src/app/carrito/step2/page.tsx
+++ b/src/app/carrito/step2/page.tsx
@@ -94,9 +94,31 @@ export default function Step2Page() {
 
   const handleBack = () => router.push("/carrito/step1");
   const handleNext = () => {
-    // Verificar que haya dirección en el contexto antes de navegar
-    if (!selectedAddress) {
-      console.warn("⚠️ [STEP2] Intentando navegar a step3 pero no hay dirección en el contexto");
+    // El contexto (selectedAddress) puede NO haberse actualizado aún justo
+    // después de guardar la dirección (handleAddressAdded guarda en
+    // checkout-address pero no dispara el evento de cambio). Para no bloquear el
+    // avance —y evitar el doble clic— también validamos leyendo checkout-address
+    // directamente de localStorage.
+    let hasAddress = !!(
+      selectedAddress?.ciudad &&
+      (selectedAddress?.lineaUno || selectedAddress?.direccionFormateada)
+    );
+    if (!hasAddress && typeof window !== "undefined") {
+      try {
+        const raw = window.localStorage.getItem("checkout-address");
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          hasAddress = !!(
+            parsed?.ciudad && (parsed?.linea_uno || parsed?.direccionFormateada)
+          );
+        }
+      } catch {
+        /* checkout-address ilegible: se cae al warning de abajo */
+      }
+    }
+
+    if (!hasAddress) {
+      console.warn("⚠️ [STEP2] Intentando navegar a step3 pero no hay dirección");
       return;
     }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,23 @@
   animation: fadeIn 0.5s ease-in-out;
 }
 
+/* Burbuja del chatbot: entra deslizándose de izquierda a derecha */
+@keyframes chatbotSlideInLeft {
+  from {
+    opacity: 0;
+    transform: translateX(-16px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+.animate-chatbot-slide-in {
+  animation: chatbotSlideInLeft 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  transform-origin: right center;
+}
+
 /* Animaciones para CheckoutSuccessOverlay y CheckoutErrorOverlay */
 @keyframes bgPop {
   0% {
@@ -570,6 +587,19 @@ GIF PAUSE CONTROL - ENHANCED VERSION WITH SMOOTH TRANSITIONS
   -webkit-backdrop-filter: blur(12px);
   box-shadow: -6px 0 32px 0 rgba(0, 0, 0, 0.15);
   z-index: 99999;
+  /* Entrada deslizándose de izquierda a derecha (drawer anclado a la izquierda) */
+  animation: chatbotPanelSlideIn 0.38s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes chatbotPanelSlideIn {
+  from {
+    transform: translateX(-100%);
+    opacity: 0.6;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }
 
 @media (max-width: 640px) {

--- a/src/app/ofertas/page.tsx
+++ b/src/app/ofertas/page.tsx
@@ -110,30 +110,34 @@ export default function OfertasPage() {
             {ofertas.map((item) => (
               <div
                 key={item.title}
-                className="flex-1 flex flex-col items-center justify-center bg-white/10 border border-white/40 rounded-xl shadow-md backdrop-blur-md group transition-all duration-300 cursor-pointer h-full mx-1 px-2 py-2"
+                className="flex-1 flex flex-col items-center justify-center bg-white/10 border border-white/40 rounded-xl shadow-md backdrop-blur-md group transition-all duration-300 cursor-pointer h-full mx-1 px-2 py-2 relative"
                 style={{ height: "calc(30vh - 10px)", overflow: "hidden" }}
               >
+                {/* Toda la card clickeable (está debajo del header, sin riesgo) */}
+                <Link
+                  href={item.href}
+                  className="absolute inset-0 z-0"
+                  aria-label={"Ver ofertas de " + item.title}
+                  scroll={false}
+                />
                 <Image
                   src={item.icon}
                   alt={item.title + " icon"}
                   width={88}
                   height={88}
-                  className={`mb-2 transition-transform duration-300 group-hover:scale-110${
+                  className={`mb-2 transition-transform duration-300 group-hover:scale-110 relative z-10 pointer-events-none${
                     item.whiteIcon ? " filter invert brightness-200" : ""
                   }`}
                   priority
                 />
-                <h2 className="text-white text-xl font-bold mb-2 text-center transition-colors duration-300 group-hover:text-white/90 px-1">
+                <h2 className="text-white text-xl font-bold mb-2 text-center transition-colors duration-300 group-hover:text-white/90 px-1 relative z-10 pointer-events-none">
                   {item.title}
                 </h2>
-                <Link
-                  href={item.href}
-                  className="mt-1 px-3 py-0.5 border border-white/80 rounded-full text-white text-xl font-medium text-center hover:bg-white hover:text-[#1a1a1a] transition-colors duration-200 group-hover:bg-white group-hover:text-[#1a1a1a]"
-                  aria-label={item.info + " " + item.title}
-                  scroll={false}
+                <span
+                  className="mt-1 px-3 py-0.5 border border-white/80 rounded-full text-white text-xl font-medium text-center transition-colors duration-200 group-hover:bg-white group-hover:text-[#1a1a1a] relative z-10 pointer-events-none"
                 >
                   {item.info}
-                </Link>
+                </span>
               </div>
             ))}
           </div>
@@ -143,7 +147,7 @@ export default function OfertasPage() {
         {ofertas.map((item, index) => (
           <div
             key={item.title}
-            className={`hidden md:flex flex-1 flex-col items-center justify-center ${item.bg} group transition-all duration-300 cursor-pointer h-full pt-20`}
+            className={`hidden md:flex flex-1 flex-col items-center justify-center ${item.bg} group transition-all duration-300 cursor-pointer h-full pt-20 relative`}
             style={{
               height: "100vh",
               minHeight: "100vh",
@@ -155,28 +159,37 @@ export default function OfertasPage() {
               }s, opacity 0.8s cubic-bezier(0.4, 0, 0.2, 1) ${index * 0.15}s`,
             }}
           >
+            {/* Toda la columna clickeable: overlay que cubre DESDE debajo del
+                header (top-20 = 80px, alto del navbar) hasta abajo. Así un clic
+                en cualquier parte de la sección entra, pero un clic en el header
+                NO lo dispara (el overlay no llega hasta arriba). */}
+            <Link
+              href={item.href}
+              className="absolute inset-x-0 bottom-0 top-20 z-0"
+              aria-label={"Ver ofertas de " + item.title}
+              scroll={false}
+            />
+            {/* Contenido visual: pointer-events-none para que el clic caiga en
+                el overlay (el hover sigue funcionando vía group-hover). */}
             <Image
               src={item.icon}
               alt={item.title + " icon"}
               width={100}
               height={100}
-              className={`mb-10 transition-transform duration-300 group-hover:scale-110${
+              className={`mb-10 transition-transform duration-300 group-hover:scale-110 relative z-10 pointer-events-none${
                 item.whiteIcon ? " filter invert brightness-200" : ""
               }`}
               priority
             />
-            <h2 className="text-white text-2xl md:text-3xl font-bold mb-6 text-center transition-colors duration-300 group-hover:text-white/90">
+            <h2 className="text-white text-2xl md:text-3xl font-bold mb-6 text-center transition-colors duration-300 group-hover:text-white/90 relative z-10 pointer-events-none">
               {item.title}
             </h2>
-            {/* Botón de más información: navega a la categoría de productos con oferta */}
-            <Link
-              href={item.href}
-              className="mt-2 px-6 py-2 border-2 border-white rounded-full text-white text-lg font-medium hover:bg-white hover:text-[#1a1a1a] transition-colors duration-200 group-hover:bg-white group-hover:text-[#1a1a1a]"
-              aria-label={item.info + " " + item.title}
-              scroll={false}
+            {/* "Más información" ahora es visual (span); la columna entera es el link */}
+            <span
+              className="mt-2 px-6 py-2 border-2 border-white rounded-full text-white text-lg font-medium transition-colors duration-200 group-hover:bg-white group-hover:text-[#1a1a1a] relative z-10 pointer-events-none"
             >
               {item.info}
-            </Link>
+            </span>
           </div>
         ))}
       </div>

--- a/src/app/productos/[categoria]/components/OfertasSection.tsx
+++ b/src/app/productos/[categoria]/components/OfertasSection.tsx
@@ -4,6 +4,7 @@
 
 "use client";
 import React, { useMemo, useState, useCallback } from "react";
+import { SlidersHorizontal } from "lucide-react";
 import ProductCard from "../../components/ProductCard";
 import BundleCard from "../../components/BundleCard";
 import { useProducts } from "@/features/products/useProducts";
@@ -61,19 +62,37 @@ export default function OfertasSection({ seccion }: OfertasSectionProps) {
   // Estados para paginación
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(50);
+  // Orden (solo en ofertas): 'relevante' = orden original del API (default),
+  // 'asc' = menor a mayor, 'desc' = mayor a menor.
+  const [sortOrder, setSortOrder] = useState<"relevante" | "asc" | "desc">("relevante");
+
+  const handleSortChange = useCallback((order: "relevante" | "asc" | "desc") => {
+    setSortOrder(order);
+    setCurrentPage(1);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
 
   // Memoizar los filtros para evitar recreaciones innecesarias
   const initialFilters = useMemo(() => {
-    const baseFilters = { 
+    const baseFilters = {
       withDiscount: true,
       page: currentPage,
       limit: itemsPerPage,
       sortBy: 'precio',
-      sortOrder:'desc',
+      // Backend solo entiende asc/desc; 'relevante' usa el orden por defecto
+      // (el reordenamiento fino se hace en cliente sobre orderedItems).
+      sortOrder: sortOrder === 'asc' ? 'asc' : 'desc',
       precioMin: 1,
-      stockMin: 1,
+      // minStock es la clave que useProducts mapea a stockMinimo; antes decía
+      // 'stockMin' (clave muerta) y el filtro de stock nunca se aplicaba → se
+      // mostraban ofertas sin stock.
+      minStock: 1,
+      // Rutear la query pesada de ofertas por el proxy cacheado (Data Cache de
+      // Next): el primer visitante paga los ~6s, el resto la recibe en ~ms.
+      // Si el proxy falla, getFilteredV2 cae al endpoint directo.
+      cacheProxyPath: '/api/pcache/ofertas',
     };
-    
+
     if (seccion && ofertasFiltersMap[seccion]) {
       const sectionFilters = ofertasFiltersMap[seccion];
       return {
@@ -81,9 +100,9 @@ export default function OfertasSection({ seccion }: OfertasSectionProps) {
         ...sectionFilters,
       };
     }
-    
+
     return baseFilters;
-  }, [seccion, currentPage, itemsPerPage]);
+  }, [seccion, currentPage, itemsPerPage, sortOrder]);
 
   // Usar el hook de productos con filtro de ofertas
   const { 
@@ -96,6 +115,21 @@ export default function OfertasSection({ seccion }: OfertasSectionProps) {
     totalPages,
     refreshProducts 
   } = useProducts(initialFilters);
+
+  // Ordenar los items visibles por precio en el CLIENTE (el backend devuelve
+  // orderedItems intercalado, no por precio). 'relevante' = orden original.
+  // DEBE ir ANTES de cualquier return condicional (regla de hooks).
+  const priceOf = (item: MixedProductItem): number =>
+    Number(String((item as { price?: string }).price ?? "").replace(/[^\d]/g, "")) || 0;
+  const displayItems = useMemo(() => {
+    if (sortOrder === "relevante") return orderedItems;
+    const arr = [...orderedItems];
+    arr.sort((a, b) =>
+      sortOrder === "asc" ? priceOf(a) - priceOf(b) : priceOf(b) - priceOf(a)
+    );
+    return arr;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderedItems, sortOrder]);
 
   // Handlers para paginación
   const handlePageChange = useCallback((page: number) => {
@@ -144,6 +178,34 @@ export default function OfertasSection({ seccion }: OfertasSectionProps) {
   // Obtener el banner para esta sección
   const bannerConfig = seccion ? OFERTAS_BANNERS_MAP[seccion] : null;
 
+  // Botones de orden (reutilizados en sidebar desktop y barra móvil)
+  const sortOptions: Array<{ key: "relevante" | "asc" | "desc"; label: string }> = [
+    { key: "relevante", label: "Relevante" },
+    { key: "asc", label: "Menor a mayor" },
+    { key: "desc", label: "Mayor a menor" },
+  ];
+  // Barra de orden HORIZONTAL (debajo del título, ancho completo)
+  const sortBar = (
+    <div className="mb-6 flex flex-wrap items-center gap-2">
+      <span className="mr-1 flex items-center gap-2 text-sm font-bold text-gray-900">
+        <SlidersHorizontal className="h-4 w-4" /> Ordenar por precio:
+      </span>
+      {sortOptions.map((opt) => (
+        <button
+          key={opt.key}
+          onClick={() => handleSortChange(opt.key)}
+          className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-colors ${
+            sortOrder === opt.key
+              ? "border-gray-900 bg-gray-900 text-white"
+              : "border-gray-300 text-gray-700 hover:border-gray-400"
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+
   return (
     <div className="container mx-auto px-4 md:px-8 lg:px-12 py-8">
       <h1 className="text-3xl font-bold mb-6 text-center">
@@ -153,31 +215,23 @@ export default function OfertasSection({ seccion }: OfertasSectionProps) {
       {/* Banner promocional */}
       {bannerConfig && <Banner config={bannerConfig} className="mb-10 max-w-7xl mx-auto" />}
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-8 p-8">
-        {(orderedItems.length === 0 && !loading)? (
-          <div className="col-span-3 text-center text-gray-500 text-lg py-4">
+      {/* Orden: barra horizontal debajo del título, arriba del grid */}
+      {sortBar}
+
+      {/* Grid a ancho completo */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 items-stretch">
+        {(displayItems.length === 0 && !loading) ? (
+          <div className="col-span-full text-center text-gray-500 text-lg py-4">
             Vuelve pronto y encuentra las mejores ofertas
           </div>
         ) : (
-          orderedItems.map((item: MixedProductItem) => {
+          displayItems.map((item: MixedProductItem) => {
             if (item.itemType === 'bundle') {
-              // Renderizar BundleCard para bundles
               const { itemType, ...bundleProps } = item;
-              return (
-                <BundleCard 
-                  key={bundleProps.id} 
-                  {...bundleProps}
-                />
-              );
+              return <BundleCard key={bundleProps.id} {...bundleProps} />;
             } else {
-              // Renderizar ProductCard para productos
               const { itemType, ...productProps } = item;
-              return (
-                <ProductCard 
-                  key={productProps.id} 
-                  {...productProps}
-                />
-              );
+              return <ProductCard key={productProps.id} {...productProps} />;
             }
           })
         )}

--- a/src/app/productos/[categoria]/components/ProductsGrid.tsx
+++ b/src/app/productos/[categoria]/components/ProductsGrid.tsx
@@ -193,7 +193,7 @@ export const CategoryProductsGrid = forwardRef<
     return (
       <div
         ref={ref}
-        className={viewMode === "grid" ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 md:gap-5 lg:gap-6 items-start" : "flex flex-wrap"}
+        className={viewMode === "grid" ? "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 md:gap-5 lg:gap-6 items-stretch" : "flex flex-wrap"}
       >
         {/* Mostrar skeletons cuando loading es true (incluyendo cambio de página) */}
         {loading ? (
@@ -221,7 +221,10 @@ export const CategoryProductsGrid = forwardRef<
                     return (
                       <motion.div
                         key={item.key}
-                        className="w-full"
+                        // self-start: el banner conserva su altura natural (formato
+                        // alto) y NO se estira con items-stretch, así no dicta la
+                        // altura de la fila ni las cards lo copian.
+                        className="w-full self-start"
                         initial={{ opacity: 0, y: -20 }}
                         animate={{ opacity: 1, y: 0 }}
                         transition={{
@@ -260,7 +263,7 @@ export const CategoryProductsGrid = forwardRef<
                     return (
                       <div
                         key={item.key}
-                        className="w-full"
+                        className="w-full h-full"
                       >
                         <BundleCard
                           {...bundleProps}
@@ -281,7 +284,7 @@ export const CategoryProductsGrid = forwardRef<
                     return (
                       <div
                         key={item.key}
-                        className="w-full"
+                        className="w-full h-full"
                       >
                         <ProductCard
                           key={product.id}

--- a/src/app/productos/components/BundleCard.tsx
+++ b/src/app/productos/components/BundleCard.tsx
@@ -961,10 +961,11 @@ export default function BundleCard({
           )}
         </div>
 
-        {/* Precio - usa la opción seleccionada */}
+        {/* Precio. sm:min-h-[42px] en el slot: reserva la línea "Ahorra" igual
+            que ProductCard, para mantener los botones alineados entre cards */}
         <div className="px-3 space-y-3 mt-auto">
           {selectedOption && (
-            <div className="space-y-1 min-h-[32px]">
+            <div className="space-y-1 min-h-[32px] sm:min-h-[42px]">
               {(() => {
                 // Usar precio de la opción seleccionada
                 const currentPrice = selectedOption.price;
@@ -1009,6 +1010,13 @@ export default function BundleCard({
             </div>
           )}
 
+          {/* Sección de cero interés — va ANTES de los botones (sin min-h
+              reservado) para que la fila de botones quede siempre pegada al
+              fondo y alineada con las demás cards del grid (simetría) */}
+          <div className="mt-2 sm:mt-3 flex items-start justify-center">
+            <CeroInteresSection ceroInteresData={ceroInteresData} />
+          </div>
+
           {/* Botones de acción - Horizontal */}
           <div className="flex items-center gap-3">
             <button
@@ -1046,11 +1054,6 @@ export default function BundleCard({
             >
               Más información
             </button>
-          </div>
-
-          {/* Sección de cero interés - Debajo de los botones */}
-          <div className="mt-2 sm:mt-3 min-h-[120px] sm:min-h-[130px] flex items-start justify-center">
-            <CeroInteresSection ceroInteresData={ceroInteresData} />
           </div>
         </div>
       </div>

--- a/src/app/productos/components/ProductCard.tsx
+++ b/src/app/productos/components/ProductCard.tsx
@@ -958,7 +958,9 @@ export default function ProductCard({
 
           {/* Contenedor para selectores y botón de entrego y estreno */}
           <div className="px-3 flex gap-2 items-start">
-            {/* Columna izquierda: Selectores */}
+            {/* Columna izquierda: Selectores (altura natural — sin reserva fija,
+                que dejaba hueco enorme en categorías con pocos selectores como
+                TV). Cada card queda compacta; el precio va justo tras selectores. */}
             <div className="flex-1 space-y-2">
               {/* Selector de colores - Mostrar si hay colores válidos (hex + nombre) */}
               {(() => {
@@ -1103,10 +1105,11 @@ export default function ProductCard({
             )}
           </div>
 
-          {/* Precio */}
+          {/* Precio. sm:min-h-[42px] en el slot: precio con línea "Ahorra" mide
+              42px, sin ella 32px — reservar el alto mantiene botones alineados */}
           <div className="px-3 space-y-3 mt-auto">
             {finalCurrentPrice && (
-              <div className="space-y-1 min-h-[32px]">
+              <div className="space-y-1 min-h-[32px] sm:min-h-[42px]">
                 {(() => {
                   const { hasSavings, savings } = calculateSavings(
                     finalCurrentPrice,
@@ -1147,6 +1150,18 @@ export default function ProductCard({
               </div>
             )}
             {/* Botones de acción - Horizontal */}
+            {/* Mensaje de cuotas sin interés — va ANTES de los botones para que
+                la fila de botones siempre quede pegada al fondo y alineada
+                entre cards (simetría del grid) */}
+            {apiProduct?.indcerointeres?.[0] === 1 && (
+              <div className="mt-2 sm:mt-3 flex items-start justify-center">
+                <CeroInteresSection
+                  ceroInteresData={ceroInteresData}
+                  isInChat={isInChat}
+                />
+              </div>
+            )}
+
             <div className="flex items-center gap-3">
               <button
                 onClick={(e) => {
@@ -1191,16 +1206,6 @@ export default function ProductCard({
                 Más información
               </button>
             </div>
-
-            {/* Mensaje de cuotas sin interés */}
-            {apiProduct?.indcerointeres?.[0] === 1 && (
-              <div className="mt-2 sm:mt-3 flex items-start justify-center">
-                <CeroInteresSection
-                  ceroInteresData={ceroInteresData}
-                  isInChat={isInChat}
-                />
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/src/app/productos/viewpremium/[id]/page.tsx
+++ b/src/app/productos/viewpremium/[id]/page.tsx
@@ -429,7 +429,7 @@ export default function ProductViewPage({ params }) {
         {/* Grid principal */}
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-0 items-start relative">
           {/* Columna izquierda: Carrusel - ocupa el ancho */}
-          <div className="lg:col-span-9 lg:sticky lg:top-24 self-start overflow-hidden lg:-mt-8">
+          <div className="lg:col-span-9 lg:sticky lg:top-24 self-start overflow-hidden">
             <ProductCarousel
               ref={carouselRef}
               product={productToUse}

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Cookie, X, ChevronDown } from "lucide-react";
 import { saveLocationPermission } from "@/lib/consent/location";
 
 /**
@@ -155,8 +154,11 @@ function getCookie(name: string): string | null {
 
 export default function CookieBanner() {
   const [show, setShow] = useState(false);
-  const [expanded, setExpanded] = useState(false);
   const [mounted, setMounted] = useState(false);
+  // Vista del modal: principal o preferencias (estilo "Configurar" de Samsung)
+  const [view, setView] = useState<"main" | "config">("main");
+  const [prefAnalytics, setPrefAnalytics] = useState(true);
+  const [prefMarketing, setPrefMarketing] = useState(true);
 
   // Montar componente
   useEffect(() => {
@@ -174,6 +176,12 @@ export default function CookieBanner() {
       setShow(true);
       return;
     }
+
+    // Hidratar los toggles con la elección REAL guardada. Sin esto arrancaban
+    // siempre en ON: un usuario que rechazó, al reabrir "Configurar" y dar
+    // "Guardar preferencias", otorgaba analytics+marketing sin querer.
+    setPrefAnalytics(!!consent.analytics);
+    setPrefMarketing(!!consent.marketing);
 
     // Verificar que la decisión sea explícita (no pending)
     if (consent.decision === "accepted") {
@@ -228,9 +236,15 @@ export default function CookieBanner() {
     setShow(false);
   };
 
-  const handleClose = () => {
-    // Solo ocultar visualmente, NO guardar nada
-    // El banner volverá a aparecer en la próxima navegación/recarga
+  const handleSavePreferences = () => {
+    // Preferencias granulares (el sistema de consentimiento ya distingue
+    // analytics vs marketing). Si apagó ambas, equivale a rechazo explícito.
+    const anyAccepted = prefAnalytics || prefMarketing;
+    saveConsentToAllSources(
+      prefAnalytics,
+      prefMarketing,
+      anyAccepted ? "accepted" : "rejected"
+    );
     setShow(false);
   };
 
@@ -239,140 +253,138 @@ export default function CookieBanner() {
     return null;
   }
 
+  // Modal centrado estilo Samsung oficial: wordmark + "Continuar sin aceptar"
+  // arriba, texto con links de políticas, botones pill Configurar/Aceptar Todo.
+  // Sin backdrop oscuro (como samsung.com): la página sigue visible detrás.
   return (
     <div
-      className="fixed top-0 left-0 right-0 z-[99999] bg-white border-b-2 border-gray-300 shadow-lg"
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        zIndex: 999999,
-      }}
+      className="pointer-events-none fixed inset-x-0 top-0 z-[99999] flex justify-center px-4 pt-6 sm:pt-8"
+      style={{ zIndex: 999999 }}
     >
-      <div className="max-w-7xl mx-auto px-4 py-4">
-        <div className="flex flex-col sm:flex-row items-start gap-4">
-          {/* Icon */}
-          <Cookie className="h-6 w-6 text-black flex-shrink-0" />
+      <div
+        role="dialog"
+        aria-modal="false"
+        aria-label="Preferencias de cookies"
+        className="pointer-events-auto w-full max-w-[460px] rounded-xl bg-white p-6 shadow-[0_8px_40px_rgba(0,0,0,0.25)]"
+      >
+        {/* Encabezado: wordmark + continuar sin aceptar */}
+        <div className="mb-4 flex items-start justify-between gap-4">
+          {/* Wordmark oficial de Samsung (mismo asset que usa el navbar) */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="https://res.cloudinary.com/dnglv0zqg/image/upload/v1760575601/Samsung_black_ec1b9h.svg"
+            alt="Samsung"
+            className="-mt-1.5 h-7 w-auto"
+            style={{ height: "28px", width: "auto" }}
+          />
+          <button
+            onClick={handleReject}
+            className="text-sm font-semibold text-gray-900 underline underline-offset-2 hover:text-gray-600 whitespace-nowrap"
+          >
+            Continuar sin aceptar
+          </button>
+        </div>
 
-          {/* Content */}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-2">
-              <h2 className="text-lg font-bold text-black">
-                Desbloquea ofertas exclusivas para ti
-              </h2>
-              <button
-                onClick={() => setExpanded(!expanded)}
-                className="text-gray-600 hover:text-black transition-colors"
-                aria-label={expanded ? "Contraer" : "Expandir"}
+        {view === "main" ? (
+          <>
+            <p className="mb-5 text-[13px] leading-relaxed text-gray-800">
+              Nuestra web usa cookies, incluidas las cookies opcionales, para
+              ofrecerle la mejor experiencia en nuestro sitio y para mostrarle
+              anuncios relevantes según su uso de nuestro sitio web. Usted puede
+              manejar sus preferencias o aceptar todas las cookies. Para obtener
+              más información, consulte nuestra{" "}
+              <a
+                href="/soporte/politica-cookies"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline underline-offset-2"
               >
-                <ChevronDown
-                  className={`h-5 w-5 transition-transform duration-200 ${
-                    expanded ? "rotate-180" : ""
-                  }`}
-                />
+                Política de privacidad
+              </a>{" "}
+              y{" "}
+              <a
+                href="/soporte/politica-cookies"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline underline-offset-2"
+              >
+                Política de cookies
+              </a>
+              .
+            </p>
+
+            <div className="flex gap-3">
+              <button
+                onClick={() => setView("config")}
+                className="flex-1 rounded-full border-2 border-[#000000] px-5 py-2.5 text-sm font-bold text-[#000000] transition-colors hover:bg-[#000000]/5"
+              >
+                Configurar
+              </button>
+              <button
+                onClick={handleAccept}
+                className="flex-1 rounded-full bg-[#000000] px-5 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#222222]"
+              >
+                Aceptar Todo
               </button>
             </div>
-
-            {!expanded && (
-              <p className="text-sm text-gray-600 leading-relaxed">
-                Recibe promociones personalizadas, descuentos en tiendas cercanas y acceso anticipado a lanzamientos Samsung.
-              </p>
-            )}
-
-            {expanded && (
-              <div className="text-sm space-y-4 mt-3">
-                {/* Beneficios de aceptar */}
-                <div className="border-l-2 border-gray-900 pl-4 py-2">
-                  <p className="font-semibold text-gray-900 mb-3">
-                    Beneficios al aceptar cookies y ubicación:
-                  </p>
-                  <ul className="space-y-2.5">
-                    <li className="text-gray-700">
-                      <strong className="text-gray-900">Ofertas cerca de ti</strong> basadas en tu ubicación actual
-                    </li>
-                    <li className="text-gray-700">
-                      <strong className="text-gray-900">Promociones personalizadas</strong> según tus productos favoritos
-                    </li>
-                    <li className="text-gray-700">
-                      <strong className="text-gray-900">Envío gratis</strong> en productos de tiendas cercanas
-                    </li>
-                    <li className="text-gray-700">
-                      <strong className="text-gray-900">Acceso anticipado</strong> a lanzamientos de nuevos Galaxy
-                    </li>
-                    <li className="text-gray-700">
-                      <strong className="text-gray-900">Experiencia mejorada</strong> con recomendaciones inteligentes
-                    </li>
-                  </ul>
+          </>
+        ) : (
+          <>
+            <div className="mb-4 space-y-3">
+              {/* Esenciales: siempre activas */}
+              <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">Esenciales</p>
+                  <p className="text-xs text-gray-500">Necesarias para que el sitio funcione</p>
                 </div>
-
-                {/* Información legal y técnica */}
-                <div className="border border-gray-200 rounded p-4 space-y-3 bg-gray-50">
-                  <div>
-                    <p className="font-semibold text-gray-900 mb-2 text-xs">
-                      Tecnologías que utilizamos:
-                    </p>
-                    <div className="space-y-1.5 text-xs text-gray-600">
-                      <p>
-                        <strong className="text-gray-900">Análisis:</strong> Microsoft Clarity y Sentry para mejorar la experiencia del sitio y detectar errores.
-                      </p>
-                      <p>
-                        <strong className="text-gray-900">Marketing:</strong> Google Analytics, Meta (Facebook) y TikTok para mostrarte ofertas relevantes y medir el rendimiento de nuestras campañas.
-                      </p>
-                      <p>
-                        <strong className="text-gray-900">Ubicación:</strong> Geolocalización del navegador para ofrecerte productos de tiendas cercanas.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="border-l-2 border-gray-400 pl-3 py-1">
-                    <p className="font-semibold text-gray-900 text-xs mb-1">
-                      Protección de datos
-                    </p>
-                    <p className="text-xs text-gray-600 leading-relaxed">
-                      Cumplimos con la <strong className="text-gray-900">Ley 1581/2012 de Protección de Datos Personales de Colombia</strong>.
-                      Si rechazas cookies, seguiremos recopilando datos anónimos y agregados (sin identificarte)
-                      para mejorar nuestro servicio. Tus datos personales solo se procesan con tu consentimiento expreso
-                      y nunca se venden a terceros.
-                    </p>
-                  </div>
-
-                  <a
-                    href="/soporte/politica-cookies"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-gray-900 hover:text-black underline font-medium text-xs"
-                  >
-                    Ver política de cookies completa →
-                  </a>
-                </div>
+                <span className="text-xs font-semibold text-gray-400">Siempre activas</span>
               </div>
-            )}
-          </div>
 
-          {/* Actions */}
-          <div className="flex items-center gap-3 shrink-0">
-            <button
-              onClick={handleReject}
-              className="text-sm text-gray-700 hover:text-gray-900 font-medium px-4 py-2 rounded-lg transition-colors border border-gray-300 hover:border-gray-400 bg-white"
-            >
-              Rechazar
-            </button>
-            <button
-              onClick={handleAccept}
-              className="text-sm bg-black text-white hover:bg-gray-800 font-semibold rounded-lg px-6 py-2 transition-all shadow-sm hover:shadow-md"
-            >
-              Aceptar
-            </button>
-            <button
-              onClick={handleClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors p-1.5 rounded-lg hover:bg-gray-100 hidden sm:block"
-              aria-label="Cerrar"
-            >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
-        </div>
+              {/* Análisis */}
+              <label className="flex cursor-pointer items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">Análisis</p>
+                  <p className="text-xs text-gray-500">Nos ayudan a mejorar el sitio</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={prefAnalytics}
+                  onChange={(e) => setPrefAnalytics(e.target.checked)}
+                  className="h-5 w-5 accent-[#000000]"
+                />
+              </label>
+
+              {/* Marketing */}
+              <label className="flex cursor-pointer items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">Marketing</p>
+                  <p className="text-xs text-gray-500">Anuncios relevantes (Google, Meta, TikTok)</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={prefMarketing}
+                  onChange={(e) => setPrefMarketing(e.target.checked)}
+                  className="h-5 w-5 accent-[#000000]"
+                />
+              </label>
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                onClick={() => setView("main")}
+                className="flex-1 rounded-full border-2 border-gray-300 px-5 py-2.5 text-sm font-bold text-gray-700 transition-colors hover:bg-gray-50"
+              >
+                Volver
+              </button>
+              <button
+                onClick={handleSavePreferences}
+                className="flex-1 rounded-full bg-[#000000] px-5 py-2.5 text-sm font-bold text-white transition-colors hover:bg-[#222222]"
+              >
+                Guardar preferencias
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/RegistrationAddressFormWithPlaceDetails.tsx
+++ b/src/components/RegistrationAddressFormWithPlaceDetails.tsx
@@ -195,18 +195,6 @@ export const RegistrationAddressFormWithPlaceDetails: React.FC<RegistrationAddre
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Nombre de la dirección
-            </label>
-            <input
-              type="text"
-              value={addressData.shippingName}
-              onChange={(e) => handleFieldChange('shippingName', e.target.value)}
-              placeholder="ej: Mi casa, Oficina, Casa de mamá"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
               Tipo de dirección
             </label>
             <select
@@ -295,18 +283,6 @@ export const RegistrationAddressFormWithPlaceDetails: React.FC<RegistrationAddre
       {!addressData.useSameAddress && (
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Nombre de la dirección
-              </label>
-              <input
-                type="text"
-                value={addressData.billingName}
-                onChange={(e) => handleFieldChange('billingName', e.target.value)}
-                placeholder="ej: Mi casa, Oficina, Casa de mamá"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              />
-            </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
                 Tipo de dirección

--- a/src/components/chatbotButton.tsx
+++ b/src/components/chatbotButton.tsx
@@ -37,9 +37,18 @@ export default function ChatbotButton({
     }
   }, [showTooltip]);
 
+  // Defensa en profundidad: si el gesto empezó en la × del tooltip, el
+  // contenedor NO debe iniciar arrastre/click (que abriría el chat). La ×
+  // ya frena mousedown/touchstart con stopPropagation, pero esta guarda
+  // cubre cualquier caso donde el evento igual llegue aquí.
+  const startedOnCloseButton = (target: EventTarget | null): boolean =>
+    target instanceof Element &&
+    !!target.closest('[aria-label="Cerrar mensaje"]');
+
   // Handlers para arrastre con mouse
   const handleMouseDown = (e: React.MouseEvent) => {
     if (e.button !== 0) return; // Solo click izquierdo
+    if (startedOnCloseButton(e.target)) return; // × del tooltip: no abrir chat
     setIsDragging(true);
     setHasMoved(false); // Resetear el estado de movimiento
     dragStartY.current = e.clientY;
@@ -80,6 +89,7 @@ export default function ChatbotButton({
 
   // Handlers para arrastre táctil
   const handleTouchStart = (e: React.TouchEvent) => {
+    if (startedOnCloseButton(e.target)) return; // × del tooltip: no abrir chat
     setIsDragging(true);
     setHasMoved(false); // Resetear el estado de movimiento
     dragStartY.current = e.touches[0].clientY;
@@ -151,19 +161,25 @@ export default function ChatbotButton({
     >
       {/* Burbuja de mensaje mejorada */}
       {showTooltip && (
-        <div className="relative bg-white shadow-xl rounded-2xl px-4 py-3 max-w-[180px] mb-1 animate-fade-in border border-gray-100">
+        <div className="relative bg-white shadow-xl rounded-2xl px-4 py-3 max-w-[180px] mb-1 animate-chatbot-slide-in border border-gray-100">
           <p className="text-sm text-gray-800 font-medium leading-tight">
             ¿Dudas? Estoy aquí para ayudarte 👋
           </p>
           {/* Triángulo apuntando al botón */}
           <div className="absolute -right-2 bottom-4 w-0 h-0 border-t-[8px] border-t-transparent border-l-[8px] border-l-white border-b-[8px] border-b-transparent"></div>
-          {/* Botón de cerrar tooltip mejorado */}
+          {/* Botón de cerrar tooltip. IMPORTANTE: frenar mousedown/touchstart
+              además del click. El contenedor externo usa onMouseDown/onTouchStart
+              para arrastrar/abrir el chat; sin stopPropagation en esos eventos,
+              tocar la × burbujea al contenedor y abre el chat (bug en mobile y
+              desktop). El stopPropagation del onClick por sí solo no basta. */}
           <button
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
               setShowTooltip(false);
             }}
-            className="absolute -top-2 -right-2 w-5 h-5 bg-gray-700 hover:bg-gray-800 rounded-full flex items-center justify-center text-xs text-white shadow-md transition-colors"
+            className="absolute -top-2 -right-2 w-5 h-5 bg-gray-700 hover:bg-gray-800 rounded-full flex items-center justify-center text-xs text-white shadow-md transition-colors before:absolute before:-inset-2.5 before:content-['']"
             aria-label="Cerrar mensaje"
           >
             ×

--- a/src/components/navbar/AddressDropdown.tsx
+++ b/src/components/navbar/AddressDropdown.tsx
@@ -181,6 +181,19 @@ const AddressDropdown: React.FC<AddressDropdownProps> = React.memo(({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [invalidate, refetch, user?.id]);
 
+  // Al cerrar sesión: limpiar TODO el estado local de direcciones. Si no, la
+  // navbar sigue mostrando la dirección de la cuenta anterior (el estado
+  // `addresses` es el último fallback de displayAddress y no se limpia solo).
+  useEffect(() => {
+    const handleLogout = () => {
+      setAddresses([]);
+      setGuestAddress(null);
+      setOpen(false);
+    };
+    window.addEventListener('user-logout', handleLogout);
+    return () => window.removeEventListener('user-logout', handleLogout);
+  }, []);
+
   const handleToggle = () => {
     if (!open && addresses.length === 0 && !isFetchingRef.current) {
       fetchAddresses();

--- a/src/constants/chatbotRoutes.ts
+++ b/src/constants/chatbotRoutes.ts
@@ -13,6 +13,8 @@ export const CHATBOT_HIDDEN_ROUTES = [
   "/error-checkout",    // Match exacto
   "/success-checkout/", // Match prefijo: /success-checkout/[orderId]
   "/charging-result",   // Match exacto
+  "/verify-purchase/",         // Match prefijo: /verify-purchase/[id]
+  "/support/verify-purchase/", // Match prefijo: /support/verify-purchase/[id]
 ] as const;
 
 /** Rutas donde el chatbot debe MOSTRARSE (prioridad sobre hidden) */

--- a/src/features/auth/context.tsx
+++ b/src/features/auth/context.tsx
@@ -28,6 +28,8 @@ interface AuthContextType {
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (userData: User) => Promise<void>;
+  /** Actualiza campos del usuario en sesión sin re-loguear (p.ej. tras editar el perfil): refresca el estado, persiste imagiq_user y notifica al navbar. */
+  updateUser: (partial: Partial<User>) => void;
   logout: () => void;
   hasRole: (role: number | number[]) => boolean;
   isAdmin: () => boolean;
@@ -238,6 +240,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  // Actualiza campos del usuario en sesión SIN re-loguear (no limpia datos
+  // previos como login()). Úsalo tras editar el perfil: refresca el estado
+  // (navbar reactivo), persiste imagiq_user y notifica a los listeners.
+  const updateUser = (partial: Partial<User>) => {
+    if (!user) return;
+    const merged = { ...user, ...partial };
+    // El updater de setUser DEBE ser puro; los side-effects (persistencia +
+    // evento) van fuera para no ejecutarse dos veces en StrictMode/render
+    // concurrente de React 19.
+    setUser(merged);
+    try {
+      localStorage.setItem("imagiq_user", JSON.stringify(merged));
+    } catch { /* best-effort */ }
+    if (typeof window !== "undefined") {
+      const role = merged.role ?? (merged as User & { rol?: number }).rol;
+      window.dispatchEvent(
+        new CustomEvent("user-changed", {
+          detail: { userId: merged.id, role, email: merged.email },
+        })
+      );
+    }
+  };
+
   // Logout function
   const logout = () => {
     console.log('🚪 [AuthContext] Cerrando sesión...');
@@ -330,6 +355,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isAuthenticated: !!user && isTokenValidBool,
     isLoading,
     login,
+    updateUser,
     logout,
     hasRole,
     isAdmin,

--- a/src/features/profile/components/ProfilePage.tsx
+++ b/src/features/profile/components/ProfilePage.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState } from "react";
+import { toast } from "sonner";
 import { PUBLIC_ROUTES } from "@/constants/routes";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
@@ -61,7 +62,7 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ className }) => {
   const handleBackToMain = () => setCurrentView("main");
 
   const handleSaveProfile = async (data: EditProfileData) => {
-    const success = await actions.updateProfile({
+    const res = await actions.updateProfile({
       nombre: data.nombre,
       apellido: data.apellido,
       email: data.email,
@@ -70,8 +71,16 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ className }) => {
       numero_documento: data.numero_documento,
     });
 
-    if (success) {
+    if (res.ok) {
+      toast.success("Perfil actualizado correctamente");
       setIsEditProfileModalOpen(false);
+    } else {
+      // Usar el mensaje REAL devuelto por updateProfile (no state.error, que es
+      // asíncrono y llega tarde). Fallback con la pista de validación del backend.
+      toast.error(
+        res.error ||
+          "No se pudo actualizar el perfil. Verifica que el teléfono tenga 10 dígitos y el documento entre 6 y 10."
+      );
     }
   };
 

--- a/src/features/profile/components/addresses/EditAddressModal.tsx
+++ b/src/features/profile/components/addresses/EditAddressModal.tsx
@@ -18,7 +18,9 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
   onSave,
   onClose,
 }) => {
-  const [nombreDireccion, setNombreDireccion] = useState(address.nombreDireccion || "");
+  // Campo "Nombre de la dirección" eliminado del formulario: se conserva el
+  // valor existente de la dirección (no editable) para no perder el dato.
+  const [nombreDireccion] = useState(address.nombreDireccion || "");
   const [complemento, setComplemento] = useState(address.complemento || "");
   const [instrucciones, setInstrucciones] = useState(address.instruccionesEntrega || "");
   const [tipo, setTipo] = useState(address.tipo?.toUpperCase() || "CASA");
@@ -77,20 +79,6 @@ const EditAddressModal: React.FC<EditAddressModalProps> = ({
 
         {/* Form */}
         <form onSubmit={handleSubmit} className="px-6 pb-6 pt-2 space-y-4">
-          {/* Nombre */}
-          <div>
-            <label className="block text-sm font-semibold text-gray-700 mb-1">
-              Nombre de la dirección
-            </label>
-            <input
-              type="text"
-              value={nombreDireccion}
-              onChange={(e) => setNombreDireccion(e.target.value)}
-              placeholder="Ej: Casa, Oficina, Casa mamá..."
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent text-sm"
-            />
-          </div>
-
           {/* Tipo */}
           <div>
             <label className="block text-sm font-semibold text-gray-700 mb-1">

--- a/src/features/profile/hooks/useProfile.ts
+++ b/src/features/profile/hooks/useProfile.ts
@@ -25,7 +25,7 @@ interface UseProfileReturn {
   actions: {
     loadProfile: () => Promise<void>;
     refreshData: () => Promise<void>;
-    updateProfile: (data: UpdateProfileRequest) => Promise<boolean>;
+    updateProfile: (data: UpdateProfileRequest) => Promise<{ ok: boolean; error?: string }>;
     logout: () => Promise<void>;
   };
   isLoading: boolean;
@@ -164,10 +164,10 @@ export const useProfile = (): UseProfileReturn => {
 
   // Actualizar perfil
   const updateProfile = useCallback(
-    async (data: UpdateProfileRequest): Promise<boolean> => {
+    async (data: UpdateProfileRequest): Promise<{ ok: boolean; error?: string }> => {
       if (!authContext.user?.id) {
         setError("Usuario no autenticado");
-        return false;
+        return { ok: false, error: "Usuario no autenticado" };
       }
 
       setLoading(true);
@@ -176,16 +176,28 @@ export const useProfile = (): UseProfileReturn => {
       try {
         await profileService.updateProfile(authContext.user.id, data);
 
+        // Sincronizar la sesión global (navbar, contexto) con los datos nuevos,
+        // si no, el nombre/correo de arriba quedaba viejo hasta recargar.
+        authContext.updateUser({
+          nombre: data.nombre,
+          apellido: data.apellido,
+          email: data.email,
+          telefono: data.telefono,
+          numero_documento: data.numero_documento,
+        });
+
         // Recargar el perfil para obtener los datos actualizados
         await loadProfile();
 
-        return true;
+        return { ok: true };
       } catch (err) {
         console.error("Error actualizando perfil:", err);
         const errorMessage =
           err instanceof Error ? err.message : "Error al actualizar perfil";
         setError(errorMessage);
-        return false;
+        // Devolver el error para que el caller muestre el mensaje REAL (state.error
+        // es asíncrono y llega tarde en el mismo tick).
+        return { ok: false, error: errorMessage };
       } finally {
         setLoading(false);
       }

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -772,7 +772,14 @@ export function useCart(): UseCartReturn {
           if (newProducts.length === 0) {
             localStorage.removeItem(STORAGE_KEYS.CART_ITEMS);
           } else {
-            apiDelete(`/api/cart/items/${productId}`);
+            // fire-and-forget, pero registrar el fallo para no desincronizar en silencio
+            apiDelete(`/api/cart/items/${encodeURIComponent(productId)}`).catch(
+              (err) =>
+                console.error(
+                  "[useCart] Falló DELETE de item en backend (carrito local ya actualizado):",
+                  err
+                )
+            );
             localStorage.setItem(
               STORAGE_KEYS.CART_ITEMS,
               JSON.stringify(newProducts)

--- a/src/hooks/useDefaultAddress.ts
+++ b/src/hooks/useDefaultAddress.ts
@@ -115,16 +115,30 @@ export function useDefaultAddress(tipo: TipoUsoDireccion = 'ENVIO'): UseDefaultA
       invalidate();
     };
 
+    // Al cerrar sesión: el cache es GLOBAL (compartido entre usuarios), así que
+    // hay que limpiarlo y borrar la dirección mostrada; si no, la navbar sigue
+    // mostrando la dirección de la cuenta anterior (fuga de datos).
+    const handleLogout = () => {
+      cache.clear();
+      ongoingRequests.clear();
+      if (isMountedRef.current) {
+        setAddress(null);
+        setIsLoading(false);
+      }
+    };
+
     if (typeof window !== 'undefined') {
       window.addEventListener('address-changed', handleAddressChange);
       window.addEventListener('checkout-address-changed', handleAddressChange);
       // Evento genérico que también podría dispararse
       window.addEventListener('address-updated', handleAddressChange);
+      window.addEventListener('user-logout', handleLogout);
 
       return () => {
         window.removeEventListener('address-changed', handleAddressChange);
         window.removeEventListener('checkout-address-changed', handleAddressChange);
         window.removeEventListener('address-updated', handleAddressChange);
+        window.removeEventListener('user-logout', handleLogout);
       };
     }
   }, [invalidate]);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -291,9 +291,16 @@ export const productEndpoints = {
     return (params: ProductFilterParams, init?: RequestInit) => {
       const normalizedKey = normalizeParams(params);
 
+      // Ruteo opcional por un proxy cacheado (ej: /api/pcache/ofertas). El flag
+      // NO se manda al backend (se excluye de los query params); si el proxy
+      // falla, se cae al endpoint directo.
+      const cacheProxyPath =
+        (params as ProductFilterParams & { cacheProxyPath?: string }).cacheProxyPath;
+
       // Construir URL completa para la petición real (con todos los parámetros)
       const searchParams = new URLSearchParams();
       Object.entries(params).forEach(([key, value]) => {
+        if (key === "cacheProxyPath") return; // flag interno, no va al backend
         if (value !== undefined && value !== null && value !== "") {
           // Detectar si el key tiene sintaxis extendida (column_operator o column_range_min/max)
           // Patrón: column_operator o column_range_min/max
@@ -317,14 +324,31 @@ export const productEndpoints = {
           }
         }
       });
-      const url = `/api/products/v2/filtered?${searchParams.toString()}`;
+      const qs = searchParams.toString();
+      const directUrl = `/api/products/v2/filtered?${qs}`;
+      const url = cacheProxyPath ? `${cacheProxyPath}?${qs}` : directUrl;
 
       // Usar clave normalizada para deduplicación
       if (inFlightByKey[normalizedKey]) {
         return inFlightByKey[normalizedKey] as Promise<ApiResponse<ProductApiResponse>>;
       }
 
-      const p = apiClient.get<ProductApiResponse>(url, init).finally(() => {
+      const doFetch = async (): Promise<ApiResponse<ProductApiResponse>> => {
+        const res = await apiClient.get<ProductApiResponse>(url, init);
+        // Fallback: si el proxy cacheado falló, reintentar contra el endpoint
+        // directo. PERO no si el fallo fue un abort (típico al cambiar de
+        // filtro/orden rápido): reintentar con el mismo signal ya abortado es
+        // trabajo inútil que vuelve a fallar de inmediato.
+        const aborted =
+          res.message === "Request aborted" ||
+          (init?.signal as AbortSignal | undefined)?.aborted;
+        if (cacheProxyPath && !res.success && !aborted) {
+          return apiClient.get<ProductApiResponse>(directUrl, init);
+        }
+        return res;
+      };
+
+      const p = doFetch().finally(() => {
         // liberar inmediatamente al resolver/rechazar para no cachear respuestas
         delete inFlightByKey[normalizedKey];
       });

--- a/src/lib/sentry/client.ts
+++ b/src/lib/sentry/client.ts
@@ -81,6 +81,27 @@ export async function initSentry(): Promise<void> {
       tracesSampleRate: config.tracesSampleRate ?? 0.1,
       replaysSessionSampleRate: config.replaysSessionSampleRate ?? 0.1,
       replaysOnErrorSampleRate: config.replaysOnErrorSampleRate ?? 1,
+      // Filtrar ruido de terceros: Flixmedia genera la mayoría de errores en
+      // /productos/* — scripts async no cancelables que corren tras la navegación
+      // SPA, bugs dentro de su bundle minificado (opts/opts2), y puentes nativos
+      // de WebView (Android "Java object is gone" / iOS webkit.messageHandlers).
+      // No son fallos de la app y contaminan Sentry, así que se descartan aquí.
+      ignoreErrors: [
+        '_loadInpageCallback',
+        'flixCartClick',
+        'flixJsCallbacks',
+        'opts is not defined',
+        'opts2 is not defined',
+        'Java object is gone',
+        'webkit.messageHandlers',
+        'AbortError',
+      ],
+      denyUrls: [
+        /flixfacts\.com/,
+        /flixcar\.com/,
+        /flixsyndication/,
+        /modular\/js\/minify/,
+      ],
       integrations: [
         Sentry.browserTracingIntegration(),
         Sentry.replayIntegration({


### PR DESCRIPTION
## Resumen
PR con todos los cambios acumulados en la rama (checkout + varios ajustes de UX).

### 🔐 Login del invitado en checkout
- `CheckoutLoginModal`: cuando el correo del invitado ya tiene cuenta (rol 2), abre login por **clave** o **código OTP** (correo/WhatsApp). Logo Samsung, ícono Gmail multicolor + WhatsApp, ojito de contraseña, **código OTP en 6 casillas** con auto-verificación al completar, **guard de 5 intentos → bloqueo 20 min**, y hint del teléfono **enmascarado**. Botones azul→negro.
- **Invitado sin fricción:** se quita el modal "Registra tu cuenta" en step7 (ya no se le insiste crear cuenta; procesa como invitado).

### 🧭 Indicador de pasos + botones del checkout
- `CheckoutShell` + `CheckoutStepIndicator`: progreso Tus datos → Entrega → Pago → Confirmar desde step2.
- Botón **"Continuar" en el panel derecho** (junto a "Volver") con **un solo clic**: `skipPickupCheck` en `Step4OrderSummary` + fix de `handleNext` (lee `checkout-address` de localStorage para no bloquear el avance por el contexto no actualizado).

### 📍 Direcciones
- Se quita el campo **"Nombre de la dirección"** de los formularios (checkout, editar perfil, registro); se autogenera desde la calle.
- La navbar **limpia la dirección al cerrar sesión** (`useDefaultAddress` + `AddressDropdown` escuchan `user-logout`) — antes filtraba la de la cuenta anterior.

### 🎨 Otros ajustes de UX
- `CookieBanner`: más arriba, sin texto de Clarity/Sentry, botones a negro.
- Chatbot: fix del botón **×** que abría el chat + animación de slide; **oculto en verify-purchase**.
- Perfil: feedback de éxito/error al editar.
- Ajustes varios: ofertas/product cards, viewpremium, useCart, api, sentry, pcache de ofertas.

## No se tocó
Addi, PSE ni 3D Secure — sin cambios en pagos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)