### PR TITLE
fix(ui): quitar el asterisco rojo de 'Aplican T&C' en las tarjetas de producto

### DIFF
--- a/src/components/CeroInteresSection.tsx
+++ b/src/components/CeroInteresSection.tsx
@@ -45,7 +45,7 @@ export default function CeroInteresSection({
               : 'text-[6px] sm:text-[7px] md:text-[8px] lg:text-[9px]' // Tamaño normal
           )}
         >
-          Aplican T&C <span className="text-red-600">*</span>
+          Aplican T&C
         </span>
       </p>
       


### PR DESCRIPTION
## Cambio
Se quita el asterisco rojo (`*`) que aparecía junto a **"Aplican T&C"** en la sección de "Compra con 0% de interés con bancos aliados" de las tarjetas de producto (ProductCard/BundleCard), en `CeroInteresSection.tsx`.

Solo se elimina el `<span className="text-red-600">*</span>`; el texto "Aplican T&C" se mantiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)