### PR TITLE
chore: subir APP_VERSION a 1.0.9 (limpia el caché de los clientes)

### DIFF
--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -7,4 +7,4 @@
  *
  * Formato recomendado: "MAJOR.MINOR.PATCH" (ej: "1.0.0", "1.0.1", "2.0.0")
  */
-export const APP_VERSION = "1.0.8";
+export const APP_VERSION = "1.0.9";


### PR DESCRIPTION
## Cambio
Se sube `APP_VERSION` de **1.0.8 → 1.0.9** en `src/config/version.ts`.

Al desplegarse, `versionManager.checkAndUpdateVersion()` detecta el cambio de versión y **limpia el localStorage** de cada cliente (excepto la clave `app_version`), forzando que la app recargue datos frescos y no arrastre caché viejo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)