### PR TITLE
fix(viewpremium): swap premium → carrusel por color con un poco de scroll

### DIFF
--- a/src/app/productos/viewpremium/components/ProductCarousel.tsx
+++ b/src/app/productos/viewpremium/components/ProductCarousel.tsx
@@ -363,6 +363,30 @@ const ProductCarousel = forwardRef<HTMLDivElement, ProductCarouselProps>(({
                   </div>
                 );
               })()}
+
+              {/* Flechas de navegación por color (desktop), verticalmente centradas */}
+              {productImages.length > 1 && (
+                <>
+                  <button
+                    onClick={() => setCurrentImageIndex((prev) => (prev === 0 ? productImages.length - 1 : prev - 1))}
+                    aria-label="Imagen anterior"
+                    className="hidden md:flex absolute left-4 top-1/2 -translate-y-1/2 w-12 h-12 rounded-full bg-white/95 hover:bg-white shadow-lg items-center justify-center transition-all hover:scale-105 z-10"
+                  >
+                    <svg className="w-6 h-6 text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => setCurrentImageIndex((prev) => (prev + 1) % productImages.length)}
+                    aria-label="Imagen siguiente"
+                    className="hidden md:flex absolute right-4 top-1/2 -translate-y-1/2 w-12 h-12 rounded-full bg-white/95 hover:bg-white shadow-lg items-center justify-center transition-all hover:scale-105 z-10"
+                  >
+                    <svg className="w-6 h-6 text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                </>
+              )}
             </div>
             {/* Botón Ver más - estilo Samsung */}
             <div className="flex justify-center -mt-2 md:mt-1">

--- a/src/app/productos/viewpremium/components/ProductCarousel.tsx
+++ b/src/app/productos/viewpremium/components/ProductCarousel.tsx
@@ -336,8 +336,8 @@ const ProductCarousel = forwardRef<HTMLDivElement, ProductCarouselProps>(({
             <div 
               className="relative w-full max-w-4xl mx-auto flex items-center justify-center overflow-hidden zoom-safe-secondary-media px-4 sm:px-8"
               style={{
-                height: "min(70vh, 680px)",
-                minHeight: "320px",
+                height: "min(64vh, 600px)",
+                minHeight: "300px",
               }}
               onTouchStart={handleTouchStart}
               onTouchMove={handleTouchMove}
@@ -389,7 +389,7 @@ const ProductCarousel = forwardRef<HTMLDivElement, ProductCarouselProps>(({
               )}
             </div>
             {/* Botón Ver más - estilo Samsung */}
-            <div className="flex justify-center -mt-2 md:mt-1">
+            <div className="flex justify-center mt-2 md:mt-3 mb-6">
               <button
                 onClick={onOpenModal}
                 className="px-6 py-2.5 bg-white text-black border-2 border-black rounded-full text-sm font-medium hover:bg-black hover:text-white transition-all hover:scale-105"

--- a/src/app/productos/viewpremium/hooks/useProductLogic.ts
+++ b/src/app/productos/viewpremium/hooks/useProductLogic.ts
@@ -179,32 +179,30 @@ export const useProductLogic = (product: ProductCardProps | null) => {
   const productImages = getProductImages();
   const detailImages = getDetailImages();
 
-  // Swap entre carrusel premium (sticky) y carrusel de producto (por color).
-  // Antes se usaba un umbral fijo de 19% del scroll total, lo que era frágil:
-  // en páginas largas caía en medio del bloque de specs; en páginas cortas
-  // disparaba demasiado pronto. Ahora observamos si el bloque ProductInfo
-  // (specsRef) entra en viewport — más robusto y alineado con lo que el
-  // usuario realmente ve.
+  // Swap entre carrusel premium (arriba) y carrusel de producto por color:
+  // arriba del todo se ve el premium; al bajar un poco el scroll (un tris) se
+  // oculta el premium y aparece el carrusel normal por color. Umbral relativo
+  // al alto del viewport (robusto en cualquier pantalla/página), con histéresis
+  // para no titilar en el borde. Sustituye al IntersectionObserver de specs,
+  // que disparaba el swap demasiado abajo.
   React.useEffect(() => {
-    const target = specsRef.current;
-    if (!target) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        // Mientras ProductInfo esté visible, mostrar el carrusel de producto
-        // (showStickyCarousel = false). Cuando no esté visible (usuario está
-        // arriba, en la zona premium), volver al premium (= true).
-        setShowStickyCarousel(!entry.isIntersecting);
-      },
-      {
-        // rootMargin negativo en top: dispara ANTES de que specs toque el
-        // borde superior, para que el swap ocurra con algo de anticipación.
-        rootMargin: '-20% 0px -30% 0px',
-        threshold: 0,
-      },
-    );
-    observer.observe(target);
-    return () => observer.disconnect();
+    let raf = 0;
+    const evaluate = () => {
+      raf = 0;
+      const vh = window.innerHeight || 800;
+      const y = window.scrollY;
+      if (y > vh * 0.45) setShowStickyCarousel(false); // bajó un tris → normal
+      else if (y < vh * 0.3) setShowStickyCarousel(true); // volvió arriba → premium
+    };
+    const onScroll = () => {
+      if (!raf) raf = window.requestAnimationFrame(evaluate);
+    };
+    evaluate(); // estado inicial según la posición actual
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (raf) window.cancelAnimationFrame(raf);
+    };
   }, []);
 
   // Resetear índice de imagen cuando cambie el color seleccionado


### PR DESCRIPTION
## Problema
En **viewpremium**, al bajar un poco el scroll debería ocultarse el carrusel **premium** y aparecer el carrusel **normal del producto (imágenes por color)** — como estaba antes. Pero el swap dependía de que la sección de specs (`ProductInfo`, `specsRef`) entrara al viewport, lo que lo disparaba demasiado abajo; en la práctica el premium se quedaba.

## Fix
`useProductLogic.ts`: se reemplaza el `IntersectionObserver` sobre `specsRef` por un **umbral de scroll relativo al alto del viewport**:
- Cerca del tope → carrusel **premium**.
- Al bajar ~un tris (>45% del viewport) → carrusel **por color**; al volver arriba (<30%) → premium.
- Con `requestAnimationFrame` (sin thrash) e **histéresis** para que no titile en el borde.

Robusto en pantallas/páginas de cualquier tamaño (el 19%-de-scroll-total anterior era frágil). **Solo afecta viewpremium.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)