### PR TITLE
fix(viewpremium): redirigir a vista normal si producto premium no tiene contenido premium

### DIFF
--- a/src/app/productos/viewpremium/[id]/page.tsx
+++ b/src/app/productos/viewpremium/[id]/page.tsx
@@ -360,12 +360,40 @@ export default function ProductViewPage({ params }) {
     (seg) => seg?.toUpperCase() === "PREMIUM"
   );
 
-  // Nota: antes redirigíamos a /productos/view cuando el producto no tenía
-  // imagenPremium/videoPremium, pero eso causaba que productos PREMIUM sin
-  // assets premium no mostraran imágenes. Ahora el ProductCarousel cae a las
-  // imágenes del color seleccionado si premiumImages está vacío, así que el
-  // único gate que queda es el segmento PREMIUM del producto.
-  if (!isPremiumProduct) {
+  // Validar que el producto tenga contenido premium (imágenes o videos premium).
+  // IMPORTANTE: usamos EXACTAMENTE la misma definición que view/[id]
+  // (hasPremiumContent), porque view/[id] redirige HACIA aquí cuando
+  // (hasPremiumContent && segmento PREMIUM). Al hacer que este gate sea la
+  // negación exacta de esa condición, las dos vistas nunca pueden rebotar en un
+  // loop infinito de redirección. imagenPremium/videoPremium vienen como
+  // string[][] (array de arrays) a nivel apiProduct y string[] a nivel color.
+  const checkArrayOfArrays = (arr?: string[][]): boolean => {
+    if (!arr || !Array.isArray(arr)) return false;
+    return arr.some((innerArray: string[]) => {
+      if (!Array.isArray(innerArray) || innerArray.length === 0) return false;
+      return innerArray.some(item => item && typeof item === 'string' && item.trim() !== '');
+    });
+  };
+
+  const hasPremiumContent =
+    checkArrayOfArrays(productToUse.apiProduct?.imagenPremium) ||
+    checkArrayOfArrays(productToUse.apiProduct?.videoPremium) ||
+    checkArrayOfArrays(productToUse.apiProduct?.imagen_premium) ||
+    checkArrayOfArrays(productToUse.apiProduct?.video_premium) ||
+    (productToUse.colors?.some(color => {
+      const hasColorImages = color.imagen_premium && Array.isArray(color.imagen_premium) &&
+        color.imagen_premium.length > 0 &&
+        color.imagen_premium.some((img: string) => img && typeof img === 'string' && img.trim() !== '');
+      const hasColorVideos = color.video_premium && Array.isArray(color.video_premium) &&
+        color.video_premium.length > 0 &&
+        color.video_premium.some((vid: string) => vid && typeof vid === 'string' && vid.trim() !== '');
+      return hasColorImages || hasColorVideos;
+    }) || false);
+
+  // Si NO es PREMIUM por segmento, o SÍ es premium pero NO tiene ni imagen ni
+  // video premium, redirigir a la vista normal /productos/view/[id] (que ya
+  // renderiza las imágenes estándar del producto de forma independiente).
+  if (!isPremiumProduct || !hasPremiumContent) {
     router.replace(`/productos/view/${id}`);
     return <ViewPremiumSkeleton />;
   }


### PR DESCRIPTION
## Qué

Un producto con **segmento PREMIUM** pero **sin imagen ni video premium** ahora redirige a `/productos/view/[id]` (la vista normal) en lugar de quedarse en la página premium mostrando solo las imágenes por color.

## Por qué

La página premium solo aporta valor cuando hay contenido premium (carrusel de `imagen_premium`/`video_premium`). Si no lo hay, el carrusel premium ya caía a las imágenes normales por color — así que la vista premium ≈ vista normal, pero en la página equivocada. Con este cambio, esos productos van directo a la vista que les corresponde.

## Seguridad contra loop de redirección ⚠️

`view/[id]` **redirige de vuelta** a `viewpremium` cuando `hasPremiumContent(apiProduct) && isPremiumSegment(apiProduct)`.

Para que **no haya loop infinito**, este gate usa la **misma definición `hasPremiumContent`** (chequea `imagenPremium`/`videoPremium` y sus alias, tanto a nivel `apiProduct` como a nivel color). Así la condición de redirección de `viewpremium` (`!isPremiumProduct || !hasPremiumContent`) es la **negación lógica exacta** de la de `view/[id]` (`hasPremiumContent && segmento PREMIUM`) — y dos condiciones mutuamente excluyentes nunca pueden rebotar.

Se verificó con los 4 estados posibles (P×H): en ninguno hay ida-y-vuelta.

## Nota

- **quioscos ya tenía esta misma lógica** — esto lleva `imagiq-frontend` a paridad. No requiere cambios en quioscos.
- La vista normal `view/[id]` renderiza las imágenes estándar del producto de forma independiente, así que tras el redirect el usuario **sí ve imágenes** (verificado).
- Reemplaza el comentario anterior que decía que este redirect se había quitado; el motivo de aquel bug (no mostraba imágenes) ya no aplica porque la vista normal renderiza imágenes por su cuenta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)