### PR TITLE
fix(chatbot): envía el token para que el asistente pueda consultar el pedido

### DIFF
--- a/src/services/chatbot.service.ts
+++ b/src/services/chatbot.service.ts
@@ -57,11 +57,21 @@ export async function sendMessageToAgent(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 120000); // 120 segundos = 2 minutos
 
+    // Token del usuario, si tiene sesión iniciada. Sin esto el asistente no
+    // puede consultar SU pedido: el backend deriva la identidad del JWT y trata
+    // como anónimo a quien no lo manda (nunca del user_id del cuerpo, que era
+    // falsificable y permitía leer pedidos ajenos).
+    const authToken =
+      typeof window !== "undefined"
+        ? localStorage.getItem("imagiq_token")
+        : null;
+
     const response = await fetch(`${API_BASE_URL}/api/agent`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...(API_KEY && { "X-API-Key": API_KEY }),
+        ...(authToken && { Authorization: `Bearer ${authToken}` }),
       },
       body: JSON.stringify(body),
       signal: controller.signal,
@@ -70,7 +80,16 @@ export async function sendMessageToAgent(
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      throw new Error(`Error ${response.status}: ${response.statusText}`);
+      // El backend acompaña sus rechazos (429, 400, 503) con un `answer` ya
+      // redactado en español. Mostrarlo es más útil que un código de estado.
+      const errorBody = (await response.json().catch(() => null)) as
+        | { answer?: string; message?: string }
+        | null;
+      throw new Error(
+        errorBody?.answer ||
+          errorBody?.message ||
+          `Error ${response.status}: ${response.statusText}`
+      );
     }
 
     const data: ChatbotResponse = await response.json();


### PR DESCRIPTION
Acompaña a [backend#651](https://github.com/Davases22/imagiq-backend/pull/651), que cierra una fuga de datos en el asistente.

## Qué pasaba

El widget de chat llamaba a `/api/agent` con `fetch` crudo y **sólo** la API key, sin la cabecera `Authorization` que `apiClient` sí envía en el resto de la aplicación.

Eso importa ahora: el backend dejó de aceptar el `user_id` del cuerpo — era un campo libre, así que cualquiera podía escribir el UUID de otra persona y leer sus pedidos — y ahora deriva la identidad del JWT. Sin el token, **un cliente con sesión iniciada seguía siendo anónimo para el asistente** y "¿cómo va mi pedido?" respondía siempre "necesito que inicies sesión".

## Qué cambia

1. Se envía `Authorization: Bearer <token>` desde `localStorage.imagiq_token`, igual que hace `apiClient`. Con esto la consulta de pedidos funciona por primera vez para clientes autenticados (y sólo sobre **sus** pedidos).
2. Los rechazos del backend (429 por límite de uso, 400 por consulta muy larga, 503 por indisponibilidad) ahora traen un `answer` ya redactado en español. Se muestra ese mensaje en vez de `Error 429: Too Many Requests`.

## Verificación

`next build` limpio. Sin errores de tipos nuevos en `chatbot.service.ts`.

Sin este PR el asistente sigue funcionando para todo lo demás (productos, tiendas, FAQ); lo único que queda inaccesible es la consulta del propio pedido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)