### PR TITLE
release: promoción develop → main (asistente conversacional)

### DIFF
--- a/src/services/chatbot.service.ts
+++ b/src/services/chatbot.service.ts
@@ -57,11 +57,21 @@ export async function sendMessageToAgent(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 120000); // 120 segundos = 2 minutos
 
+    // Token del usuario, si tiene sesión iniciada. Sin esto el asistente no
+    // puede consultar SU pedido: el backend deriva la identidad del JWT y trata
+    // como anónimo a quien no lo manda (nunca del user_id del cuerpo, que era
+    // falsificable y permitía leer pedidos ajenos).
+    const authToken =
+      typeof window !== "undefined"
+        ? localStorage.getItem("imagiq_token")
+        : null;
+
     const response = await fetch(`${API_BASE_URL}/api/agent`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         ...(API_KEY && { "X-API-Key": API_KEY }),
+        ...(authToken && { Authorization: `Bearer ${authToken}` }),
       },
       body: JSON.stringify(body),
       signal: controller.signal,
@@ -70,7 +80,16 @@ export async function sendMessageToAgent(
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      throw new Error(`Error ${response.status}: ${response.statusText}`);
+      // El backend acompaña sus rechazos (429, 400, 503) con un `answer` ya
+      // redactado en español. Mostrarlo es más útil que un código de estado.
+      const errorBody = (await response.json().catch(() => null)) as
+        | { answer?: string; message?: string }
+        | null;
+      throw new Error(
+        errorBody?.answer ||
+          errorBody?.message ||
+          `Error ${response.status}: ${response.statusText}`
+      );
     }
 
     const data: ChatbotResponse = await response.json();


### PR DESCRIPTION
Promoción de `develop` a producción. Solo trae [#1068](https://github.com/Davases22/imagiq-frontend/pull/1068): 2 commits, 1 archivo (`src/services/chatbot.service.ts`).

## Qué habilita

El backend ([#651](https://github.com/Davases22/imagiq-backend/pull/651), ya en producción) dejó de aceptar el `user_id` del cuerpo de la petición — era un campo libre, así que cualquiera podía escribir el UUID de otra persona y leer sus pedidos — y ahora deriva la identidad del JWT verificado.

El widget de chat llamaba a `/api/agent` con `fetch` crudo y **sólo** la API key, sin la cabecera `Authorization` que `apiClient` sí envía en el resto de la app. Resultado: un cliente con sesión iniciada seguía siendo anónimo para el asistente y "¿cómo va mi pedido?" respondía siempre "necesito que inicies sesión".

Con esto, la consulta de pedidos funciona por primera vez para clientes autenticados — y sólo sobre **sus** pedidos.

Además, los rechazos del backend (429 por límite de uso, 400 por consulta muy larga, 503) traen un `answer` ya redactado en español; se muestra ese mensaje en vez de `Error 429: Too Many Requests`.

## Riesgo

Bajo. El cambio añade una cabecera cuando hay token y mejora un mensaje de error. Sin él, el asistente ya funciona en producción para todo lo demás (productos, tiendas, preguntas frecuentes); lo único inaccesible es la consulta del propio pedido.

`next build` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)