### PR TITLE
feat(submenus): iconos de submenú recortados al producto + fixes del carrusel

### DIFF
--- a/src/app/productos/[categoria]/components/SeriesSlider.tsx
+++ b/src/app/productos/[categoria]/components/SeriesSlider.tsx
@@ -9,6 +9,7 @@ import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { getCloudinaryUrl } from "@/lib/cloudinary";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import type { SeriesItem } from "../config/series-configs";
 import type { FilterState } from "../../components/FilterSidebar";
@@ -125,7 +126,10 @@ export default function SeriesSlider({
 
       <div
         ref={scrollContainerRef}
-        className="flex gap-3 sm:gap-4 overflow-x-auto scrollbar-hide scroll-smooth pb-2"
+        // pt-2/px-1: el contenedor con overflow recorta lo que sobresale por arriba
+        // y por los lados; sin este aire, la tarjeta activa (whileHover/scale 1.02 +
+        // borde negro) se veía cortada en el borde superior.
+        className="flex gap-3 sm:gap-4 overflow-x-auto scrollbar-hide scroll-smooth pt-2 pb-2 px-1"
         style={{
           scrollbarWidth: "none",
           msOverflowStyle: "none",
@@ -162,10 +166,11 @@ export default function SeriesSlider({
                   "hover:shadow-sm"
                 ],
                 // Estilos cuando SÍ está activo - SIMPLIFICADO
+                // Sin sombra: con la tarjeta ya sin recortar, el shadow-lg se veía
+                // como una franja gris debajo del borde negro.
                 isActive && [
                   "bg-white",
-                  "border-2 border-black",
-                  "shadow-lg"
+                  "border-2 border-black"
                 ]
               )}
               type="button"
@@ -192,7 +197,10 @@ export default function SeriesSlider({
               {serie.image ? (
                 <div className="relative w-16 h-16 sm:w-20 sm:h-20 lg:w-24 lg:h-24 flex-shrink-0">
                   <Image
-                    src={serie.image}
+                    // `menu-icon` recorta el lienzo vacío del PNG (traen ~57% de
+                    // margen lateral): el producto llena la tarjeta en vez de verse
+                    // diminuto, y se sirve optimizado en alta calidad.
+                    src={getCloudinaryUrl(serie.image, "menu-icon")}
                     alt={serie.name}
                     fill
                     className={cn(

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -13,6 +13,8 @@ const CLOUDINARY_BASE_URL = `https://res.cloudinary.com/${CLOUDINARY_CLOUD_NAME}
  * Tipos de transformación disponibles por contexto de uso
  */
 export type ImageTransformType =
+  // Menú / submenú
+  | 'menu-icon'        // Iconos de menú y submenú (recortados al producto)
   // Productos
   | 'catalog'          // Grid de productos (1000x1000)
   | 'product-main'     // Vista principal de producto (1200x1200)
@@ -39,6 +41,11 @@ export type ImageTransformType =
  * - b_auto:predominant: Rellena espacios vacíos con color predominante
  */
 const TRANSFORM_CONFIGS: Record<ImageTransformType, string> = {
+  // Iconos de menú/submenú: e_trim recorta el lienzo vacío del PNG (los assets del
+  // catálogo traen ~57% de margen lateral transparente, por eso el producto se veía
+  // diminuto dentro de la tarjeta). c_limit nunca amplía; q_auto:best = alta calidad.
+  'menu-icon': 'e_trim,f_auto,q_auto:best,c_limit,w_512',
+
   // Catálogo - 1000x1000, ALTA CALIDAD optimizada para velocidad
   // q_90: Calidad premium (diferencia imperceptible vs q_100, 40% menos peso)
   // SIN dpr_2.0: Next.js maneja Retina con srcset automático, evita timeouts de generación
@@ -224,6 +231,8 @@ export function getResponsiveSrcSet(
  * Dimensiones optimizadas para balance calidad/rendimiento
  */
 export const IMAGE_DIMENSIONS: Record<ImageTransformType, { width: number; height: number }> = {
+  // Menú / submenú
+  'menu-icon': { width: 512, height: 512 },
   // Productos
   catalog: { width: 1000, height: 1000 },
   'product-main': { width: 1200, height: 1200 },


### PR DESCRIPTION
## El reporte
Juan David: *"tengo un tema con las fotos de los submenús… recién las actualizo con nuestros productos y se ven muy pequeñas"*.

## Causa (medida, no estimada)
Los PNG subidos (600×400) traen **~57% de lienzo transparente a los lados** (el reloj ocupa solo ~42% del ancho), y la caja cuadrada de 96 px con `object-contain` los reduce aún más → el producto terminaba ocupando **~8-10% del área** de la tarjeta.

## Cambios
1. **Preset `menu-icon`** en `cloudinary.ts`: `e_trim` (recorta el lienzo vacío) + `q_auto:best` (alta calidad) + `c_limit,w_512` (nunca amplía). Medido: el reloj pasa de 41×64 → **62×96 px (+125% de área)** y pesa menos.
2. **`SeriesSlider` usa el preset** — antes pasaba la URL cruda (único punto del flujo de imágenes que esquivaba `getCloudinaryUrl`).
3. **Aire en el carrusel** (`pt-2 px-1`): el contenedor con overflow recortaba el borde superior de la tarjeta activa al crecer con `whileHover`/scale 1.02.
4. **Sin `shadow-lg` en la tarjeta activa**: se veía como una franja gris debajo del borde negro.

## Rendimiento
- **Cero costo de primera carga**: las 64 imágenes de menú/submenú de producción ya fueron **pre-generadas en Cloudinary** (192 variantes AVIF/WebP/plano, 0 fallos). La caché de derivados es global y **persiste entre deploys**.
- En régimen normal: mismo pipeline de siempre (`next/image`), pero el origen recortado pesa **menos** que el PNG crudo que se descargaba antes.

## Notas
- `e_trim` aplica sobre assets con fondo transparente (verificado en los actuales). Si un asset futuro llega con fondo opaco, simplemente no se recorta (se ve como hoy, no peor).
- La corrección de raíz sigue siendo **subir los assets cuadrados y sin margen** — plantilla sugerida para contenido: lienzo cuadrado, producto ≥85% del lado, PNG con transparencia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)