### PR TITLE
feat(empresas): conectar los botones 'Contáctanos' al endpoint real de leads

### DIFF
--- a/src/app/ventas-corporativas/page.tsx
+++ b/src/app/ventas-corporativas/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import { apiClient } from "@/lib/api";
 import {
   IndustrySelector,
   ProductShowcase,
@@ -36,8 +37,16 @@ export default function VentasCorporativasPage() {
   const handleFormSubmit = async (data: SpecializedConsultationFormData) => {
     setIsSubmitting(true);
     try {
-      console.log("Formulario enviado:", data);
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await apiClient.post("/api/messaging/corporate-lead", {
+        fullName: data.fullName.trim(),
+        company: data.company.trim(),
+        email: data.email.trim(),
+        phone: data.phone.trim(),
+        industry: selectedIndustry?.name || "General",
+        solutionInterest: data.solutionInterest,
+        message: data.message?.trim() || undefined,
+        recaptchaToken: data.recaptchaToken ?? undefined,
+      });
       alert(
         "¡Gracias por tu interés! Nos pondremos en contacto contigo pronto."
       );

--- a/src/components/sections/ventas-corporativas/SpecializedConsultationModal.tsx
+++ b/src/components/sections/ventas-corporativas/SpecializedConsultationModal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import ReCAPTCHA from "react-google-recaptcha";
+import { apiClient } from "@/lib/api";
 import Modal from "@/components/Modal";
 import FormField from "./FormField";
 import LoadingButton from "./LoadingButton";
@@ -45,6 +46,16 @@ export default function SpecializedConsultationModal({
   });
 
   const recaptchaRef = useRef<ReCAPTCHA>(null);
+  // La clave pública viene del backend (claves solo en Railway). Sin clave,
+  // el widget no se muestra y no se exige el token (protege el rate limit).
+  const [recaptchaSiteKey, setRecaptchaSiteKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiClient
+      .get<{ siteKey: string | null }>("/api/messaging/recaptcha-config")
+      .then((r) => setRecaptchaSiteKey(r.data?.siteKey ?? null))
+      .catch(() => setRecaptchaSiteKey(null));
+  }, []);
 
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -68,7 +79,7 @@ export default function SpecializedConsultationModal({
     if (!formData.acceptPrivacy) {
       newErrors.acceptPrivacy = "Debes aceptar la política de privacidad";
     }
-    if (!formData.recaptchaToken) {
+    if (recaptchaSiteKey && !formData.recaptchaToken) {
       newErrors.recaptchaToken = "Debes completar la verificación reCAPTCHA";
     }
 
@@ -114,7 +125,7 @@ export default function SpecializedConsultationModal({
           disabled={isLoading}
         />
         <label htmlFor="consultationPrivacy" className="text-sm text-gray-700 leading-relaxed">
-          Acepto la <a href="#" className="text-blue-600 underline hover:text-blue-800 transition-colors">política de privacidad de Samsung Electronics S.A.</a>
+          Acepto la <a href="/soporte/politicas-generales" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline hover:text-blue-800 transition-colors">política de privacidad de Samsung Electronics S.A.</a>
           <div className="text-gray-500 text-xs mt-1">* Obligatorio</div>
         </label>
       </div>
@@ -224,16 +235,18 @@ export default function SpecializedConsultationModal({
           />
         </div>
 
-        <div className="flex flex-col items-center gap-2">
-          <ReCAPTCHA
-            ref={recaptchaRef}
-            sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"}
-            onChange={(token) => handleInputChange("recaptchaToken", token)}
-            onExpired={() => handleInputChange("recaptchaToken", null)}
-            onError={() => handleInputChange("recaptchaToken", null)}
-          />
-          {errors.recaptchaToken && <p className="text-red-500 text-xs">{errors.recaptchaToken}</p>}
-        </div>
+        {recaptchaSiteKey && (
+          <div className="flex flex-col items-center gap-2">
+            <ReCAPTCHA
+              ref={recaptchaRef}
+              sitekey={recaptchaSiteKey}
+              onChange={(token) => handleInputChange("recaptchaToken", token)}
+              onExpired={() => handleInputChange("recaptchaToken", null)}
+              onError={() => handleInputChange("recaptchaToken", null)}
+            />
+            {errors.recaptchaToken && <p className="text-red-500 text-xs">{errors.recaptchaToken}</p>}
+          </div>
+        )}
       </form>
     </Modal>
   );

--- a/src/hooks/useIndustryModal.ts
+++ b/src/hooks/useIndustryModal.ts
@@ -6,6 +6,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { apiClient } from "@/lib/api";
 import { SpecializedConsultationFormData } from "@/types/corporate-sales";
 
 interface UseIndustryModalReturn {
@@ -37,15 +38,17 @@ export function useIndustryModal(
       setIsSubmitting(true);
 
       try {
-        console.log(
-          `Formulario ${industryName || "corporativo"} enviado:`,
-          data
-        );
+        await apiClient.post("/api/messaging/corporate-lead", {
+          fullName: data.fullName.trim(),
+          company: data.company.trim(),
+          email: data.email.trim(),
+          phone: data.phone.trim(),
+          industry: industryName || "General",
+          solutionInterest: data.solutionInterest,
+          message: data.message?.trim() || undefined,
+          recaptchaToken: data.recaptchaToken ?? undefined,
+        });
 
-        // Simular delay de envío
-        await new Promise((resolve) => setTimeout(resolve, 2000));
-
-        // Mostrar mensaje de éxito
         alert(
           "¡Gracias por tu interés! Nos pondremos en contacto contigo pronto."
         );


### PR DESCRIPTION
Contraparte frontend de **imagiq-backend#658** (mergear aquella primero). Cierra el **blocker B1** de la auditoría de Ventas Corporativas: los 6 formularios (landing + education/hotels/government/retail/finance) descartaban cada lead con `console.log` + alert de éxito falso.

## Qué cambia (3 archivos)
- **`useIndustryModal.ts`** (las 5 industrias) y **`page.tsx`** (landing): POST real a `/api/messaging/corporate-lead` con la **industria de origen** en el payload.
- **`SpecializedConsultationModal`**: la site key de reCAPTCHA se obtiene del backend (`/api/messaging/recaptcha-config`) → se **elimina la clave de test de Google** que estaba incrustada. Sin clave configurada, el widget no aparece (protege el rate limit del gateway).
- **Link de privacidad**: `href="#"` → `/soporte/politicas-generales` (se recolecta PII real; el checkbox obligatorio enlazaba a nada — riesgo habeas data).

## Validado en local
Lead de muestra entregado al buzón con la plantilla nueva ✅ · captcha real verificado server-side (token falso → 400) ✅ · typecheck limpio ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)