### PR TITLE
fix(empresas): enviar la URL de la página de origen con cada lead corporativo

### DIFF
--- a/src/app/ventas-corporativas/page.tsx
+++ b/src/app/ventas-corporativas/page.tsx
@@ -46,6 +46,7 @@ export default function VentasCorporativasPage() {
         solutionInterest: data.solutionInterest,
         message: data.message?.trim() || undefined,
         recaptchaToken: data.recaptchaToken ?? undefined,
+        sourceUrl: typeof window !== "undefined" ? window.location.href : undefined,
       });
       alert(
         "¡Gracias por tu interés! Nos pondremos en contacto contigo pronto."

--- a/src/hooks/useIndustryModal.ts
+++ b/src/hooks/useIndustryModal.ts
@@ -47,6 +47,7 @@ export function useIndustryModal(
           solutionInterest: data.solutionInterest,
           message: data.message?.trim() || undefined,
           recaptchaToken: data.recaptchaToken ?? undefined,
+          sourceUrl: typeof window !== "undefined" ? window.location.href : undefined,
         });
 
         alert(


### PR DESCRIPTION
Contraparte de **imagiq-backend#659** (mergear aquella primero): los 6 formularios de Ventas Corporativas envían `window.location.href` como `sourceUrl` → el correo del lead incluye la página exacta (industria) desde donde escribió el cliente, como link clickeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)