### PR TITLE
fix(empresas): toast elegante en vez del alert nativo al enviar el formulario

### DIFF
--- a/src/app/ventas-corporativas/page.tsx
+++ b/src/app/ventas-corporativas/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { apiClient } from "@/lib/api";
+import { toast } from "sonner";
 import {
   IndustrySelector,
   ProductShowcase,
@@ -48,15 +49,17 @@ export default function VentasCorporativasPage() {
         recaptchaToken: data.recaptchaToken ?? undefined,
         sourceUrl: typeof window !== "undefined" ? window.location.href : undefined,
       });
-      alert(
-        "¡Gracias por tu interés! Nos pondremos en contacto contigo pronto."
-      );
       setIsModalOpen(false);
+      toast.success("¡Gracias por tu interés!", {
+        description: "Nos pondremos en contacto contigo pronto.",
+        duration: 6000,
+      });
     } catch (error) {
       console.error("Error al enviar formulario:", error);
-      alert(
-        "Hubo un error al enviar el formulario. Por favor intenta de nuevo."
-      );
+      toast.error("No pudimos enviar tu solicitud", {
+        description: "Por favor intenta de nuevo en unos minutos.",
+        duration: 6000,
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/src/hooks/useIndustryModal.ts
+++ b/src/hooks/useIndustryModal.ts
@@ -7,6 +7,7 @@
 
 import { useState, useCallback } from "react";
 import { apiClient } from "@/lib/api";
+import { toast } from "sonner";
 import { SpecializedConsultationFormData } from "@/types/corporate-sales";
 
 interface UseIndustryModalReturn {
@@ -50,16 +51,17 @@ export function useIndustryModal(
           sourceUrl: typeof window !== "undefined" ? window.location.href : undefined,
         });
 
-        alert(
-          "¡Gracias por tu interés! Nos pondremos en contacto contigo pronto."
-        );
-
         setIsModalOpen(false);
+        toast.success("¡Gracias por tu interés!", {
+          description: "Nos pondremos en contacto contigo pronto.",
+          duration: 6000,
+        });
       } catch (error) {
         console.error("Error al enviar formulario:", error);
-        alert(
-          "Hubo un error al enviar el formulario. Por favor, intenta de nuevo."
-        );
+        toast.error("No pudimos enviar tu solicitud", {
+          description: "Por favor intenta de nuevo en unos minutos.",
+          duration: 6000,
+        });
       } finally {
         setIsSubmitting(false);
       }


### PR DESCRIPTION
Al enviar el modal de **Contáctanos** (landing + 5 industrias) salía el `alert()` nativo del navegador — la ventanita del sistema operativo.

Ahora usa **sonner** (ya instalado y montado en el layout):
- ✅ Éxito: toast verde *"¡Gracias por tu interés!"* con descripción, 6 s
- ❌ Error: toast rojo con sugerencia de reintento
- El modal se cierra antes del toast de éxito

2 archivos, sin dependencias nuevas. Typecheck limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)