### PR TITLE
fix(sentry): capturar errores siempre, identificar usuarios y filtrar ruido de terceros

### DIFF
--- a/src/app/carrito/utils/index.ts
+++ b/src/app/carrito/utils/index.ts
@@ -130,7 +130,9 @@ export async function payWithPse(props: PsePaymentData): Promise<{ redirectUrl: 
 export async function fetchBanks(): Promise<{ bankCode: string; bankName: string }[]> {
   try {
     const data = await apiGet<{ bankCode: string; bankName: string }[]>('/api/payments/epayco/banks');
-    return data;
+    // Si el endpoint responde error, data puede ser un objeto y el .map() del
+    // selector de bancos PSE reventaría el checkout (mismo guard que en soporte).
+    return Array.isArray(data) ? data : [];
   } catch (error) {
     // Provide detailed error information for debugging
     if (error instanceof Error) {

--- a/src/app/soporte/inicio_de_soporte/page.tsx
+++ b/src/app/soporte/inicio_de_soporte/page.tsx
@@ -66,7 +66,9 @@ interface CardData {
 async function fetchBanks(): Promise<Bank[]> {
   try {
     const response = await apiClient.get<Bank[]>("/api/payments/epayco/banks");
-    return response.data;
+    // Si el endpoint responde 400/errores, data puede llegar como objeto de
+    // error y el .map() de bancos reventaba la página (visto en Sentry).
+    return Array.isArray(response.data) ? response.data : [];
   } catch (error) {
     console.error("Error fetching banks:", error);
     return [];

--- a/src/components/analytics/SentryScript.tsx
+++ b/src/components/analytics/SentryScript.tsx
@@ -7,7 +7,7 @@ import { initSentry } from '@/lib/sentry/client';
 /**
  * Sentry - First-Party Loading
  *
- * SOLO se carga si el usuario acepta cookies de analytics
+ * Errores: siempre. Tracing/Replay: solo con consentimiento de analytics.
  */
 export default function SentryScript() {
   const [mounted, setMounted] = useState(false);
@@ -20,13 +20,11 @@ export default function SentryScript() {
     if (!mounted || typeof window === 'undefined') return;
 
     const loadSentry = () => {
-      // Verificar consentimiento
-      if (!hasAnalyticsConsent()) {
-        return;
-      }
-
-      // Ejecutar inicialización asíncrona
-      void initSentry();
+      // SIEMPRE se inicializa la captura de ERRORES (monitoreo técnico sin
+      // tracing/replay/PII). Antes Sentry solo arrancaba con consentimiento de
+      // analytics -> quedaba ciego para la mayoría de usuarios (~2 eventos/día).
+      // Con consentimiento se activa el modo completo (tracing + replay).
+      void initSentry(hasAnalyticsConsent());
     };
 
     // Cargar inmediatamente

--- a/src/features/auth/context.tsx
+++ b/src/features/auth/context.tsx
@@ -17,6 +17,7 @@ import {
   ReactNode,
 } from "react";
 import { apiClient } from "@/lib/api";
+import { setUser as setSentryUser, clearUser as clearSentryUser } from "@/lib/sentry/client";
 import { User } from "@/types/user";
 import { addressesService } from "@/services/addresses.service";
 import { setPosthogUserId, posthogUtils } from "@/lib/posthogClient";
@@ -154,6 +155,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     setUser(userData);
+    // Identificar al usuario en Sentry: sin esto los issues muestran 0 usuarios
+    // afectados y no se puede dimensionar el impacto real de un error.
+    try {
+      setSentryUser({ id: String(userData.id ?? ""), email: userData.email });
+    } catch { /* Sentry puede no estar inicializado aún */ }
     localStorage.setItem("imagiq_user", JSON.stringify(userData));
 
     // IMPORTANTE: Guardar userId de forma consistente
@@ -269,7 +275,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     
     // Reset PostHog user session
     posthogUtils.reset();
-    
+
+    try {
+      clearSentryUser();
+    } catch { /* noop */ }
+
     setUser(null);
 
     // CRÍTICO: Usar función especializada para logout que limpia TODO

--- a/src/features/auth/context.tsx
+++ b/src/features/auth/context.tsx
@@ -70,6 +70,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setUser(userData);
           apiClient.setAuthToken(savedToken!);
 
+          // Identificar también en sesiones RESTAURADAS (no solo en login): sin
+          // esto la mayoría de sesiones reportaban errores anónimos. El cliente
+          // de Sentry decide cuánto enviar según el consentimiento (solo id sin él).
+          try {
+            setSentryUser({ id: String(userData.id ?? ""), email: userData.email });
+          } catch { /* Sentry puede no estar inicializado aún */ }
+
           // Identify user in PostHog on session restore
           const userRole = userData.role ?? (userData as User & { rol?: number }).rol;
           setPosthogUserId(userData.id, {

--- a/src/lib/sentry/client.ts
+++ b/src/lib/sentry/client.ts
@@ -38,7 +38,7 @@ let configLoading = false;
  * }
  * ```
  */
-export async function initSentry(): Promise<void> {
+export async function initSentry(fullMode: boolean = true): Promise<void> {
   // Validaciones previas
   if (!sentryConfig.enabled) {
     return;
@@ -74,13 +74,17 @@ export async function initSentry(): Promise<void> {
       return;
     }
 
-    // Inicializar Sentry con la configuración obtenida del backend
+    // Inicializar Sentry con la configuración obtenida del backend.
+    // Modo 'errors-only' (sin consentimiento de analytics): captura errores sin
+    // tracing ni replays ni PII — monitoreo técnico por interés legítimo.
+    // Modo completo (con consentimiento): tracing + session replay.
     Sentry.init({
       dsn: config.dsn,
       environment: config.environment || 'production',
-      tracesSampleRate: config.tracesSampleRate ?? 0.1,
-      replaysSessionSampleRate: config.replaysSessionSampleRate ?? 0.1,
-      replaysOnErrorSampleRate: config.replaysOnErrorSampleRate ?? 1,
+      tracesSampleRate: fullMode ? (config.tracesSampleRate ?? 0.1) : 0,
+      replaysSessionSampleRate: fullMode ? (config.replaysSessionSampleRate ?? 0.1) : 0,
+      replaysOnErrorSampleRate: fullMode ? (config.replaysOnErrorSampleRate ?? 1) : 0,
+      sendDefaultPii: fullMode,
       // Filtrar ruido de terceros: Flixmedia genera la mayoría de errores en
       // /productos/* — scripts async no cancelables que corren tras la navegación
       // SPA, bugs dentro de su bundle minificado (opts/opts2), y puentes nativos
@@ -95,20 +99,30 @@ export async function initSentry(): Promise<void> {
         'Java object is gone',
         'webkit.messageHandlers',
         'AbortError',
+        // 3DS de ePayco (validateThreeds.min.js): parsea postMessage ajenos y
+        // revienta con JSON malformado — script de terceros, no nuestro código.
+        'JSON Parse error: Unexpected identifier',
+        // Grabadores de sesión de terceros (Clarity/PostHog) compitiendo.
+        'session recording is available',
       ],
       denyUrls: [
         /flixfacts\.com/,
         /flixcar\.com/,
         /flixsyndication/,
         /modular\/js\/minify/,
+        // Script 3DS de ePayco servido desde su CDN.
+        /general\/3DS\//,
+        /apiflow\.epayco\.co/,
       ],
-      integrations: [
-        Sentry.browserTracingIntegration(),
-        Sentry.replayIntegration({
-          maskAllText: false,
-          blockAllMedia: false,
-        }),
-      ],
+      integrations: fullMode
+        ? [
+            Sentry.browserTracingIntegration(),
+            Sentry.replayIntegration({
+              maskAllText: false,
+              blockAllMedia: false,
+            }),
+          ]
+        : [],
     });
 
     // Exponer Sentry globalmente para compatibilidad

--- a/src/lib/sentry/client.ts
+++ b/src/lib/sentry/client.ts
@@ -14,8 +14,14 @@ import * as Sentry from '@sentry/nextjs';
 import { sentryConfig } from './config';
 import { apiGet } from '@/lib/api-client';
 
-/** Flag para evitar inicializaciones múltiples */
-let sentryInitialized = false;
+/**
+ * Modo con el que quedó inicializado el SDK.
+ * 'errors' -> captura técnica sin tracing/replay/PII (sin consentimiento).
+ * 'full'   -> monitoreo completo (con consentimiento).
+ * El upgrade errors->full SÍ re-inicializa (Sentry.init reemplaza el cliente);
+ * sin esto, aceptar cookies a mitad de sesión quedaba sin efecto hasta un F5.
+ */
+let initializedMode: 'none' | 'errors' | 'full' = 'none';
 
 /** Flag para rastrear si la configuración está siendo cargada */
 let configLoading = false;
@@ -44,7 +50,9 @@ export async function initSentry(fullMode: boolean = true): Promise<void> {
     return;
   }
 
-  if (sentryInitialized) {
+  const targetMode = fullMode ? 'full' : 'errors';
+  // Ya estamos en el modo pedido (o superior): nada que hacer.
+  if (initializedMode === 'full' || initializedMode === targetMode) {
     return;
   }
 
@@ -99,9 +107,8 @@ export async function initSentry(fullMode: boolean = true): Promise<void> {
         'Java object is gone',
         'webkit.messageHandlers',
         'AbortError',
-        // 3DS de ePayco (validateThreeds.min.js): parsea postMessage ajenos y
-        // revienta con JSON malformado — script de terceros, no nuestro código.
-        'JSON Parse error: Unexpected identifier',
+        // El JSON malformado del 3DS de ePayco se filtra por denyUrls (abajo):
+        // filtrarlo por mensaje ocultaría JSON.parse PROPIOS rotos en iOS/WebKit.
         // Grabadores de sesión de terceros (Clarity/PostHog) compitiendo.
         'session recording is available',
       ],
@@ -130,7 +137,7 @@ export async function initSentry(fullMode: boolean = true): Promise<void> {
       globalThis.window.Sentry = Sentry as unknown as typeof globalThis.window.Sentry;
     }
 
-    sentryInitialized = true;
+    initializedMode = targetMode;
     configLoading = false;
   } catch (error) {
     console.error('[Sentry] Error during initialization:', error);
@@ -160,7 +167,7 @@ export async function initSentry(fullMode: boolean = true): Promise<void> {
  * ```
  */
 export function captureError(error: Error, context?: Record<string, unknown>): void {
-  if (!sentryInitialized) {
+  if (initializedMode === 'none') {
     return;
   }
 
@@ -192,7 +199,7 @@ export function captureMessage(
   message: string,
   level: 'info' | 'warning' | 'error' = 'info'
 ): void {
-  if (!sentryInitialized) {
+  if (initializedMode === 'none') {
     return;
   }
 
@@ -227,11 +234,17 @@ export function setUser(user: {
   email?: string;
   username?: string;
 }): void {
-  if (!sentryInitialized) {
+  if (initializedMode === 'none') {
     return;
   }
 
   try {
+    // Sin consentimiento de analytics (modo errores) NO se envía PII:
+    // solo el id pseudónimo, suficiente para contar usuarios afectados.
+    if (initializedMode === 'errors') {
+      Sentry.setUser(user.id ? { id: user.id } : null);
+      return;
+    }
     Sentry.setUser(user);
   } catch (err) {
     console.error('[Sentry] Failed to set user:', err);
@@ -252,7 +265,7 @@ export function setUser(user: {
  * ```
  */
 export function clearUser(): void {
-  if (!sentryInitialized) {
+  if (initializedMode === 'none') {
     return;
   }
 
@@ -278,5 +291,5 @@ export function clearUser(): void {
  * ```
  */
 export function isSentryInitialized(): boolean {
-  return sentryInitialized;
+  return initializedMode !== 'none';
 }


### PR DESCRIPTION
Resultado de la revisión a fondo de Sentry (org `imagiq`, con métricas de la API).

## El hallazgo principal: Sentry estaba casi ciego
**~1-4 eventos/día** — el SDK solo se inicializaba si el usuario aceptaba cookies de analytics (`hasAnalyticsConsent()` default `false`). La gran mayoría del tráfico navegaba sin monitoreo de errores.

## Cambios
1. **Cobertura**: `initSentry(fullMode)` — la captura de **errores** arranca **siempre** (sin tracing, sin replay, `sendDefaultPii:false` → monitoreo técnico por interés legítimo). Con consentimiento → modo completo (tracing + replay con las tasas del backend, como hoy).
2. **Usuarios afectados**: `Sentry.setUser` en login / clear en logout — todos los issues mostraban **0 usuarios**, imposible dimensionar impacto.
3. **Menos ruido**: filtros para el 3DS de ePayco (`validateThreeds.min.js` truena parseando postMessage ajenos — 10 eventos en checkout que no son nuestro código) y para el conflicto de grabadores de sesión.
4. **Bug real corregido** ([issue 7514166220](https://imagiq.sentry.io/issues/7514166220/)): si `/api/payments/epayco/banks` responde 400, `data` no es array y el `.map()` **reventaba la página de soporte** → guard `Array.isArray`.

## Verificado
Typecheck limpio · el endpoint de config del backend responde 200 con DSN ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)