### PR TITLE
feat(bundle): preselecciona la variante del combo + display + velocidad

### DIFF
--- a/src/app/productos/components/BundleCard.tsx
+++ b/src/app/productos/components/BundleCard.tsx
@@ -12,6 +12,7 @@
 import { useState, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { prefetchBundle } from "@/features/products/useProducts";
 import { Plus, Loader } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -798,6 +799,13 @@ export default function BundleCard({
         "rounded-lg w-full h-full flex flex-col mx-auto",
         className
       )}
+      onMouseEnter={() => {
+        // Prefetch del bundle al pasar el mouse: al hacer click, los datos ya
+        // están en caché y la vista aparece casi al instante.
+        if (baseCodigoMarket && codCampana && selectedOption?.product_sku) {
+          void prefetchBundle(baseCodigoMarket, codCampana, selectedOption.product_sku);
+        }
+      }}
     >
       {/* Sección de imágenes del bundle - overflow visible para que las imágenes se "salgan" - Clickable */}
       <div

--- a/src/app/productos/dispositivos-moviles/detalles-producto/DetailsProductSection.tsx
+++ b/src/app/productos/dispositivos-moviles/detalles-producto/DetailsProductSection.tsx
@@ -7,7 +7,7 @@ import { useCartContext } from "@/features/cart/CartContext";
 import { useFavorites } from "@/features/products/useProducts";
 import type { ProductCardProps } from "@/app/productos/components/ProductCard";
 import type { StaticImageData } from "next/image";
-import type { ProductVariant, ColorOption } from "@/hooks/useProductSelection";
+import type { ProductVariant, ColorOption, ActiveFilterHints } from "@/hooks/useProductSelection";
 import fallbackImage from "@/img/dispositivosmoviles/cel1.png";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { cleanProductName } from "@/lib/utils";
@@ -49,6 +49,35 @@ const DetailsProductSection: React.FC<{
   }) => void;
   hideBreadcrumbs?: boolean;
 }> = ({ product, onVariantsReady, onProductSelectionChange, hideBreadcrumbs = false }) => {
+  // Preselección de variante: si venimos de un bundle (o de "Más información"),
+  // hay una selección guardada en localStorage; la traducimos a hints para que
+  // useProductSelection muestre la MISMA variante (p.ej. 50"/21kg) y no la "mejor".
+  const bundleHints = React.useMemo((): ActiveFilterHints | undefined => {
+    if (typeof window === "undefined") return undefined;
+    try {
+      const raw = localStorage.getItem(`product_selection_${product.id}`);
+      if (!raw) return undefined;
+      const parsed = JSON.parse(raw) as {
+        color?: string;
+        colorHex?: string;
+        capacity?: string;
+        ram?: string;
+      };
+      const capacidad = (parsed.capacity || "").trim();
+      const ram = (parsed.ram || "").trim();
+      const colorVals = [parsed.color, parsed.colorHex]
+        .map((c) => (c || "").trim())
+        .filter(Boolean);
+      const hints: ActiveFilterHints = {};
+      if (capacidad) hints.capacidad = [capacidad];
+      if (colorVals.length) hints.color = colorVals;
+      if (ram) hints.memoriaram = [ram];
+      return Object.keys(hints).length ? hints : undefined;
+    } catch {
+      return undefined;
+    }
+  }, [product.id]);
+
   // Hooks - Usar el mismo sistema que ProductCard
   const productSelection = useProductSelection(
     product.apiProduct || {
@@ -76,7 +105,10 @@ const DetailsProductSection: React.FC<{
       precioeccommerce: [],
       fechaInicioVigencia: [],
       fechaFinalVigencia: [],
-    }
+    },
+    undefined,
+    undefined,
+    bundleHints
   );
 
   // Notificar cuando las variantes estén listas (usando productSelection)

--- a/src/app/productos/viewbundle/[baseCodigoMarket]/[codCampana]/[productSku]/components/BundleProductsGrid.tsx
+++ b/src/app/productos/viewbundle/[baseCodigoMarket]/[codCampana]/[productSku]/components/BundleProductsGrid.tsx
@@ -43,6 +43,16 @@ function ProductCard({ product }: { product: BundleProduct }) {
 
   const imageUrl = getValidImageUrl();
 
+  // Normaliza valores placeholder ("No aplica", "0", "-", vacío) a "" para no
+  // mostrarlos: el cliente no debe ver "No aplica | 50\"" ni "Negro | -".
+  const clean = (v?: string) => {
+    const s = (v || "").trim();
+    if (!s || s === "-" || s === "0" || /^no\s*aplica$/i.test(s)) return "";
+    return s;
+  };
+  const colorLabel = clean(product.nombreColor);
+  const capacidadLabel = clean(product.capacidad);
+
   return (
     <div className="bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-lg transition-all duration-300 flex flex-col h-full">
       {/* Imagen del producto */}
@@ -62,12 +72,12 @@ function ProductCard({ product }: { product: BundleProduct }) {
           {product.modelo}
         </h3>
         
-        {/* Detalles (color, capacidad) */}
-        {(product.nombreColor || product.capacidad) && (
+        {/* Detalles (color, capacidad) — placeholders "No aplica"/"0"/"-" se ocultan */}
+        {(colorLabel || capacidadLabel) && (
           <div className="text-sm text-gray-600 mb-4">
-            {product.nombreColor && <span>{product.nombreColor}</span>}
-            {product.nombreColor && product.capacidad && <span> | </span>}
-            {product.capacidad && <span>{product.capacidad}</span>}
+            {colorLabel && <span>{colorLabel}</span>}
+            {colorLabel && capacidadLabel && <span> | </span>}
+            {capacidadLabel && <span>{capacidadLabel}</span>}
           </div>
         )}
 
@@ -77,7 +87,33 @@ function ProductCard({ product }: { product: BundleProduct }) {
         {/* Botón "Saber más" */}
         <Link
           href={productUrl}
-          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          onClick={() => {
+            // Guardar la VARIANTE del bundle para que la PDP destino la
+            // preseleccione (misma clave/estructura que usa ProductCard). Sin
+            // esto la PDP cae a la "mejor"/primera variante (58" en vez de 50",
+            // 15kg en vez de 21kg) y confunde al cliente con otro precio.
+            try {
+              localStorage.setItem(
+                `product_selection_${baseCodigoMarket}`,
+                JSON.stringify({
+                  productId: baseCodigoMarket,
+                  productName: product.modelo,
+                  price: product.product_discount_price,
+                  originalPrice: product.product_original_price,
+                  color: product.nombreColor, // nombre display
+                  colorHex: product.color, // hex
+                  capacity: product.capacidad,
+                  ram: product.memoriaram,
+                  sku: product.sku,
+                  ean: product.ean,
+                  image: product.imagePreviewUrl,
+                })
+              );
+            } catch {
+              /* localStorage no disponible: navegar sin preselección */
+            }
+            window.scrollTo({ top: 0, behavior: "smooth" });
+          }}
           className="mt-4 w-full py-2.5 px-4 bg-white text-gray-900 border-2 border-gray-900 rounded-full font-medium text-center hover:bg-gray-900 hover:text-white transition-colors duration-200"
         >
           Saber más

--- a/src/app/productos/viewbundle/[baseCodigoMarket]/[codCampana]/[productSku]/page.tsx
+++ b/src/app/productos/viewbundle/[baseCodigoMarket]/[codCampana]/[productSku]/page.tsx
@@ -64,13 +64,10 @@ export default function BundleViewPage({ params }: BundleViewPageProps) {
     };
   }, [showStickyBar]);
 
-  // Transición suave al cargar
+  // Mostrar el contenido en cuanto los datos estén listos (sin retraso artificial
+  // de 150 ms que alargaba el skeleton aunque el bundle ya hubiera cargado).
   useEffect(() => {
-    if (!loading && bundle) {
-      const timer = setTimeout(() => setShowContent(true), 150);
-      return () => clearTimeout(timer);
-    }
-    setShowContent(false);
+    setShowContent(!loading && !!bundle);
   }, [loading, bundle]);
 
   // AHORA SÍ PODEMOS HACER VALIDACIONES Y RETURNS CONDICIONALES

--- a/src/app/productos/viewpremium/[id]/page.tsx
+++ b/src/app/productos/viewpremium/[id]/page.tsx
@@ -7,7 +7,7 @@ import ViewPremiumSkeleton from "./ViewPremiumSkeleton";
 import StickyPriceBar from "@/app/productos/dispositivos-moviles/detalles-producto/StickyPriceBar";
 import { useScrollNavbar } from "@/hooks/useScrollNavbar";
 import { Breadcrumbs } from "@/components/breadcrumbs";
-import { useProductSelection } from "@/hooks/useProductSelection";
+import { useProductSelection, type ActiveFilterHints } from "@/hooks/useProductSelection";
 import { useCartContext } from "@/features/cart/CartContext";
 import { useRouter } from "next/navigation";
 import fallbackImage from "@/img/dispositivosmoviles/cel1.png";
@@ -149,6 +149,35 @@ export default function ProductViewPage({ params }) {
     goToImage,
   } = useProductLogic(product);
 
+  // Preselección de variante desde la selección guardada (bundle / "Más
+  // información"): mismos hints que view, para que la variante (p.ej. TV 50")
+  // coincida con la del bundle y no caiga a la "mejor"/primera.
+  const bundleHints = React.useMemo((): ActiveFilterHints | undefined => {
+    if (typeof window === "undefined" || !id) return undefined;
+    try {
+      const raw = localStorage.getItem(`product_selection_${id}`);
+      if (!raw) return undefined;
+      const parsed = JSON.parse(raw) as {
+        color?: string;
+        colorHex?: string;
+        capacity?: string;
+        ram?: string;
+      };
+      const capacidad = (parsed.capacity || "").trim();
+      const ram = (parsed.ram || "").trim();
+      const colorVals = [parsed.color, parsed.colorHex]
+        .map((c) => (c || "").trim())
+        .filter(Boolean);
+      const hints: ActiveFilterHints = {};
+      if (capacidad) hints.capacidad = [capacidad];
+      if (colorVals.length) hints.color = colorVals;
+      if (ram) hints.memoriaram = [ram];
+      return Object.keys(hints).length ? hints : undefined;
+    } catch {
+      return undefined;
+    }
+  }, [id]);
+
   // Hook para manejo inteligente de selección de productos - compartido entre componentes
   const productSelection = useProductSelection(
     product?.apiProduct || {
@@ -179,7 +208,10 @@ export default function ProductViewPage({ params }) {
       indRetoma: [],
       indcerointeres: [],
       skuPostback: [],
-    }
+    },
+    undefined,
+    undefined,
+    bundleHints
   );
 
   // 🔥 ViewContent: una vez por producto, cuando productSelection resuelve el

--- a/src/app/productos/viewpremium/hooks/useProductLogic.ts
+++ b/src/app/productos/viewpremium/hooks/useProductLogic.ts
@@ -19,22 +19,52 @@ export const useProductLogic = (product: ProductCardProps | null) => {
   // Inicializar selecciones cuando el producto se carga
   React.useEffect(() => {
     if (product) {
-      // Seleccionar el primer color disponible
+      // Selección guardada (bundle / "Más información"): si existe, preseleccionar
+      // ESA variante en vez de la primera, para que el TV 50"/lavadora 21kg del
+      // combo no abran otra variante. Sin selección o sin coincidencia -> fallback
+      // al comportamiento anterior (primera/mínima).
+      let saved: { color?: string; capacity?: string; ram?: string } | null = null;
+      if (typeof window !== "undefined" && product.id) {
+        try {
+          const raw = localStorage.getItem(`product_selection_${product.id}`);
+          if (raw) saved = JSON.parse(raw);
+        } catch {
+          saved = null;
+        }
+      }
+      const norm = (s?: string | null) => (s || "").trim().toLowerCase();
+
+      // Seleccionar el color guardado si coincide, sino el primero disponible
       if (product.colors && product.colors.length > 0) {
-        setSelectedColor(product.colors[0].name);
+        const match = saved?.color
+          ? product.colors.find(
+              (c) => norm(c.name) === norm(saved!.color) || norm(c.label) === norm(saved!.color),
+            )
+          : undefined;
+        setSelectedColor((match ?? product.colors[0]).name);
       }
-      // Seleccionar la primera capacidad disponible
+      // Seleccionar la capacidad guardada si coincide, sino la primera disponible
       if (product.capacities && product.capacities.length > 0) {
-        setSelectedStorage(product.capacities[0].value);
+        const match = saved?.capacity
+          ? product.capacities.find(
+              (c) => norm(c.value) === norm(saved!.capacity) || norm(c.label) === norm(saved!.capacity),
+            )
+          : undefined;
+        setSelectedStorage((match ?? product.capacities[0]).value);
       }
-      // Seleccionar la RAM mínima si hay opciones disponibles
+      // Seleccionar la RAM guardada si coincide, sino la mínima (comportamiento previo)
       if (product.apiProduct?.memoriaram) {
         const ramOptions = Array.from(new Set(product.apiProduct.memoriaram))
           .filter(ram => ram && ram.trim() !== '');
 
         if (ramOptions.length > 0) {
-          // Si solo hay una opción, preseleccionarla
-          if (ramOptions.length === 1) {
+          const savedRam = saved?.ram
+            ? ramOptions.find((r) => norm(r) === norm(saved!.ram))
+            : undefined;
+          if (savedRam) {
+            setSelectedRam(savedRam);
+          } else if (ramOptions.length === 1) {
+            // Si solo hay una opción, preseleccionarla
             setSelectedRam(ramOptions[0]);
           } else {
             // Si hay múltiples opciones, seleccionar la mínima

--- a/src/features/products/useProducts.ts
+++ b/src/features/products/useProducts.ts
@@ -1311,21 +1311,71 @@ export const useProduct = (productId: string) => {
 };
 
 /**
+ * Caché en memoria de bundles ya resueltos (el proyecto no usa React Query).
+ * Permite que las revisitas al mismo bundle Y el prefetch desde el card sean
+ * instantáneos, en vez de re-pedir todo en cada entrada.
+ */
+const bundleCache = new Map<string, BundleCardProps>();
+const bundleCacheKey = (b: string, c: string, s: string) => `${b}|${c}|${s}`;
+
+/**
+ * Prefetch de un bundle (best-effort) para llenar la caché ANTES de navegar.
+ * Se dispara al pasar el mouse por el card: al hacer click, los datos ya están
+ * y la vista aparece casi al instante. Si falla, useBundle hace el fetch normal.
+ */
+export async function prefetchBundle(
+  baseCodigoMarket: string,
+  codCampana: string,
+  productSku: string,
+): Promise<void> {
+  if (!baseCodigoMarket || !codCampana || !productSku) return;
+  const key = bundleCacheKey(baseCodigoMarket, codCampana, productSku);
+  if (bundleCache.has(key)) return;
+  try {
+    const response = await productEndpoints.getBundleById(baseCodigoMarket, codCampana, productSku);
+    if (response.success && response.data) {
+      bundleCache.set(key, mapDirectBundleResponseToFrontend(response.data));
+    }
+  } catch {
+    /* prefetch best-effort */
+  }
+}
+
+/**
  * Hook para obtener un bundle específico por sus 3 parámetros
  * @param baseCodigoMarket - Código base del producto principal
  * @param codCampana - Código de la campaña
  * @param productSku - SKU de la opción del bundle
  * @returns Bundle, loading state, y error state
+ *
+ * Usa la caché en memoria: si el bundle ya fue prefetcheado o visitado, se
+ * muestra al instante (sin skeleton) y se refresca en segundo plano.
  */
 export const useBundle = (baseCodigoMarket: string, codCampana: string, productSku: string) => {
-  const [bundle, setBundle] = useState<BundleCardProps | null>(null);
-  const [loading, setLoading] = useState(true);
+  const cachedInitial =
+    baseCodigoMarket && codCampana && productSku
+      ? bundleCache.get(bundleCacheKey(baseCodigoMarket, codCampana, productSku))
+      : undefined;
+  const [bundle, setBundle] = useState<BundleCardProps | null>(cachedInitial ?? null);
+  const [loading, setLoading] = useState(!cachedInitial);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const key =
+      baseCodigoMarket && codCampana && productSku
+        ? bundleCacheKey(baseCodigoMarket, codCampana, productSku)
+        : null;
+    const hit = key ? bundleCache.get(key) : undefined;
+
+    // Con caché: mostrar al instante y refrescar en segundo plano (sin skeleton).
+    if (hit) {
+      setBundle(hit);
+      setLoading(false);
+      setError(null);
+    }
+
     const fetchBundle = async () => {
-      // No hay cache, hacer petición normal con loading
-      setLoading(true);
+      if (!hit) setLoading(true);
       setError(null);
 
       try {
@@ -1333,17 +1383,16 @@ export const useBundle = (baseCodigoMarket: string, codCampana: string, productS
         const response = await productEndpoints.getBundleById(baseCodigoMarket, codCampana, productSku);
 
         if (response.success && response.data) {
-          const apiData = response.data;
-          const mappedBundle = mapDirectBundleResponseToFrontend(apiData);
-
+          const mappedBundle = mapDirectBundleResponseToFrontend(response.data);
+          if (key) bundleCache.set(key, mappedBundle);
           setBundle(mappedBundle);
           setError(null);
-        } else {
+        } else if (!hit) {
           setError("Bundle no encontrado");
         }
       } catch (err) {
         console.error("Error fetching bundle:", err);
-        setError("Error al cargar el bundle");
+        if (!hit) setError("Error al cargar el bundle");
       } finally {
         setLoading(false);
       }

--- a/src/hooks/useProductSelection.ts
+++ b/src/hooks/useProductSelection.ts
@@ -162,7 +162,11 @@ export interface UseProductSelectionReturn {
 
 }
 
-export function useProductSelection(apiProduct: ProductApiData, productColors?: Array<{ label: string, hex: string }>, activeFilterHints?: ActiveFilterHints): UseProductSelectionReturn {
+export function useProductSelection(apiProduct: ProductApiData, productColors?: Array<{ label: string, hex: string }>, activeFilterHints?: ActiveFilterHints, preselectHints?: ActiveFilterHints): UseProductSelectionReturn {
+  // `activeFilterHints` (catálogo) PRESELECCIONA y además FILTRA las opciones
+  // visibles. `preselectHints` (deep-link desde un bundle / "Más información")
+  // SOLO preselecciona la variante inicial y NO filtra: el selector debe seguir
+  // mostrando TODAS las opciones (43", 55", 58"...) con la del bundle marcada.
   // Crear todas las variantes del producto basadas en los arrays indexados
   const allVariants = useMemo((): ProductVariant[] => {
     const variants: ProductVariant[] = [];
@@ -364,7 +368,7 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
   const [selection, setSelection] = useState<SelectionState>(() => {
     // Si hay variantes disponibles, seleccionar la mejor (stock > 0, mejor precio, características comunes)
     if (allVariants.length > 0) {
-      const bestVariant = findBestVariantToDisplay(allVariants, activeFilterHints);
+      const bestVariant = findBestVariantToDisplay(allVariants, activeFilterHints ?? preselectHints);
       if (bestVariant) {
         return {
           selectedColor: bestVariant.color || null,
@@ -386,7 +390,7 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
   useEffect(() => {
     // Si no hay selección actual y hay variantes disponibles, seleccionar la mejor
     if (!selection.selectedColor && allVariants.length > 0) {
-      const bestVariant = findBestVariantToDisplay(allVariants, activeFilterHints);
+      const bestVariant = findBestVariantToDisplay(allVariants, activeFilterHints ?? preselectHints);
       if (bestVariant) {
         setSelection({
           selectedColor: bestVariant.color || null,
@@ -401,7 +405,7 @@ export function useProductSelection(apiProduct: ProductApiData, productColors?: 
   // Re-seleccionar variante cuando cambien los filtros del catálogo
   useEffect(() => {
     if (allVariants.length > 0) {
-      const bestVariant = findBestVariantToDisplay(allVariants, activeFilterHints);
+      const bestVariant = findBestVariantToDisplay(allVariants, activeFilterHints ?? preselectHints);
       if (bestVariant) {
         setSelection({
           selectedColor: bestVariant.color || null,


### PR DESCRIPTION
## Contexto
Mejoras en la **vista de bundle** y en las PDP a las que enlaza el botón "Saber más".

## 1. La variante correcta (el bug importante) 🎯
"Saber más" abría la variante **"mejor"/primera** (58" en vez de 50", 15kg en vez de 21kg) → el cliente veía **otro precio** al del combo y se confundía.

**Fix:** al navegar se guarda la variante del bundle en `localStorage` (mismo patrón que `ProductCard`), y las PDP la **preseleccionan**. Se agregó un parámetro `preselectHints` a `useProductSelection` que **solo preselecciona SIN filtrar** las demás opciones — el selector sigue mostrando todas (43", 55", 58"...) con la del bundle marcada. Cubre `view` (`DetailsProductSection`) y `viewpremium` (`useProductLogic`).

> El `activeFilterHints` del catálogo (que sí filtra a propósito) **no se toca**.

## 2. Display de placeholders
En la grilla del bundle, los valores `"No aplica"`, `"0"`, `"-"` y vacíos se **ocultan** (ya no `"No aplica | 50\""` ni `"Negro | -"`).

## 3. Velocidad
- **Caché en memoria** del bundle (el proyecto no usa React Query) → revisitar el mismo bundle es **instantáneo**.
- **Prefetch** al pasar el mouse por el card → al hacer click los datos **ya están**.
- Se elimina el **`setTimeout` de 150ms** que alargaba el skeleton.

> Nota: la carga en **frío total** (bundle nuevo, sin prefetch) mejora solo los 150ms; para dejarla instantánea también en ese caso, el siguiente paso sería **SSR** (refactor aparte, no incluido aquí).

## Archivos (8)
`BundleProductsGrid`, `DetailsProductSection`, `viewpremium/page`, `useProductLogic`, `useProductSelection`, `viewbundle/page`, `useProducts`, `BundleCard`.

## Verificación
- Typecheck limpio (0 errores).
- Fallbacks seguros: sin selección guardada o sin coincidencia → comportamiento anterior.
- Validado en local: preselección + todas las opciones visibles + display + caché/prefetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)