### PR TITLE
fix(checkout): un invitado (rol 3) no debe ver tarjetas guardadas

### DIFF
--- a/src/app/carrito/Step3.tsx
+++ b/src/app/carrito/Step3.tsx
@@ -87,13 +87,17 @@ export default function Step3({
   }, [canPickUp, stores.length, storesLoading, availableStoresWhenCanPickUpFalse.length, availableCities.length, deliveryMethod, address]);
 
   // Hook para precarga de tarjetas y zero interest
-  const { preloadCards, preloadZeroInterest } = useCardsCache();
+  const { preloadCards, preloadZeroInterest, canUseSavedCards } = useCardsCache();
 
   // Precargar tarjetas y zero interest en segundo plano al entrar al Step3
   React.useEffect(() => {
     const preloadData = async () => {
       // Primero precargar las tarjetas
       await preloadCards();
+
+      // Seguridad: un invitado (rol 3) no debe cargar tarjetas guardadas (ni para
+      // el cálculo de zero-interest). Solo usuarios registrados (rol 2).
+      if (!canUseSavedCards()) return;
 
       // Luego precargar zero interest si hay productos en el carrito
       if (products.length > 0) {
@@ -131,7 +135,7 @@ export default function Step3({
     };
 
     preloadData();
-  }, [preloadCards, preloadZeroInterest, products, calculations.total]);
+  }, [preloadCards, preloadZeroInterest, canUseSavedCards, products, calculations.total]);
 
   // Trade-In state management - ahora soporta múltiples productos
   // Inicialización perezosa para evitar parpadeos y asegurar estado correcto desde el inicio

--- a/src/app/carrito/Step5.tsx
+++ b/src/app/carrito/Step5.tsx
@@ -102,12 +102,27 @@ export default function Step5({ onBack, onContinue }: Step5Props) {
       }
     }
 
-    // Cargar tarjetas guardadas desde el cache
+    // Cargar tarjetas guardadas desde el cache — SOLO para usuarios registrados
+    // (rol 2). Un invitado (rol 3, identificado solo con el email) NO debe ver
+    // métodos de pago guardados; además limpiamos el caché persistido para que no
+    // queden tarjetas de una sesión rol 2 anterior en el mismo navegador.
     try {
-      const cardsData = localStorage.getItem("checkout-cards-cache");
-      if (cardsData) {
-        const parsed = JSON.parse(cardsData) as DBCard[];
-        setSavedCards(parsed);
+      let rol: number | null = null;
+      try {
+        const u = JSON.parse(localStorage.getItem("imagiq_user") || "null");
+        rol = typeof u?.rol === "number" ? u.rol : (typeof u?.role === "number" ? u.role : null);
+      } catch {
+        rol = null;
+      }
+      if (rol === 2) {
+        const cardsData = localStorage.getItem("checkout-cards-cache");
+        if (cardsData) {
+          const parsed = JSON.parse(cardsData) as DBCard[];
+          setSavedCards(parsed);
+        }
+      } else {
+        setSavedCards([]);
+        localStorage.removeItem("checkout-cards-cache");
       }
     } catch (error) {
       console.error("Error loading saved cards:", error);

--- a/src/app/carrito/hooks/useCardsCache.ts
+++ b/src/app/carrito/hooks/useCardsCache.ts
@@ -68,6 +68,34 @@ export function useCardsCache() {
     return null;
   }, [authContext.user?.id, loggedUser?.id]);
 
+  // Rol del usuario (2 = registrado, 3 = invitado). Solo los REGISTRADOS pueden
+  // ver métodos de pago guardados; un invitado (rol 3, auto-logueado solo con el
+  // email) NO debe ver tarjetas de esa cuenta — eso expondría datos de pago de un
+  // tercero (parte del account takeover). Ver [[reference_usuarios_rol_invitado]].
+  const getUserRole = useCallback((): number | null => {
+    const readRole = (u: unknown): number | null => {
+      if (!u || typeof u !== "object") return null;
+      const o = u as { rol?: unknown; role?: unknown };
+      if (typeof o.rol === "number") return o.rol;
+      if (typeof o.role === "number") return o.role;
+      return null;
+    };
+    const fromCtx = readRole(authContext.user);
+    if (fromCtx !== null) return fromCtx;
+    const fromLogged = readRole(loggedUser);
+    if (fromLogged !== null) return fromLogged;
+    try {
+      const stored = localStorage.getItem("imagiq_user");
+      if (stored) return readRole(JSON.parse(stored));
+    } catch {
+      /* noop */
+    }
+    return null;
+  }, [authContext.user, loggedUser]);
+
+  // Solo los usuarios registrados (rol 2) pueden cargar tarjetas guardadas.
+  const canUseSavedCards = useCallback((): boolean => getUserRole() === 2, [getUserRole]);
+
   // Verificar si el caché es válido
   const isCacheValid = useCallback(() => {
     const now = Date.now();
@@ -83,6 +111,12 @@ export function useCardsCache() {
   const loadSavedCards = useCallback(async (forceReload = false): Promise<DBCard[]> => {
     const userId = getUserId();
     if (!userId) {
+      setSavedCards([]);
+      return [];
+    }
+
+    // Seguridad: un invitado (rol 3) NO debe ver tarjetas guardadas.
+    if (!canUseSavedCards()) {
       setSavedCards([]);
       return [];
     }
@@ -138,12 +172,15 @@ export function useCardsCache() {
     } finally {
       setIsLoadingCards(false);
     }
-  }, [getUserId, isCacheValid]);
+  }, [getUserId, isCacheValid, canUseSavedCards]);
 
   // Precargar tarjetas sin mostrar loading (para precarga anticipada)
   const preloadCards = useCallback(async () => {
     const userId = getUserId();
     if (!userId) return;
+
+    // Seguridad: un invitado (rol 3) NO debe ver tarjetas guardadas.
+    if (!canUseSavedCards()) return;
 
     // Si ya hay caché válido, no hacer nada
     if (isCacheValid() && cardsCache.data) {
@@ -187,7 +224,7 @@ export function useCardsCache() {
     } catch (error) {
 
     }
-  }, [getUserId, isCacheValid]);
+  }, [getUserId, isCacheValid, canUseSavedCards]);
 
   // Invalidar caché manualmente
   const invalidateCache = useCallback(() => {
@@ -320,6 +357,7 @@ export function useCardsCache() {
     preloadCards,
     invalidateCache,
     isCacheValid,
+    canUseSavedCards,
     zeroInterestData,
     isLoadingZeroInterest,
     loadZeroInterest,


### PR DESCRIPTION
## Problema (seguridad)
Un **invitado (rol 3)** se auto-loguea solo con el email y queda con un `userId` en `localStorage`. La carga de métodos de pago usa ese `userId` **sin verificar el rol**, así que le traía las **tarjetas guardadas** de esa cuenta → **exposición de datos de pago de un tercero** (parte del account takeover conocido).

## Fix
Las tarjetas guardadas solo se cargan/muestran para usuarios **registrados (rol 2)**. Cubre los **3 caminos** del checkout:
- **`useCardsCache`**: nuevo `canUseSavedCards()` (rol === 2) como guard en `loadSavedCards` y `preloadCards`.
- **`Step3`**: guard antes de la carga directa de tarjetas para el cálculo de zero-interest.
- **`Step5`**: solo lee `checkout-cards-cache` si es rol 2; si no, **limpia** ese caché (evita que queden tarjetas de una sesión rol 2 previa en el mismo navegador).

## Verificación
- Typecheck limpio.
- Rol 2 (registrado) → ve sus tarjetas como antes. Invitado rol 3 → no ve ninguna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)