### PR TITLE
fix(checkout): un invitado (rol 3) no ve direcciones guardadas

### DIFF
--- a/src/app/carrito/hooks/useDelivery.tsx
+++ b/src/app/carrito/hooks/useDelivery.tsx
@@ -1831,13 +1831,23 @@ export const useDelivery = (config?: UseDeliveryConfig) => {
     };
   }, []); // IMPORTANTE: Array vacío - solo ejecutar al montar. fetchCandidateStores es estable via useCallback
 
-  // Cargar direcciones del usuario usando AddressesService
+  // Cargar direcciones del usuario usando AddressesService.
+  // Un invitado (rol 3) NO debe ver las direcciones guardadas de la cuenta (con
+  // solo el email se accedería a datos de un tercero). Solo usuarios rol 2.
   useEffect(() => {
-    const userInfo = safeGetLocalStorage<{ id?: string; email?: string }>(
-      "imagiq_user",
-      {}
-    );
-    if (userInfo && (userInfo.id || userInfo.email)) {
+    const userInfo = safeGetLocalStorage<{
+      id?: string;
+      email?: string;
+      rol?: number;
+      role?: number;
+    }>("imagiq_user", {});
+    const rol =
+      typeof userInfo?.rol === "number"
+        ? userInfo.rol
+        : typeof userInfo?.role === "number"
+          ? userInfo.role
+          : null;
+    if (rol === 2 && userInfo && (userInfo.id || userInfo.email)) {
       addressesService
         .getUserAddresses()
         .then((addresses: Address[]) => {
@@ -1847,6 +1857,8 @@ export const useDelivery = (config?: UseDeliveryConfig) => {
           console.error("Error loading addresses:", error);
           setAddresses([]);
         });
+    } else {
+      setAddresses([]);
     }
   }, []);
 
@@ -2008,7 +2020,20 @@ export const useDelivery = (config?: UseDeliveryConfig) => {
     // Esta función refresca la lista de direcciones y opcionalmente
     // dispara la consulta de candidate stores si se proporciona la nueva dirección
     try {
-      let addresses = await addressesService.getUserAddresses();
+      // Invitado (rol 3): NO traer las direcciones guardadas de la cuenta; solo la
+      // dirección nueva que agregó en esta sesión. Solo rol 2 ve las guardadas.
+      const userInfo = safeGetLocalStorage<{ rol?: number; role?: number }>(
+        "imagiq_user",
+        {}
+      );
+      const rol =
+        typeof userInfo?.rol === "number"
+          ? userInfo.rol
+          : typeof userInfo?.role === "number"
+            ? userInfo.role
+            : null;
+      let addresses: Address[] =
+        rol === 2 ? await addressesService.getUserAddresses() : [];
 
       // FIX: Asegurar que la nueva dirección esté en la lista (manejar lag de replicación/DB)
       if (newAddress && newAddress.id) {

--- a/src/features/checkout/CheckoutAddressContext.tsx
+++ b/src/features/checkout/CheckoutAddressContext.tsx
@@ -38,6 +38,31 @@ const CheckoutAddressContext = createContext<
 // Provider
 // ---------------------------------------------------------------------------
 
+// Rol del usuario (2 = registrado, 3 = invitado). Solo los REGISTRADOS pueden
+// ver direcciones guardadas de la cuenta; un invitado (rol 3, identificado solo
+// con el email) no debe ver los datos de un tercero (parte del account takeover).
+function roleFromObj(u: unknown): number | null {
+  if (u && typeof u === "object") {
+    const o = u as { rol?: unknown; role?: unknown };
+    if (typeof o.rol === "number") return o.rol;
+    if (typeof o.role === "number") return o.role;
+  }
+  return null;
+}
+function readUserRole(u: unknown): number | null {
+  const fromObj = roleFromObj(u);
+  if (fromObj !== null) return fromObj;
+  if (typeof window !== "undefined") {
+    try {
+      const stored = localStorage.getItem("imagiq_user");
+      if (stored) return roleFromObj(JSON.parse(stored));
+    } catch {
+      /* noop */
+    }
+  }
+  return null;
+}
+
 export function CheckoutAddressProvider({ children }: { children: ReactNode }) {
   const { user } = useAuthContext();
   const userId = user?.id ?? null;
@@ -49,14 +74,17 @@ export function CheckoutAddressProvider({ children }: { children: ReactNode }) {
 
   // ---- Fetch addresses from DB ----
   const fetchAddresses = useCallback(async () => {
-    if (!userId) {
-      // No user yet — try reading from localStorage as transient fallback
+    // Un invitado (rol 3) NO debe ver las direcciones GUARDADAS de la cuenta: con
+    // solo el email se accedería a datos de un tercero (dónde vive). Solo se usa
+    // la dirección transitoria que el invitado agregó en esta sesión.
+    if (!userId || readUserRole(user) !== 2) {
       try {
         const raw = localStorage.getItem("checkout-address");
         if (raw) {
           setSelectedAddress(JSON.parse(raw) as Address);
         }
       } catch { /* ignore */ }
+      setAddresses([]);
       setIsLoading(false);
       return;
     }
@@ -95,7 +123,7 @@ export function CheckoutAddressProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsLoading(false);
     }
-  }, [userId]);
+  }, [userId, user]);
 
   // Fetch on mount and when user changes
   useEffect(() => {


### PR DESCRIPTION
## Problema (seguridad)
Complementa **#1089** (tarjetas). Un **invitado (rol 3)** auto-logueado solo con el email tenía acceso a las **direcciones guardadas** de esa cuenta → **dónde vive un tercero** (parte del account takeover).

## Fix
Solo los usuarios **registrados (rol 2)** ven direcciones guardadas. Un invitado **pone su dirección** en la sesión y **no ve las guardadas**.
- **`CheckoutAddressContext`**: no llama `getUserAddresses` para invitados; usa solo la dirección transitoria de la sesión.
- **`useDelivery`**: guard de rol en la carga al montar **y** en `addAddress` (el invitado usa solo la dirección nueva, no las guardadas).

## ⚠️ Importante sobre el OTP
Esto oculta los datos en la **UI**. Para poder **quitar el OTP** con seguridad falta **blindar los endpoints** del backend (`getUserAddresses`, `getUserPaymentMethods`) para que rechacen sesiones de invitado. **Mientras eso no esté, el OTP debe mantenerse** (si no, se reabre la fuga aunque la UI no muestre nada).

## Verificación
- Typecheck limpio.
- Rol 2 → ve sus direcciones. Invitado → solo la que agrega en la sesión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)